### PR TITLE
[FIX] Deeply nested blocks in `_extract_import_go`

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -1034,21 +1034,22 @@ class CodeParser:
                 imports.append(val)
         return imports
 
+    def _extract_go_import_spec(self, spec) -> list[str]:
+        return [
+            s.text.decode("utf-8", errors="replace").strip('"')
+            for s in spec.children
+            if s.type == "interpreted_string_literal"
+        ]
+
     def _extract_import_go(self, node) -> list[str]:
         imports = []
         for child in node.children:
             if child.type == "import_spec_list":
                 for spec in child.children:
                     if spec.type == "import_spec":
-                        for s in spec.children:
-                            if s.type == "interpreted_string_literal":
-                                val = s.text.decode("utf-8", errors="replace")
-                                imports.append(val.strip('"'))
+                        imports.extend(self._extract_go_import_spec(spec))
             elif child.type == "import_spec":
-                for s in child.children:
-                    if s.type == "interpreted_string_literal":
-                        val = s.text.decode("utf-8", errors="replace")
-                        imports.append(val.strip('"'))
+                imports.extend(self._extract_go_import_spec(child))
         return imports
 
     def _extract_import_rust(self, text: str) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🎯 What: Refactored `_extract_import_go` in `src/better_code_review_graph/parser.py` by extracting the logic for processing `import_spec` nodes into a new helper method `_extract_go_import_spec`.

💡 Why: The original implementation had deeply nested loops and conditionals, which made the code harder to read and maintain. This change reduces cognitive load and improves code clarity.

✅ Verification:
- Ran Go-specific import tests: `PYTHONPATH=src uv run pytest tests/test_parser_extra.py -k TestGo` (3 passed).
- Ran all tests in `tests/test_parser_extra.py` (24 passed).
- Verified linting and formatting with `uv run ruff check --fix .` and `uv run ruff format .`.

✨ Result: Improved code maintainability and readability without changing any functional behavior.

---
*PR created automatically by Jules for task [15871815651386492807](https://jules.google.com/task/15871815651386492807) started by @n24q02m*