### PR TITLE
[FIX] Deeply nested blocks in `_extract_import`

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -921,72 +921,96 @@ class CodeParser:
                     return node.children[i + 1].text.decode("utf-8", errors="replace")
         return None
 
+    def _get_bases_python(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type == "argument_list":
+                for arg in child.children:
+                    if arg.type in ("identifier", "attribute"):
+                        bases.append(arg.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_jvm(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type in (
+                "superclass",
+                "super_interfaces",
+                "extends_type",
+                "implements_type",
+                "type_identifier",
+                "supertype",
+                "delegation_specifier",
+            ):
+                text = child.text.decode("utf-8", errors="replace")
+                bases.append(text)
+        return bases
+
+    def _get_bases_cpp(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type == "base_class_clause":
+                for sub in child.children:
+                    if sub.type == "type_identifier":
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_web(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type in ("extends_clause", "implements_clause"):
+                for sub in child.children:
+                    if sub.type in (
+                        "identifier",
+                        "type_identifier",
+                        "nested_identifier",
+                    ):
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_solidity(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type == "inheritance_specifier":
+                for sub in child.children:
+                    if sub.type == "user_defined_type":
+                        for ident in sub.children:
+                            if ident.type == "identifier":
+                                bases.append(
+                                    ident.text.decode("utf-8", errors="replace")
+                                )
+        return bases
+
+    def _get_bases_go(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type == "type_spec":
+                for sub in child.children:
+                    if sub.type in ("struct_type", "interface_type"):
+                        for field_node in sub.children:
+                            if field_node.type == "field_declaration_list":
+                                for f in field_node.children:
+                                    if f.type == "type_identifier":
+                                        bases.append(
+                                            f.text.decode("utf-8", errors="replace")
+                                        )
+        return bases
+
     def _get_bases(self, node, language: str, source: bytes) -> list[str]:
         """Extract base classes / implemented interfaces."""
-        bases = []
         if language == "python":
-            for child in node.children:
-                if child.type == "argument_list":
-                    for arg in child.children:
-                        if arg.type in ("identifier", "attribute"):
-                            bases.append(arg.text.decode("utf-8", errors="replace"))
-        elif language in ("java", "csharp", "kotlin"):
-            # Look for superclass/interfaces in extends/implements clauses
-            for child in node.children:
-                if child.type in (
-                    "superclass",
-                    "super_interfaces",
-                    "extends_type",
-                    "implements_type",
-                    "type_identifier",
-                    "supertype",
-                    "delegation_specifier",
-                ):
-                    text = child.text.decode("utf-8", errors="replace")
-                    bases.append(text)
-        elif language == "cpp":
-            # C++: base_class_clause contains type_identifiers
-            for child in node.children:
-                if child.type == "base_class_clause":
-                    for sub in child.children:
-                        if sub.type == "type_identifier":
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
-        elif language in ("typescript", "javascript", "tsx"):
-            # extends clause
-            for child in node.children:
-                if child.type in ("extends_clause", "implements_clause"):
-                    for sub in child.children:
-                        if sub.type in (
-                            "identifier",
-                            "type_identifier",
-                            "nested_identifier",
-                        ):
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
-        elif language == "solidity":
-            # contract Foo is Bar, Baz { ... }
-            for child in node.children:
-                if child.type == "inheritance_specifier":
-                    for sub in child.children:
-                        if sub.type == "user_defined_type":
-                            for ident in sub.children:
-                                if ident.type == "identifier":
-                                    bases.append(
-                                        ident.text.decode("utf-8", errors="replace")
-                                    )
-        elif language == "go":
-            # Embedded structs / interface composition
-            for child in node.children:
-                if child.type == "type_spec":
-                    for sub in child.children:
-                        if sub.type in ("struct_type", "interface_type"):
-                            for field_node in sub.children:
-                                if field_node.type == "field_declaration_list":
-                                    for f in field_node.children:
-                                        if f.type == "type_identifier":
-                                            bases.append(
-                                                f.text.decode("utf-8", errors="replace")
-                                            )
-        return bases
+            return self._get_bases_python(node)
+        if language in ("java", "csharp", "kotlin"):
+            return self._get_bases_jvm(node)
+        if language == "cpp":
+            return self._get_bases_cpp(node)
+        if language in ("typescript", "javascript", "tsx"):
+            return self._get_bases_web(node)
+        if language == "solidity":
+            return self._get_bases_solidity(node)
+        if language == "go":
+            return self._get_bases_go(node)
+        return []
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:
         """Extract import targets as module/path strings."""
@@ -1039,11 +1063,12 @@ class CodeParser:
         for child in node.children:
             if child.type == "import_spec_list":
                 for spec in child.children:
-                    if spec.type == "import_spec":
-                        for s in spec.children:
-                            if s.type == "interpreted_string_literal":
-                                val = s.text.decode("utf-8", errors="replace")
-                                imports.append(val.strip('"'))
+                    if spec.type != "import_spec":
+                        continue
+                    for s in spec.children:
+                        if s.type == "interpreted_string_literal":
+                            val = s.text.decode("utf-8", errors="replace")
+                            imports.append(val.strip('"'))
             elif child.type == "import_spec":
                 for s in child.children:
                     if s.type == "interpreted_string_literal":

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### [FIX] Deeply nested blocks in `_extract_import`

This PR addresses the issue of deep nesting in the code around `src/better_code_review_graph/parser.py:991`. 

#### What
- Refactored the `_get_bases` method by extracting language-specific extraction logic into six new private helper methods: `_get_bases_python`, `_get_bases_jvm`, `_get_bases_cpp`, `_get_bases_web`, `_get_bases_solidity`, and `_get_bases_go`.
- Simplified the `_extract_import_go` helper method by utilizing early `continue` statements to reduce the level of nested loops.
- Applied automated linting and formatting via `ruff`.

#### Why
The original implementation of `_get_bases` contained deeply nested loops (up to 7 levels for Go), which significantly increased cognitive load and made the code difficult to maintain. By extracting these into language-specific helpers, the primary dispatcher becomes much cleaner, and the individual extraction logics are isolated.

#### Verification
- Manually inspected the refactored code to ensure logic parity.
- Ran the full test suite using `uv run pytest -k "not test_live_mcp"`.
- Result: **462 tests passed**, confirming no regressions were introduced across any of the supported languages.
- Verified that `ruff` linting and formatting checks pass.

#### Result
The code is now more modular, readable, and follows best practices for reducing cyclomatic complexity and nesting depth.

---
*PR created automatically by Jules for task [2133727943972657571](https://jules.google.com/task/2133727943972657571) started by @n24q02m*