### PR TITLE
🧪 [testing] Missing error test for _is_binary OSError/PermissionError

### DIFF
--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -118,6 +118,18 @@ class TestIsBinary:
         f = tmp_path / "missing.txt"
         assert _is_binary(f)
 
+    def test_is_binary_permission_error(self, tmp_path):
+        f = tmp_path / "protected.txt"
+        f.write_text("secret")
+        with patch("pathlib.Path.read_bytes", side_effect=PermissionError):
+            assert _is_binary(f)
+
+    def test_is_binary_os_error(self, tmp_path):
+        f = tmp_path / "broken.txt"
+        f.write_text("data")
+        with patch("pathlib.Path.read_bytes", side_effect=OSError):
+            assert _is_binary(f)
+
 
 class TestGitOperations:
     @patch("better_code_review_graph.incremental.subprocess.run")

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### 🧪 [testing] Missing error test for _is_binary OSError/PermissionError

#### What
Added explicit test cases for `OSError` and `PermissionError` in the `_is_binary` function within `src/better_code_review_graph/incremental.py`.

#### Why
The `_is_binary` function has a try-except block that catches `OSError` and `PermissionError`, returning `True` as a safe fallback (assuming the file might be binary or inaccessible/unparseable). These error paths were previously untested.

#### Verification
- Added `test_is_binary_permission_error` and `test_is_binary_os_error` to `tests/test_incremental.py`.
- Verified the tests pass: `uv run pytest tests/test_incremental.py` (28 passed).
- Confirmed that overall coverage for `src/better_code_review_graph/incremental.py` is maintained/improved.
- Ran the full test suite (excluding known hanging MCP tests) to ensure no regressions.

#### Result
Increased confidence in the robustness of the binary file detection heuristic during incremental graph updates.

---
*PR created automatically by Jules for task [12398400249555795120](https://jules.google.com/task/12398400249555795120) started by @n24q02m*