### PR TITLE
[FIX] Function `watch` is overly complex (> 100 lines)

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -7,6 +7,17 @@ and updates the graph accordingly.
 from __future__ import annotations
 
 import fnmatch
+import threading
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    HAS_WATCHDOG = True
+except ImportError:
+    FileSystemEventHandler = object  # type: ignore
+    Observer = None  # type: ignore
+    HAS_WATCHDOG = False
 import hashlib
 import logging
 import subprocess
@@ -421,119 +432,129 @@ def incremental_update_from_hook() -> None:
 _DEBOUNCE_SECONDS = 0.3
 
 
+class GraphUpdateHandler(FileSystemEventHandler):
+    def __init__(
+        self,
+        repo_root: Path,
+        store: GraphStore,
+        parser: CodeParser,
+        ignore_patterns: list[str],
+    ):
+        super().__init__()
+        self.repo_root = repo_root
+        self.store = store
+        self.parser = parser
+        self.ignore_patterns = ignore_patterns
+        self._pending: set[str] = set()
+        self._lock = threading.Lock()
+        self._timer: threading.Timer | None = None
+
+    def _should_handle(self, path: str) -> bool:
+        path_obj = Path(path)
+        if path_obj.is_symlink():
+            return False
+        try:
+            rel = str(path_obj.relative_to(self.repo_root))
+        except ValueError:
+            return False
+        if _should_ignore(rel, self.ignore_patterns):
+            return False
+        if self.parser.detect_language(path_obj) is None:
+            return False
+        return True
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        if self._should_handle(event.src_path):
+            self._schedule(event.src_path)
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        if self._should_handle(event.src_path):
+            self._schedule(event.src_path)
+
+    def on_deleted(self, event):
+        if event.is_directory:
+            return
+        # Only handle files we would normally track
+        try:
+            rel = str(Path(event.src_path).relative_to(self.repo_root))
+        except ValueError:
+            return
+        if _should_ignore(rel, self.ignore_patterns):
+            return
+        self.store.remove_file_data(event.src_path)
+        self.store.commit()
+        logger.info("Removed: %s", rel)
+
+    def _schedule(self, abs_path: str):
+        """Add file to pending set and reset the debounce timer."""
+        with self._lock:
+            self._pending.add(abs_path)
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(_DEBOUNCE_SECONDS, self._flush)
+            self._timer.start()
+
+    def _flush(self):
+        """Process all pending files after the debounce window."""
+        with self._lock:
+            paths = list(self._pending)
+            self._pending.clear()
+            self._timer = None
+
+        for abs_path in paths:
+            self._update_file(abs_path)
+
+    def _update_file(self, abs_path: str):
+        path = Path(abs_path)
+        if not path.is_file():
+            return
+        if path.is_symlink():
+            return
+        if _is_binary(path):
+            return
+        try:
+            source = path.read_bytes()
+            fhash = hashlib.sha256(source).hexdigest()
+            nodes, edges = self.parser.parse_bytes(path, source)
+            self.store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
+            self.store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
+            self.store.commit()
+            rel = str(path.relative_to(self.repo_root))
+            logger.info(
+                "Updated: %s (%d nodes, %d edges)",
+                rel,
+                len(nodes),
+                len(edges),
+            )
+        except Exception as e:
+            logger.error("Error updating %s: %s", abs_path, e)
+
+
 def watch(repo_root: Path, store: GraphStore) -> None:
     """Watch for file changes and auto-update the graph.
 
     Uses a 300ms debounce to batch rapid-fire saves into a single update.
     """
-    import threading
-
-    from watchdog.events import FileSystemEventHandler
-    from watchdog.observers import Observer
+    if not HAS_WATCHDOG:
+        logger.error("watchdog package not installed. Cannot watch for changes.")
+        return
 
     parser = CodeParser()
     ignore_patterns = _load_ignore_patterns(repo_root)
 
