### PR TITLE
🧹 [refactor `query_graph` to reduce nesting]

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -405,6 +405,215 @@ _QUERY_PATTERNS = {
 }
 
 
+def _resolve_query_target(
+    store: GraphStore, root: Path, target: str, pattern: str
+) -> dict[str, Any] | tuple[Any, str]:
+    """Resolve target - try as-is, then as absolute path, then search."""
+    node = store.get_node(target)
+    if not node:
+        full_target_raw = root / target
+        full_target = full_target_raw.resolve()
+        if (
+            full_target.is_relative_to(root.resolve())
+            and not full_target_raw.is_symlink()
+            and not full_target.is_symlink()
+        ):
+            abs_target = str(full_target)
+            node = store.get_node(abs_target)
+
+    if not node:
+        # Search by name
+        candidates = store.search_nodes(target, limit=5)
+        if len(candidates) == 1:
+            node = candidates[0]
+            target = node.qualified_name
+        elif len(candidates) > 1:
+            return {
+                "status": "ambiguous",
+                "summary": f"Multiple matches for '{target}'. Please use a qualified name.",
+                "candidates": [node_to_dict(c) for c in candidates],
+            }
+
+    if not node and pattern != "file_summary":
+        return {
+            "status": "not_found",
+            "summary": f"No node found matching '{target}'.",
+        }
+
+    return node, target
+
+
+def _handle_callers_of(
+    store: GraphStore, qn: str, node: Any
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    qns = []
+    for e in store.get_edges_by_target(qn):
+        if e.kind == "CALLS":
+            qns.append(e.source_qualified)
+            edges_out.append(edge_to_dict(e))
+
+    # Fallback: CALLS edges store unqualified target names
+    if not qns and node:
+        for e in store.search_edges_by_target_name(node.name):
+            qns.append(e.source_qualified)
+            edges_out.append(edge_to_dict(e))
+
+    if qns:
+        nodes = store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in nodes}
+        for qn_src in qns:
+            if qn_src in node_map:
+                results.append(node_to_dict(node_map[qn_src]))
+    return results, edges_out
+
+
+def _handle_callees_of(
+    store: GraphStore, qn: str, _node: Any
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    qns = []
+    for e in store.get_edges_by_source(qn):
+        if e.kind == "CALLS":
+            qns.append(e.target_qualified)
+            edges_out.append(edge_to_dict(e))
+    if qns:
+        nodes = store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in nodes}
+        for qn_tgt in qns:
+            if qn_tgt in node_map:
+                results.append(node_to_dict(node_map[qn_tgt]))
+    return results, edges_out
+
+
+def _handle_imports_of(
+    store: GraphStore, qn: str, _node: Any
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    for e in store.get_edges_by_source(qn):
+        if e.kind == "IMPORTS_FROM":
+            results.append({"import_target": e.target_qualified})
+            edges_out.append(edge_to_dict(e))
+    return results, edges_out
+
+
+def _handle_importers_of(
+    store: GraphStore, _qn: str, node: Any, root: Path, target: str
+) -> dict[str, Any] | tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    # Find edges where target matches this file
+    if node is not None:
+        abs_target = node.file_path
+    else:
+        full_target_raw = root / target
+        full_target = full_target_raw.resolve()
+        if (
+            not full_target.is_relative_to(root.resolve())
+            or full_target_raw.is_symlink()
+            or full_target.is_symlink()
+        ):
+            return {
+                "status": "error",
+                "summary": "Invalid target path",
+            }
+        abs_target = str(full_target)
+    for e in store.get_edges_by_target(abs_target):
+        if e.kind == "IMPORTS_FROM":
+            results.append({"importer": e.source_qualified, "file": e.file_path})
+            edges_out.append(edge_to_dict(e))
+    return results, edges_out
+
+
+def _handle_children_of(
+    store: GraphStore, qn: str, _node: Any
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    qns = []
+    for e in store.get_edges_by_source(qn):
+        if e.kind == "CONTAINS":
+            qns.append(e.target_qualified)
+    if qns:
+        nodes = store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in nodes}
+        for qn_tgt in qns:
+            if qn_tgt in node_map:
+                results.append(node_to_dict(node_map[qn_tgt]))
+    return results, edges_out
+
+
+def _handle_tests_for(
+    store: GraphStore, qn: str, node: Any, target: str
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    qns = []
+    for e in store.get_edges_by_target(qn):
+        if e.kind == "TESTED_BY":
+            qns.append(e.source_qualified)
+    if qns:
+        nodes = store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in nodes}
+        for qn_src in qns:
+            if qn_src in node_map:
+                results.append(node_to_dict(node_map[qn_src]))
+    # Also search by naming convention
+    name = node.name if node else target
+    test_nodes = store.search_nodes(f"test_{name}", limit=10)
+    test_nodes += store.search_nodes(f"Test{name}", limit=10)
+    seen = {r.get("qualified_name") for r in results}
+    for t in test_nodes:
+        if t.qualified_name not in seen and t.is_test:
+            results.append(node_to_dict(t))
+    return results, edges_out
+
+
+def _handle_inheritors_of(
+    store: GraphStore, qn: str, _node: Any
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    qns = []
+    for e in store.get_edges_by_target(qn):
+        if e.kind in ("INHERITS", "IMPLEMENTS"):
+            qns.append(e.source_qualified)
+            edges_out.append(edge_to_dict(e))
+    if qns:
+        nodes = store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in nodes}
+        for qn_src in qns:
+            if qn_src in node_map:
+                results.append(node_to_dict(node_map[qn_src]))
+    return results, edges_out
+
+
+def _handle_file_summary(
+    store: GraphStore, _qn: str, _node: Any, root: Path, target: str
+) -> dict[str, Any] | tuple[list[dict], list[dict]]:
+    results = []
+    edges_out = []
+    full_target_raw = root / target
+    full_target = full_target_raw.resolve()
+    if (
+        not full_target.is_relative_to(root.resolve())
+        or full_target_raw.is_symlink()
+        or full_target.is_symlink()
+    ):
+        return {
+            "status": "error",
+            "summary": "Invalid target path",
+        }
+    abs_path = str(full_target)
+    file_nodes = store.get_nodes_by_file(abs_path)
+    for n in file_nodes:
+        results.append(node_to_dict(n))
+    return results, edges_out
+
+
 def query_graph(
     pattern: str,
     target: str,
@@ -429,9 +638,6 @@ def query_graph(
                 "error": f"Unknown pattern '{pattern}'. Available: {list(_QUERY_PATTERNS.keys())}",
             }
 
-        results: list[dict] = []
-        edges_out: list[dict] = []
-
         # For callers_of, skip common builtins early (bare names only)
         # "Who calls .map()?" returns hundreds of useless hits.
         # Qualified names (e.g. "utils.py::map") bypass this filter.
@@ -450,163 +656,30 @@ def query_graph(
                 "edges": [],
             }
 
-        # Resolve target - try as-is, then as absolute path, then search
-        node = store.get_node(target)
-        if not node:
-            full_target_raw = root / target
-            full_target = full_target_raw.resolve()
-            if (
-                full_target.is_relative_to(root.resolve())
-                and not full_target_raw.is_symlink()
-                and not full_target.is_symlink()
-            ):
-                abs_target = str(full_target)
-                node = store.get_node(abs_target)
-        if not node:
-            # Search by name
-            candidates = store.search_nodes(target, limit=5)
-            if len(candidates) == 1:
-                node = candidates[0]
-                target = node.qualified_name
-            elif len(candidates) > 1:
-                return {
-                    "status": "ambiguous",
-                    "summary": f"Multiple matches for '{target}'. Please use a qualified name.",
-                    "candidates": [node_to_dict(c) for c in candidates],
-                }
-
-        if not node and pattern != "file_summary":
-            return {
-                "status": "not_found",
-                "summary": f"No node found matching '{target}'.",
-            }
+        resolved = _resolve_query_target(store, root, target, pattern)
+        if isinstance(resolved, dict):
+            return resolved
+        node, target = resolved
 
         qn = node.qualified_name if node else target
 
-        if pattern == "callers_of":
-            qns = []
-            for e in store.get_edges_by_target(qn):
-                if e.kind == "CALLS":
-                    qns.append(e.source_qualified)
-                    edges_out.append(edge_to_dict(e))
+        # Dispatch table for patterns
+        handlers = {
+            "callers_of": lambda: _handle_callers_of(store, qn, node),
+            "callees_of": lambda: _handle_callees_of(store, qn, node),
+            "imports_of": lambda: _handle_imports_of(store, qn, node),
+            "importers_of": lambda: _handle_importers_of(store, qn, node, root, target),
+            "children_of": lambda: _handle_children_of(store, qn, node),
+            "tests_for": lambda: _handle_tests_for(store, qn, node, target),
+            "inheritors_of": lambda: _handle_inheritors_of(store, qn, node),
+            "file_summary": lambda: _handle_file_summary(store, qn, node, root, target),
+        }
 
-            # Fallback: CALLS edges store unqualified target names
-            if not qns and node:
-                for e in store.search_edges_by_target_name(node.name):
-                    qns.append(e.source_qualified)
-                    edges_out.append(edge_to_dict(e))
+        handler_res = handlers[pattern]()
+        if isinstance(handler_res, dict):
+            return handler_res
 
-            if qns:
-                nodes = store.get_nodes_by_qualified_names(qns)
-                node_map = {n.qualified_name: n for n in nodes}
-                for qn_src in qns:
-                    if qn_src in node_map:
-                        results.append(node_to_dict(node_map[qn_src]))
-
-        elif pattern == "callees_of":
-            qns = []
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "CALLS":
-                    qns.append(e.target_qualified)
-                    edges_out.append(edge_to_dict(e))
-            if qns:
-                nodes = store.get_nodes_by_qualified_names(qns)
-                node_map = {n.qualified_name: n for n in nodes}
-                for qn_tgt in qns:
-                    if qn_tgt in node_map:
-                        results.append(node_to_dict(node_map[qn_tgt]))
-
-        elif pattern == "imports_of":
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "IMPORTS_FROM":
-                    results.append({"import_target": e.target_qualified})
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "importers_of":
-            # Find edges where target matches this file
-            if node is not None:
-                abs_target = node.file_path
-            else:
-                full_target_raw = root / target
-                full_target = full_target_raw.resolve()
-                if (
-                    not full_target.is_relative_to(root.resolve())
-                    or full_target_raw.is_symlink()
-                    or full_target.is_symlink()
-                ):
-                    return {
-                        "status": "error",
-                        "summary": "Invalid target path",
-                    }
-                abs_target = str(full_target)
-            for e in store.get_edges_by_target(abs_target):
-                if e.kind == "IMPORTS_FROM":
-                    results.append(
-                        {"importer": e.source_qualified, "file": e.file_path}
-                    )
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "children_of":
-            qns = []
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "CONTAINS":
-                    qns.append(e.target_qualified)
-            if qns:
-                nodes = store.get_nodes_by_qualified_names(qns)
-                node_map = {n.qualified_name: n for n in nodes}
-                for qn_tgt in qns:
-                    if qn_tgt in node_map:
-                        results.append(node_to_dict(node_map[qn_tgt]))
-
-        elif pattern == "tests_for":
-            qns = []
-            for e in store.get_edges_by_target(qn):
-                if e.kind == "TESTED_BY":
-                    qns.append(e.source_qualified)
-            if qns:
-                nodes = store.get_nodes_by_qualified_names(qns)
-                node_map = {n.qualified_name: n for n in nodes}
-                for qn_src in qns:
-                    if qn_src in node_map:
-                        results.append(node_to_dict(node_map[qn_src]))
-            # Also search by naming convention
-            name = node.name if node else target
-            test_nodes = store.search_nodes(f"test_{name}", limit=10)
-            test_nodes += store.search_nodes(f"Test{name}", limit=10)
-            seen = {r.get("qualified_name") for r in results}
-            for t in test_nodes:
-                if t.qualified_name not in seen and t.is_test:
-                    results.append(node_to_dict(t))
-
-        elif pattern == "inheritors_of":
-            qns = []
-            for e in store.get_edges_by_target(qn):
-                if e.kind in ("INHERITS", "IMPLEMENTS"):
-                    qns.append(e.source_qualified)
-                    edges_out.append(edge_to_dict(e))
-            if qns:
-                nodes = store.get_nodes_by_qualified_names(qns)
-                node_map = {n.qualified_name: n for n in nodes}
-                for qn_src in qns:
-                    if qn_src in node_map:
-                        results.append(node_to_dict(node_map[qn_src]))
-
-        elif pattern == "file_summary":
-            full_target_raw = root / target
-            full_target = full_target_raw.resolve()
-            if (
-                not full_target.is_relative_to(root.resolve())
-                or full_target_raw.is_symlink()
-                or full_target.is_symlink()
-            ):
-                return {
-                    "status": "error",
-                    "summary": "Invalid target path",
-                }
-            abs_path = str(full_target)
-            file_nodes = store.get_nodes_by_file(abs_path)
-            for n in file_nodes:
-                results.append(node_to_dict(n))
+        results, edges_out = handler_res
 
         return {
             "status": "ok",

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🎯 What:
Refactored the `query_graph` function in `src/better_code_review_graph/tools.py` by extracting target resolution logic and individual query pattern handlers into private helper functions.

💡 Why:
The original `query_graph` function was overly long and contained deeply nested blocks, making it difficult to follow and maintain.

✅ Verification:
- Created a new test suite `tests/test_query_graph_refactor.py` (verified and then cleaned up) to ensure all patterns still work correctly.
- Ran existing tests in `tests/test_tools.py` and `tests/test_tools_full.py`.
- Verified formatting and linting with `ruff`.

✨ Result:
Improved code readability and maintainability by reducing nesting and delegating logic to focused helper functions.

---
*PR created automatically by Jules for task [5232115736159834562](https://jules.google.com/task/5232115736159834562) started by @n24q02m*