### PR TITLE
🧹 [FIX] Deeply nested blocks in `_get_name`

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -852,24 +852,44 @@ class CodeParser:
             return f"{file_path}::{enclosing_class}.{name}"
         return f"{file_path}::{name}"
 
+    def _get_solidity_name(self, node) -> str | None:
+        """Extract name for Solidity constructor/fallback/receive."""
+        if node.type == "constructor_definition":
+            return "constructor"
+        if node.type == "fallback_receive_definition":
+            for child in node.children:
+                if child.type in ("receive", "fallback"):
+                    return child.text.decode("utf-8", errors="replace")
+        return None
+
+    def _get_cpp_name(self, node, language: str, kind: str) -> str | None:
+        """Extract C/C++ function name from declarators."""
+        for child in node.children:
+            if child.type in ("function_declarator", "pointer_declarator"):
+                result = self._get_name(child, language, kind)
+                if result:
+                    return result
+        return None
+
+    def _get_go_name(self, node, language: str, kind: str) -> str | None:
+        """Extract Go name from type_spec."""
+        for child in node.children:
+            if child.type == "type_spec":
+                return self._get_name(child, language, kind)
+        return None
+
     def _get_name(self, node, language: str, kind: str) -> str | None:
         """Extract the name from a class/function definition node."""
-        # Solidity: constructor and receive/fallback have no identifier child
         if language == "solidity":
-            if node.type == "constructor_definition":
-                return "constructor"
-            if node.type == "fallback_receive_definition":
-                for child in node.children:
-                    if child.type in ("receive", "fallback"):
-                        return child.text.decode("utf-8", errors="replace")
-        # For C/C++: function names are inside function_declarator/pointer_declarator
-        # Check these first to avoid matching the return type_identifier
+            sol_name = self._get_solidity_name(node)
+            if sol_name:
+                return sol_name
+
         if language in ("c", "cpp") and kind == "function":
-            for child in node.children:
-                if child.type in ("function_declarator", "pointer_declarator"):
-                    result = self._get_name(child, language, kind)
-                    if result:
-                        return result
+            cpp_name = self._get_cpp_name(node, language, kind)
+            if cpp_name:
+                return cpp_name
+
         # Most languages use a 'name' child
         for child in node.children:
             if child.type in (
@@ -881,11 +901,10 @@ class CodeParser:
                 "constant",
             ):
                 return child.text.decode("utf-8", errors="replace")
-        # For Go type declarations, look for type_spec
+
         if language == "go" and node.type == "type_declaration":
-            for child in node.children:
-                if child.type == "type_spec":
-                    return self._get_name(child, language, kind)
+            return self._get_go_name(node, language, kind)
+
         return None
 
     def _get_params(self, node, language: str, source: bytes) -> str | None:

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🎯 What
Refactored the `_get_name` method in `src/better_code_review_graph/parser.py` to reduce deep nesting.

💡 Why
Deep nesting in `_get_name` made the code difficult to read and maintain. Extracting language-specific logic into helpers improves modularity and reduces cognitive load.

✅ Verification
- Ran `uv run pytest tests/test_parser.py tests/test_multilang.py` (86 tests passed).
- Ran `uv run ruff check --fix .` and `uv run ruff format .`.
- Manually verified the refactored code structure.

✨ Result
A cleaner, more maintainable `_get_name` method with reduced nesting and better separation of concerns for language-specific parsing logic.

---
*PR created automatically by Jules for task [17490824577198213119](https://jules.google.com/task/17490824577198213119) started by @n24q02m*