### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limits to search tools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found Path Traversal vulnerability where user input (file paths) was concatenated to paths (`root / rel_path`) without ensuring they don't escape the project root directory.
 **Learning:** Concatenating path components using `/` without checking for bounds allows reading or modifying unauthorized system files.
 **Prevention:** To prevent this, always build paths using `(base_path / user_path).resolve()` and explicitly verify boundaries using `if not resolved_path.is_relative_to(base_path.resolve()): continue`.
+## 2025-02-23 - Prevent Resource Exhaustion via Search Tools Length Limits
+**Vulnerability:** The MCP tools `semantic_search_nodes` and `query_graph` accepted arbitrarily long strings for `query` and `target` respectively, passing them directly to the SQLite backend and potentially cloud embedding backends, creating a vector for Denial of Service (DoS) attacks through resource exhaustion.
+**Learning:** Tools exposed via an MCP server can receive excessively large inputs from clients, and relying entirely on backend database checks or API limits isn't enough; input length limits are required at the function boundary.
+**Prevention:** Always validate and clamp input string lengths (e.g. max 1000 chars) on any tool parameter that will be used in a database search query or sent to an external embedding API.

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -421,6 +421,12 @@ def query_graph(
     Returns:
         Matching nodes and edges for the query.
     """
+    if len(target) > 1000:
+        return {
+            "status": "error",
+            "error": "Target too long (exceeds 1000 characters).",
+        }
+
     store, root = _get_store(repo_root)
     try:
         if pattern not in _QUERY_PATTERNS:
@@ -849,6 +855,12 @@ def semantic_search_nodes(
     Returns:
         Ranked list of matching nodes.
     """
+    if len(query) > 1000:
+        return {
+            "status": "error",
+            "error": "Query too long (exceeds 1000 characters).",
+        }
+
     store, root = _get_store(repo_root)
     try:
         db_path = get_db_path(root)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `semantic_search_nodes` and `query_graph` MCP tools accepted arbitrarily long string inputs for the `query` and `target` parameters respectively. These massive strings were then passed directly to SQLite search queries or external cloud embedding APIs, leading to potential Denial of Service (DoS) attacks through resource exhaustion.
🎯 Impact: Attackers could tie up database connections or exhaust external API rate limits and quotas by passing massive strings as tool arguments.
🔧 Fix: Added validation checks in both tools to ensure `query` and `target` strings do not exceed 1000 characters, returning an appropriate error dictionary if they do.
✅ Verification: Created a local script passing a 10000 character string to both tools, successfully verified they reject the input and return the expected error dictionaries. Re-ran test suite (`uv run pytest tests/test_tools.py`) to confirm no regressions. Cleaned up scratchpad scripts.

---
*PR created automatically by Jules for task [7803026638831371931](https://jules.google.com/task/7803026638831371931) started by @n24q02m*