### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 query in get_impact_radius

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+
+## 2025-05-24 - N+1 Query in Impact Radius Resolution
+**Learning:** `get_impact_radius` in `graph.py` previously performed N+1 `get_node` calls to resolve seed and impacted nodes into full objects after BFS traversal.
+**Action:** Use `get_nodes_by_qualified_names` to batch fetch nodes by their qualified names in a single query after the BFS frontier expansion is complete.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -434,17 +434,9 @@ class GraphStore:
         total_impacted = len(impacted - seeds)
 
         # Resolve to full node info
-        changed_nodes = []
-        for qn in seeds:
-            node = self.get_node(qn)
-            if node:
-                changed_nodes.append(node)
+        changed_nodes = self.get_nodes_by_qualified_names(list(seeds))
 
-        impacted_nodes = []
-        for qn in impacted - seeds:
-            node = self.get_node(qn)
-            if node:
-                impacted_nodes.append(node)
+        impacted_nodes = self.get_nodes_by_qualified_names(list(impacted - seeds))
 
         impacted_files = list({n.file_path for n in impacted_nodes})
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
💡 What: Replaced iterative `get_node` calls with batch fetch using `get_nodes_by_qualified_names` in `get_impact_radius`.

🎯 Why: The original implementation performed a database query for every node found in the impact radius BFS, leading to an N+1 query bottleneck.

📊 Impact: Reduces the number of database queries for node resolution from N+1 to O(1) (with batching to respect SQLite limits).

🔬 Measurement: Verified with a performance test that mocked `get_node` and confirmed call count dropped from 10 to < 2 for a 10-node impact radius.

---
*PR created automatically by Jules for task [11873069682043372073](https://jules.google.com/task/11873069682043372073) started by @n24q02m*