### PR TITLE
[TEST] Missing error test for EmbeddingStore schema migration

### DIFF
--- a/tests/test_embeddings_extra.py
+++ b/tests/test_embeddings_extra.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sqlite3
+from unittest.mock import MagicMock, patch
+
 from better_code_review_graph.embeddings import EmbeddingStore, embed_all_nodes
 from better_code_review_graph.graph import GraphNode, GraphStore
 
@@ -58,3 +61,39 @@ class TestEmbeddingStoreNoneBackend:
         assert result == 0
         emb.close()
         graph.close()
+
+
+class TestEmbeddingStoreMigration:
+    def test_migration_operational_error(self, tmp_path):
+        """Test that missing provider column triggers ALTER TABLE migration."""
+        db_path = tmp_path / "migration.db"
+
+        # We must patch where it's USED, which is better_code_review_graph.embeddings
+        with patch("better_code_review_graph.embeddings.sqlite3") as mock_sqlite:
+            # Re-expose OperationalError so the 'except' block works
+            mock_sqlite.OperationalError = sqlite3.OperationalError
+
+            mock_conn = MagicMock()
+            mock_sqlite.connect.return_value = mock_conn
+
+            def side_effect(sql, *args, **kwargs):
+                if "SELECT provider FROM embeddings" in sql:
+                    raise sqlite3.OperationalError("no such column: provider")
+                return MagicMock()
+
+            mock_conn.execute.side_effect = side_effect
+
+            # Initialize store
+            store = EmbeddingStore(db_path)
+
+            # Verify ALTER TABLE was called
+            executed_queries = [call[0][0] for call in mock_conn.execute.call_args_list]
+            assert any(
+                "ALTER TABLE embeddings ADD COLUMN provider" in q
+                for q in executed_queries
+            )
+
+            # Verify commit was called
+            assert mock_conn.commit.called
+
+            store.close()

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
### 🎯 What
Added a new test case `test_migration_operational_error` to `tests/test_embeddings_extra.py`.

### 💡 Why
The schema migration logic in `EmbeddingStore` (handling missing `provider` column) was untested. This test ensures that if the column check fails with an `OperationalError`, the migration (ALTER TABLE) is correctly triggered.

### ✅ Verification
- Ran `uv run pytest tests/test_embeddings_extra.py` and confirmed the new test passes.
- Verified that mocking `sqlite3.OperationalError` correctly triggers the migration path.
- Ensured no regressions in other embedding tests.

### ✨ Result
Improved test coverage for the embedding store initialization and migration logic.

---
*PR created automatically by Jules for task [14600823630290714631](https://jules.google.com/task/14600823630290714631) started by @n24q02m*