### PR TITLE
🧪 [test] Missing error test for config cache_clear store initialization failure

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -325,6 +325,15 @@ class TestConfigTool:
         result = json.loads(config.fn(action="cache_clear", repo_root=str(repo)))
         assert result["status"] == "cache cleared"
 
+    def test_cache_clear_error_handling(self):
+        with patch(
+            "better_code_review_graph.tools._get_store",
+            side_effect=ValueError("No repo found"),
+        ):
+            result = json.loads(config.fn(action="cache_clear"))
+            assert result["status"] == "cache cleared"
+            assert result["embeddings_removed"] == 0
+
 
 # ---------------------------------------------------------------------------
 # help tool

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR adds a missing error test for the `config` tool's `cache_clear` action in `server.py`.

### What
Added `test_cache_clear_error_handling` to `TestConfigTool` in `tests/test_server.py`.

### Why
The error handling block in `_config_cache_clear` was untested. This test ensures that when `_get_store` fails (raising `ValueError` or `RuntimeError`), the tool gracefully returns a successful status with 0 embeddings removed, as intended by the code.

### Verification
- Ran the specific test: `PYTHONPATH=src uv run pytest tests/test_server.py -k test_cache_clear_error_handling` (Passed)
- Ran the full test suite (excluding hanging MCP live tests): `EMBEDDING_BACKEND=local PYTHONPATH=src uv run pytest -k "not test_live_mcp"` (Passed)
- Verified with `ruff` and `ty check`.

### Result
Increased test coverage for `server.py`.

---
*PR created automatically by Jules for task [12613038991141768001](https://jules.google.com/task/12613038991141768001) started by @n24q02m*