### PR TITLE
🧪 [TEST] Missing error test for get_changed_files subprocess errors

### DIFF
--- a/tests/test_incremental_extra.py
+++ b/tests/test_incremental_extra.py
@@ -553,3 +553,25 @@ class TestMainModule:
                     )
                 )
                 mock_main.assert_called_once()
+
+    @patch("better_code_review_graph.incremental.subprocess.run")
+    def test_get_changed_files_fallback_timeout(self, mock_run, tmp_path):
+        # First call fails with non-zero return code, second call timeouts
+        mock_run.side_effect = [
+            MagicMock(returncode=1, stdout=""),
+            subprocess.TimeoutExpired("git", 30),
+        ]
+        result = get_changed_files(tmp_path)
+        assert result == []
+        assert mock_run.call_count == 2
+
+    @patch("better_code_review_graph.incremental.subprocess.run")
+    def test_get_changed_files_fallback_file_not_found(self, mock_run, tmp_path):
+        # First call fails with non-zero return code, second call raises FileNotFoundError
+        mock_run.side_effect = [
+            MagicMock(returncode=1, stdout=""),
+            FileNotFoundError("git not found"),
+        ]
+        result = get_changed_files(tmp_path)
+        assert result == []
+        assert mock_run.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### [TEST] Missing error test for get_changed_files subprocess errors

#### 🎯 What
Added missing test coverage for error handling in the `get_changed_files` function's fallback logic.

#### 💡 Why
The `get_changed_files` function in `incremental.py` attempts a fallback `git diff --name-only --cached` if the primary `git diff` fails. While there were tests for errors in the primary call and general timeouts, there were no tests specifically covering cases where the *fallback* call also raises `subprocess.TimeoutExpired` or `FileNotFoundError`.

#### ✅ Verification
- Added `test_get_changed_files_fallback_timeout` to `tests/test_incremental_extra.py`.
- Added `test_get_changed_files_fallback_file_not_found` to `tests/test_incremental_extra.py`.
- Ran `uv run pytest tests/test_incremental.py tests/test_incremental_extra.py` and confirmed all 52 tests passed.
- Verified linting, formatting, and type checks pass for the modified test file.

#### ✨ Result
Improved test coverage for git operation edge cases in the incremental update logic.

---
*PR created automatically by Jules for task [14715006888073963885](https://jules.google.com/task/14715006888073963885) started by @n24q02m*