### PR TITLE
⚡ Bolt: [performance improvement] Optimize graph queries N+1 bottleneck

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -433,18 +433,9 @@ class GraphStore:
         # Record total count before any truncation for the response
         total_impacted = len(impacted - seeds)
 
-        # Resolve to full node info
-        changed_nodes = []
-        for qn in seeds:
-            node = self.get_node(qn)
-            if node:
-                changed_nodes.append(node)
-
-        impacted_nodes = []
-        for qn in impacted - seeds:
-            node = self.get_node(qn)
-            if node:
-                impacted_nodes.append(node)
+        # Resolve to full node info using batch fetching to prevent N+1 queries
+        changed_nodes = self.get_nodes_by_qualified_names(list(seeds))
+        impacted_nodes = self.get_nodes_by_qualified_names(list(impacted - seeds))
 
         impacted_files = list({n.file_path for n in impacted_nodes})
 
@@ -465,18 +456,8 @@ class GraphStore:
 
     def get_subgraph(self, qualified_names: list[str]) -> dict[str, Any]:
         """Extract a subgraph containing the specified nodes and their connecting edges."""
-        nodes = []
-        for qn in qualified_names:
-            node = self.get_node(qn)
-            if node:
-                nodes.append(node)
-
-        edges = []
-        qn_set = set(qualified_names)
-        for qn in qualified_names:
-            for e in self.get_edges_by_source(qn):
-                if e.target_qualified in qn_set:
-                    edges.append(e)
+        nodes = self.get_nodes_by_qualified_names(qualified_names)
+        edges = self.get_edges_among(set(qualified_names))
 
         return {"nodes": nodes, "edges": edges}
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
💡 What:
Replaced iterative `self.get_node(qn)` calls in `get_impact_radius` and `get_subgraph` with batched `self.get_nodes_by_qualified_names(list(...))` calls. Also replaced iterative `self.get_edges_by_source(qn)` in `get_subgraph` with a batched `self.get_edges_among(...)` call.

🎯 Why:
To fix severe N+1 SQLite query bottlenecks when analyzing the impact radius or extracting subgraphs for large repositories. Traversing lists of hundreds of nodes was generating individual SQLite queries for each node.

📊 Impact:
Significantly reduces the number of SQLite queries during impact radius calculation and subgraph extraction. Time complexity for database I/O shifts from O(N) queries to O(1) batched query blocks, making graph operations much faster and avoiding timeouts on massive codebases.

🔬 Measurement:
Run `uv run pytest` to ensure behavior remains identical. The test suite execution completed successfully in ~2m. Performance can be seen improving when fetching `get_impact_radius` with hundreds of impacted nodes.

---
*PR created automatically by Jules for task [8334969332191928990](https://jules.google.com/task/8334969332191928990) started by @n24q02m*