### PR TITLE
🧪 [TEST] Missing error test for config status store initialization failure

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -316,6 +316,17 @@ class TestConfigTool:
         assert result["total_nodes"] > 0
         assert "embedding_backend" in result
 
+    def test_status_error_handling(self):
+        # Mock _get_store in its source module since it is imported locally in _config_status
+        with patch(
+            "better_code_review_graph.tools._get_store",
+            side_effect=ValueError("No graph found"),
+        ):
+            result = json.loads(config.fn(action="status"))
+            assert result["status"] == "ok"
+            assert result["graph_path"] is None
+            assert "No graph found" in result["message"]
+
     def test_cache_clear_no_graph(self):
         result = json.loads(config.fn(action="cache_clear"))
         assert result["status"] == "cache cleared"

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### 🧪 [TEST] Missing error test for config status store initialization failure

#### 🎯 What
Added a new test case `test_status_error_handling` to `TestConfigTool` in `tests/test_server.py`.

#### 💡 Why
The error handling path in `_config_status` (within `src/better_code_review_graph/server.py`) was untested. This path is triggered when `_get_store` raises a `RuntimeError` or `ValueError`, typically when no graph is found in the repository.

#### ✅ Verification
- Ran `uv run pytest tests/test_server.py` and confirmed all 37 tests (including the new one) pass.
- Verified that mocking `better_code_review_graph.tools._get_store` correctly triggers the exception handler in `_config_status`.
- Verified the JSON response structure for the error case.

#### ✨ Result
Improved test coverage for the MCP server's configuration tool, ensuring that the system gracefully handles and reports missing graphs.

---
*PR created automatically by Jules for task [5495471100376522165](https://jules.google.com/task/5495471100376522165) started by @n24q02m*