### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 queries in graph analysis and semantic search

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -693,11 +693,14 @@ def semantic_search(
     """Search nodes using vector similarity, falling back to keyword search."""
     if embedding_store.available and embedding_store.count() > 0:
         results = embedding_store.search(query, limit=limit)
+        qns = [r[0] for r in results]
+        node_list = graph_store.get_nodes_by_qualified_names(qns)
+        node_map = {n.qualified_name: n for n in node_list}
+
         output = []
         for qn, score in results:
-            node = graph_store.get_node(qn)
-            if node:
-                d = node_to_dict(node)
+            if qn in node_map:
+                d = node_to_dict(node_map[qn])
                 d["similarity_score"] = round(score, 4)
                 output.append(d)
         return output

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -434,17 +434,8 @@ class GraphStore:
         total_impacted = len(impacted - seeds)
 
         # Resolve to full node info
-        changed_nodes = []
-        for qn in seeds:
-            node = self.get_node(qn)
-            if node:
-                changed_nodes.append(node)
-
-        impacted_nodes = []
-        for qn in impacted - seeds:
-            node = self.get_node(qn)
-            if node:
-                impacted_nodes.append(node)
+        changed_nodes = self.get_nodes_by_qualified_names(list(seeds))
+        impacted_nodes = self.get_nodes_by_qualified_names(list(impacted - seeds))
 
         impacted_files = list({n.file_path for n in impacted_nodes})
 
@@ -465,11 +456,9 @@ class GraphStore:
 
     def get_subgraph(self, qualified_names: list[str]) -> dict[str, Any]:
         """Extract a subgraph containing the specified nodes and their connecting edges."""
-        nodes = []
-        for qn in qualified_names:
-            node = self.get_node(qn)
-            if node:
-                nodes.append(node)
+        node_list = self.get_nodes_by_qualified_names(qualified_names)
+        node_map = {n.qualified_name: n for n in node_list}
+        nodes = [node_map[qn] for qn in qualified_names if qn in node_map]
 
         edges = []
         qn_set = set(qualified_names)


### PR DESCRIPTION
💡 What:
Optimized structural graph analysis and semantic search by batching node fetches. Specifically:
- Refactored `GraphStore.get_impact_radius` and `GraphStore.get_subgraph` in `graph.py` to use `get_nodes_by_qualified_names`.
- Refactored `semantic_search` in `embeddings.py` to batch resolve nodes after vector search.

🎯 Why:
Previous implementations performed iterative `get_node` calls within loops (N+1 pattern), causing significant performance degradation when processing large subgraphs or search results. While the `callers_of` pattern in `tools.py` was already found to be using batching in the current codebase, several other core methods still exhibited the N+1 pattern.

📊 Impact:
Significantly reduces database roundtrips during code review context generation (impact analysis), subgraph extraction, and semantic queries.

🧪 Measurement:
All core graph and embedding tests (`tests/test_graph.py`, `tests/test_embeddings.py`, `tests/test_tools.py`) passed, confirming functional parity with improved efficiency.

---
*PR created automatically by Jules for task [14317078556915790290](https://jules.google.com/task/14317078556915790290) started by @n24q02m*