### PR TITLE
[FIX] Deeply nested blocks in `get_staged_and_unstaged`

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -157,6 +157,17 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         return []
 
 
+def _parse_porcelain_line(line: str) -> str | None:
+    """Parse a single line from 'git status --porcelain'."""
+    if len(line) <= 3:
+        return None
+    entry = line[3:].strip()
+    # Handle renamed files: "R  old -> new"
+    if " -> " in entry:
+        return entry.split(" -> ", 1)[1]
+    return entry
+
+
 def get_staged_and_unstaged(repo_root: Path) -> list[str]:
     """Get all modified files (staged + unstaged + untracked)."""
     try:
@@ -167,17 +178,15 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
         )
-        files = []
-        for line in result.stdout.splitlines():
-            if len(line) > 3:
-                entry = line[3:].strip()
-                # Handle renamed files: "R  old -> new"
-                if " -> " in entry:
-                    entry = entry.split(" -> ", 1)[1]
-                files.append(entry)
-        return files
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
+
+    files = []
+    for line in result.stdout.splitlines():
+        parsed = _parse_porcelain_line(line)
+        if parsed:
+            files.append(parsed)
+    return files
 
 
 def get_all_tracked_files(repo_root: Path) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### [FIX] Deeply nested blocks in `get_staged_and_unstaged`

#### 🎯 What
Refactored the `get_staged_and_unstaged` function in `src/better_code_review_graph/incremental.py` to reduce nesting levels.

#### 💡 Why
The original implementation had multiple levels of nesting (try-except -> for-loop -> if-condition -> if-condition), making it harder to read and maintain.

#### ✨ Result
- Extracted the porcelain line parsing logic into a dedicated helper function `_parse_porcelain_line`.
- Refactored `get_staged_and_unstaged` to use early returns when subprocess execution fails or times out.
- The resulting code is flatter and follows better Python practices for readability.

#### ✅ Verification
- Ran `uv run ruff check --fix .` and `uv run ruff format .`
- Ran relevant tests: `uv run pytest tests/test_incremental.py tests/test_incremental_extra.py tests/test_tools_full.py` (All 124 passed)
- Ran type checks for modified files: `uv run ty check src/better_code_review_graph/incremental.py tests/test_incremental.py` (Passed)

---
*PR created automatically by Jules for task [1545098608564928477](https://jules.google.com/task/1545098608564928477) started by @n24q02m*