### PR TITLE
[TEST] Missing error test for get_docs_section store initialization exceptions

### DIFF
--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -793,6 +793,29 @@ class TestGetDocsSection:
             result = get_docs_section("usage")
         assert result["status"] == "not_found"
 
+    def test_get_docs_section_store_init_exception_fallback(self, tmp_path):
+        """get_docs_section should fallback to repo_root if _get_store fails."""
+        # Setup: Create a docs file in a temporary directory
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        docs_file = docs_dir / "LLM-OPTIMIZED-REFERENCE.md"
+        docs_file.write_text(
+            '<section name="usage">Fallback content works!</section>', encoding="utf-8"
+        )
+
+        # Mock _get_store to raise ValueError
+        with patch(
+            "better_code_review_graph.tools._get_store",
+            side_effect=ValueError("Store init failed"),
+        ):
+            # Call get_docs_section with repo_root pointing to tmp_path
+            result = get_docs_section("usage", repo_root=str(tmp_path))
+
+        # Verification
+        assert result["status"] == "ok"
+        assert result["section"] == "usage"
+        assert result["content"] == "Fallback content works!"
+
 
 # ---------------------------------------------------------------------------
 # Tool 9: find_large_functions


### PR DESCRIPTION
🧪 [testing improvement] Missing error test for get_docs_section store initialization exceptions

### What
Added a new test case `test_get_docs_section_store_init_exception_fallback` to `tests/test_tools_full.py`.

### Why
The `get_docs_section` function in `src/better_code_review_graph/tools.py` contains a try-except block that catches `RuntimeError` and `ValueError` during store initialization. This logic was previously untested. The new test verifies that the function correctly ignores these exceptions and continues to look for documentation in the provided `repo_root`.

### Coverage
- Verified that `get_docs_section` returns the correct content when `_get_store` fails but a valid `repo_root` with the docs file is provided.
- Ensured existing tests for `get_docs_section` still pass.

### Result
Increased test coverage for `tools.py` and ensured robust documentation retrieval even when the graph store cannot be initialized.

---
*PR created automatically by Jules for task [8543366746558972322](https://jules.google.com/task/8543366746558972322) started by @n24q02m*