-    class GraphUpdateHandler(FileSystemEventHandler):
-        def __init__(self):
-            self._pending: set[str] = set()
-            self._lock = threading.Lock()
-            self._timer: threading.Timer | None = None
-
-        def _should_handle(self, path: str) -> bool:
-            if Path(path).is_symlink():
-                return False
-            try:
-                rel = str(Path(path).relative_to(repo_root))
-            except ValueError:
-                return False
-            if _should_ignore(rel, ignore_patterns):
-                return False
-            if parser.detect_language(Path(path)) is None:
-                return False
-            return True
-
-        def on_modified(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_created(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_deleted(self, event):
-            if event.is_directory:
-                return
-            # Only handle files we would normally track
-            try:
-                rel = str(Path(event.src_path).relative_to(repo_root))
-            except ValueError:
-                return
-            if _should_ignore(rel, ignore_patterns):
-                return
-            store.remove_file_data(event.src_path)
-            store.commit()
-            logger.info("Removed: %s", rel)
-
-        def _schedule(self, abs_path: str):
-            """Add file to pending set and reset the debounce timer."""
-            with self._lock:
-                self._pending.add(abs_path)
-                if self._timer is not None:
-                    self._timer.cancel()
-                self._timer = threading.Timer(_DEBOUNCE_SECONDS, self._flush)
-                self._timer.start()
-
-        def _flush(self):
-            """Process all pending files after the debounce window."""
-            with self._lock:
-                paths = list(self._pending)
-                self._pending.clear()
-                self._timer = None
-
-            for abs_path in paths:
-                self._update_file(abs_path)
-
-        def _update_file(self, abs_path: str):
-            path = Path(abs_path)
-            if not path.is_file():
-                return
-            if path.is_symlink():
-                return
-            if _is_binary(path):
-                return
-            try:
-                source = path.read_bytes()
-                fhash = hashlib.sha256(source).hexdigest()
-                nodes, edges = parser.parse_bytes(path, source)
-                store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
-                store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
-                store.commit()
-                rel = str(path.relative_to(repo_root))
-                logger.info(
-                    "Updated: %s (%d nodes, %d edges)",
-                    rel,
-                    len(nodes),
-                    len(edges),
-                )
-            except Exception as e:
-                logger.error("Error updating %s: %s", abs_path, e)
-
-    handler = GraphUpdateHandler()
+    handler = GraphUpdateHandler(repo_root, store, parser, ignore_patterns)
     observer = Observer()
     observer.schedule(handler, str(repo_root), recursive=True)
     observer.start()
 
     logger.info("Watching %s for changes... (Ctrl+C to stop)", repo_root)
     try:
-        import time as _time
-
         while True:
-            _time.sleep(1)
+            time.sleep(1)
     except KeyboardInterrupt:
         observer.stop()
     observer.join()

--- a/tests/test_incremental_extra.py
+++ b/tests/test_incremental_extra.py
@@ -407,7 +407,7 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("watchdog.observers.Observer", return_value=FakeObserver()):
+        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 
@@ -511,7 +511,7 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("watchdog.observers.Observer", return_value=FakeObserver()):
+        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.3.1b1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR refactors the `watch` function in `src/better_code_review_graph/incremental.py` to address an issue where it was overly complex (> 100 lines).

**Changes:**
1.  **Extracted `GraphUpdateHandler`:** The inner class `GraphUpdateHandler` was moved to the module level. It now accepts its dependencies (`repo_root`, `store`, `parser`, `ignore_patterns`) via its constructor.
2.  **Top-level Imports:** Moved `threading` and `watchdog` imports to the top of the file. A `try-except` block handles the optional `watchdog` dependency, setting a `HAS_WATCHDOG` flag.
3.  **Simplified `watch` Function:** The `watch` function now focuses on initializing the handler and observer, making it much shorter and easier to maintain.
4.  **Updated Tests:** Patched `tests/test_incremental_extra.py` to correctly mock the `Observer` at its new module-level location.

**Verification:**
- Ran `uv run pytest tests/test_incremental.py` and `uv run pytest tests/test_incremental_extra.py`.
- Ran a broad suite of tests with `uv run pytest -k 'not test_live_mcp and not test_review_include_source'`.
- Verified with `uv run ruff check` and `uv run ruff format`.
- Verified with `uv run ty check src/better_code_review_graph/incremental.py`.
- Created and successfully ran a temporary unit test `tests/test_watch_handler.py` (since removed).

---
*PR created automatically by Jules for task [12242360928027937646](https://jules.google.com/task/12242360928027937646) started by @n24q02m*