### PR TITLE
🧹 Code Health: Fix broad exception handling in embedding backend availability checks

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -180,7 +180,7 @@ class Qwen3EmbedBackend:
             if result:
                 return len(result[0])
             return 0  # pragma: no cover
-        except Exception:
+        except (ImportError, ValueError, TypeError):
             return 0
 
 
@@ -298,6 +298,7 @@ class LiteLLMBackend:
     def check_available(self) -> int:
         """Check if the LiteLLM model is available via test request."""
         try:
+            import litellm
             from litellm import embedding as litellm_embedding
 
             kwargs: dict[str, Any] = {
@@ -313,7 +314,9 @@ class LiteLLMBackend:
             if response.data:
                 return len(response.data[0]["embedding"])
             return 0  # pragma: no cover
-        except Exception:
+        except (ImportError, ValueError):
+            return 0
+        except litellm.exceptions.OpenAIError:
             return 0
 
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -286,7 +286,7 @@ class TestLiteLLMBackend:
 
     def test_check_available_failure(self):
         backend = LiteLLMBackend()
-        with patch("litellm.embedding", side_effect=Exception("connection error")):
+        with patch("litellm.embedding", side_effect=ValueError("connection error")):
             dims = backend.check_available()
             assert dims == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.0.0b1"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
🎯 **What:** The broad `except Exception:` clauses in `src/better_code_review_graph/embeddings.py` lines 183 and 316 were replaced with specific expected exceptions for both Qwen3-embed (`ImportError, ValueError, TypeError`) and LiteLLM (`ImportError, ValueError, litellm.exceptions.OpenAIError`).

💡 **Why:** Catching broad exceptions is considered an anti-pattern as it masks unrelated errors (like syntax/typos, logic errors, or system exit interruptions). Specifying exceptions makes the codebase more explicit, resilient, and easier to debug when unexpected behavior occurs during embedding model initialization or API checks.

✅ **Verification:** 
- `uv run pytest` test suite passed locally, including verifying that tests simulate failure catching properly. 
- Updated `tests/test_embeddings.py` to mock the correct exceptions (`ValueError` instead of generic `Exception`).
- `uv run ruff check .` validated no unused imports were left.

✨ **Result:** A cleaner code file free of over-broad exception warnings that correctly limits the scope of failures it is expected to swallow and fallback to returning 0 for.

---
*PR created automatically by Jules for task [11183750269835726311](https://jules.google.com/task/11183750269835726311) started by @n24q02m*