### PR TITLE
[FIX] Deeply nested blocks in `_get_bases`

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -923,69 +923,98 @@ class CodeParser:
 
     def _get_bases(self, node, language: str, source: bytes) -> list[str]:
         """Extract base classes / implemented interfaces."""
-        bases = []
         if language == "python":
-            for child in node.children:
-                if child.type == "argument_list":
-                    for arg in child.children:
-                        if arg.type in ("identifier", "attribute"):
-                            bases.append(arg.text.decode("utf-8", errors="replace"))
-        elif language in ("java", "csharp", "kotlin"):
-            # Look for superclass/interfaces in extends/implements clauses
-            for child in node.children:
-                if child.type in (
-                    "superclass",
-                    "super_interfaces",
-                    "extends_type",
-                    "implements_type",
-                    "type_identifier",
-                    "supertype",
-                    "delegation_specifier",
-                ):
-                    text = child.text.decode("utf-8", errors="replace")
-                    bases.append(text)
-        elif language == "cpp":
-            # C++: base_class_clause contains type_identifiers
-            for child in node.children:
-                if child.type == "base_class_clause":
-                    for sub in child.children:
-                        if sub.type == "type_identifier":
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
-        elif language in ("typescript", "javascript", "tsx"):
-            # extends clause
-            for child in node.children:
-                if child.type in ("extends_clause", "implements_clause"):
-                    for sub in child.children:
-                        if sub.type in (
-                            "identifier",
-                            "type_identifier",
-                            "nested_identifier",
-                        ):
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
-        elif language == "solidity":
-            # contract Foo is Bar, Baz { ... }
-            for child in node.children:
-                if child.type == "inheritance_specifier":
-                    for sub in child.children:
-                        if sub.type == "user_defined_type":
-                            for ident in sub.children:
-                                if ident.type == "identifier":
-                                    bases.append(
-                                        ident.text.decode("utf-8", errors="replace")
-                                    )
-        elif language == "go":
-            # Embedded structs / interface composition
-            for child in node.children:
-                if child.type == "type_spec":
-                    for sub in child.children:
-                        if sub.type in ("struct_type", "interface_type"):
-                            for field_node in sub.children:
-                                if field_node.type == "field_declaration_list":
-                                    for f in field_node.children:
-                                        if f.type == "type_identifier":
-                                            bases.append(
-                                                f.text.decode("utf-8", errors="replace")
-                                            )
+            return self._get_bases_python(node)
+        if language in ("java", "csharp", "kotlin"):
+            return self._get_bases_jvm(node)
+        if language == "cpp":
+            return self._get_bases_cpp(node)
+        if language in ("typescript", "javascript", "tsx"):
+            return self._get_bases_web(node)
+        if language == "solidity":
+            return self._get_bases_solidity(node)
+        if language == "go":
+            return self._get_bases_go(node)
+        return []
+
+    def _get_bases_python(self, node) -> list[str]:
+        bases = []
+        for child in node.children:
+            if child.type == "argument_list":
+                for arg in child.children:
+                    if arg.type in ("identifier", "attribute"):
+                        bases.append(arg.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_jvm(self, node) -> list[str]:
+        bases = []
+        # Look for superclass/interfaces in extends/implements clauses
+        for child in node.children:
+            if child.type in (
+                "superclass",
+                "super_interfaces",
+                "extends_type",
+                "implements_type",
+                "type_identifier",
+                "supertype",
+                "delegation_specifier",
+            ):
+                text = child.text.decode("utf-8", errors="replace")
+                bases.append(text)
+        return bases
+
+    def _get_bases_cpp(self, node) -> list[str]:
+        bases = []
+        # C++: base_class_clause contains type_identifiers
+        for child in node.children:
+            if child.type == "base_class_clause":
+                for sub in child.children:
+                    if sub.type == "type_identifier":
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_web(self, node) -> list[str]:
+        bases = []
+        # extends clause
+        for child in node.children:
+            if child.type in ("extends_clause", "implements_clause"):
+                for sub in child.children:
+                    if sub.type in (
+                        "identifier",
+                        "type_identifier",
+                        "nested_identifier",
+                    ):
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+        return bases
+
+    def _get_bases_solidity(self, node) -> list[str]:
+        bases = []
+        # contract Foo is Bar, Baz Ellipsis
+        for child in node.children:
+            if child.type == "inheritance_specifier":
+                for sub in child.children:
+                    if sub.type == "user_defined_type":
+                        for ident in sub.children:
+                            if ident.type == "identifier":
+                                bases.append(
+                                    ident.text.decode("utf-8", errors="replace")
+                                )
+        return bases
+
+    def _get_bases_go(self, node) -> list[str]:
+        bases = []
+        # Embedded structs / interface composition
+        for child in node.children:
+            if child.type == "type_spec":
+                for sub in child.children:
+                    if sub.type in ("struct_type", "interface_type"):
+                        for field_node in sub.children:
+                            if field_node.type == "field_declaration_list":
+                                for f in field_node.children:
+                                    if f.type == "type_identifier":
+                                        bases.append(
+                                            f.text.decode("utf-8", errors="replace")
+                                        )
         return bases
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import pytest
 
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+
 
 def pytest_addoption(parser):
     """Add --setup and --browser CLI options for E2E tests."""
     parser.addoption("--setup", choices=["relay", "env", "plugin"], default="env")
     parser.addoption("--browser", choices=["chrome", "brave", "edge"], default="chrome")
-
-from better_code_review_graph.graph import GraphStore
-from better_code_review_graph.parser import EdgeInfo, NodeInfo
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest_e2e.py
+++ b/tests/conftest_e2e.py
@@ -12,12 +12,10 @@ Copy this file to each MCP server's tests/ directory unchanged.
 
 from __future__ import annotations
 
-import io
 import os
 import re
 import subprocess
 import sys
-import threading
 import time
 from typing import TextIO
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,5 +1,8 @@
 """E2E test for better-code-review-graph -- all tools except embed."""
-import json, os, subprocess
+import json
+import os
+import subprocess
+
 import pytest
 from mcp import StdioServerParameters
 from mcp.client.session import ClientSession

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,4 +1,5 @@
 """E2E test for better-code-review-graph -- all tools except embed."""
+
 import json
 import os
 import subprocess
@@ -10,35 +11,179 @@ from mcp.client.stdio import stdio_client
 
 pytestmark = pytest.mark.timeout(180)
 
+
 @pytest.mark.full
 async def test_all_tools(tmp_path):
-    r = tmp_path / "repo"; r.mkdir()
+    r = tmp_path / "repo"
+    r.mkdir()
     subprocess.run(["git", "init"], cwd=r, capture_output=True, check=True)
-    subprocess.run(["git", "config", "user.email", "t@t"], cwd=r, capture_output=True, check=True)
-    subprocess.run(["git", "config", "user.name", "T"], cwd=r, capture_output=True, check=True)
-    (r / "calc.py").write_text("def add(a,b): return a+b\ndef mul(a,b): return a*b\ndef calc(op,a,b):\n  if op=='add': return add(a,b)\n  return mul(a,b)\nclass C:\n  def run(self,op,a,b): return calc(op,a,b)\n")
-    (r / "test_calc.py").write_text("from calc import add\ndef test_add(): assert add(1,2)==3\n")
+    subprocess.run(
+        ["git", "config", "user.email", "t@t"], cwd=r, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"], cwd=r, capture_output=True, check=True
+    )
+    (r / "calc.py").write_text(
+        "def add(a,b): return a+b\ndef mul(a,b): return a*b\ndef calc(op,a,b):\n  if op=='add': return add(a,b)\n  return mul(a,b)\nclass C:\n  def run(self,op,a,b): return calc(op,a,b)\n"
+    )
+    (r / "test_calc.py").write_text(
+        "from calc import add\ndef test_add(): assert add(1,2)==3\n"
+    )
     subprocess.run(["git", "add", "."], cwd=r, capture_output=True, check=True)
     subprocess.run(["git", "commit", "-m", "i"], cwd=r, capture_output=True, check=True)
     rp = str(r)
-    sp = StdioServerParameters(command="uv", args=["run", "better-code-review-graph"], env={**os.environ, "EMBEDDING_BACKEND": "local"})
+    sp = StdioServerParameters(
+        command="uv",
+        args=["run", "better-code-review-graph"],
+        env={**os.environ, "EMBEDDING_BACKEND": "local"},
+    )
     async with stdio_client(sp) as (rd, wr):
         async with ClientSession(rd, wr) as s:
             await s.initialize()
-            assert {t.name for t in (await s.list_tools()).tools} == {"graph", "query", "review", "config", "help"}
-            d = json.loads((await s.call_tool("graph", {"action": "build", "full_rebuild": True, "repo_root": rp})).content[0].text)
+            assert {t.name for t in (await s.list_tools()).tools} == {
+                "graph",
+                "query",
+                "review",
+                "config",
+                "help",
+            }
+            d = json.loads(
+                (
+                    await s.call_tool(
+                        "graph",
+                        {"action": "build", "full_rebuild": True, "repo_root": rp},
+                    )
+                )
+                .content[0]
+                .text
+            )
             assert d["status"] == "ok" and d["total_nodes"] > 0
-            assert json.loads((await s.call_tool("graph", {"action": "update", "repo_root": rp})).content[0].text)["status"] == "ok"
-            assert json.loads((await s.call_tool("graph", {"action": "stats", "repo_root": rp})).content[0].text)["total_nodes"] > 0
-            assert (await s.call_tool("query", {"action": "query", "pattern": "callers_of", "target": "add", "repo_root": rp})).content[0].text
-            assert (await s.call_tool("query", {"action": "query", "pattern": "callees_of", "target": "calc", "repo_root": rp})).content[0].text
-            assert (await s.call_tool("query", {"action": "search", "search_query": "calc", "repo_root": rp})).content[0].text
-            assert (await s.call_tool("query", {"action": "impact", "changed_files": ["calc.py"], "repo_root": rp})).content[0].text
-            assert (await s.call_tool("query", {"action": "large_functions", "min_lines": 2, "repo_root": rp})).content[0].text
-            assert len((await s.call_tool("review", {"changed_files": ["calc.py"], "repo_root": rp})).content[0].text) > 10
-            assert json.loads((await s.call_tool("config", {"action": "status", "repo_root": rp})).content[0].text)
-            assert json.loads((await s.call_tool("config", {"action": "set", "key": "log_level", "value": "WARNING"})).content[0].text)
-            assert json.loads((await s.call_tool("config", {"action": "cache_clear", "repo_root": rp})).content[0].text)
+            assert (
+                json.loads(
+                    (await s.call_tool("graph", {"action": "update", "repo_root": rp}))
+                    .content[0]
+                    .text
+                )["status"]
+                == "ok"
+            )
+            assert (
+                json.loads(
+                    (await s.call_tool("graph", {"action": "stats", "repo_root": rp}))
+                    .content[0]
+                    .text
+                )["total_nodes"]
+                > 0
+            )
+            assert (
+                (
+                    await s.call_tool(
+                        "query",
+                        {
+                            "action": "query",
+                            "pattern": "callers_of",
+                            "target": "add",
+                            "repo_root": rp,
+                        },
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert (
+                (
+                    await s.call_tool(
+                        "query",
+                        {
+                            "action": "query",
+                            "pattern": "callees_of",
+                            "target": "calc",
+                            "repo_root": rp,
+                        },
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert (
+                (
+                    await s.call_tool(
+                        "query",
+                        {"action": "search", "search_query": "calc", "repo_root": rp},
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert (
+                (
+                    await s.call_tool(
+                        "query",
+                        {
+                            "action": "impact",
+                            "changed_files": ["calc.py"],
+                            "repo_root": rp,
+                        },
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert (
+                (
+                    await s.call_tool(
+                        "query",
+                        {"action": "large_functions", "min_lines": 2, "repo_root": rp},
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert (
+                len(
+                    (
+                        await s.call_tool(
+                            "review", {"changed_files": ["calc.py"], "repo_root": rp}
+                        )
+                    )
+                    .content[0]
+                    .text
+                )
+                > 10
+            )
+            assert json.loads(
+                (await s.call_tool("config", {"action": "status", "repo_root": rp}))
+                .content[0]
+                .text
+            )
+            assert json.loads(
+                (
+                    await s.call_tool(
+                        "config",
+                        {"action": "set", "key": "log_level", "value": "WARNING"},
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert json.loads(
+                (
+                    await s.call_tool(
+                        "config", {"action": "cache_clear", "repo_root": rp}
+                    )
+                )
+                .content[0]
+                .text
+            )
             for topic in ["graph", "query", "review", "config"]:
-                assert topic in (await s.call_tool("help", {"topic": topic})).content[0].text.lower()
-            assert "error" in (await s.call_tool("graph", {"action": "nonexistent"})).content[0].text.lower()
+                assert (
+                    topic
+                    in (await s.call_tool("help", {"topic": topic}))
+                    .content[0]
+                    .text.lower()
+                )
+            assert (
+                "error"
+                in (await s.call_tool("graph", {"action": "nonexistent"}))
+                .content[0]
+                .text.lower()
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.5.0"
+version = "3.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
# [FIX] Deeply nested blocks in `_get_bases`

## What
Refactored the `_get_bases` method in `src/better_code_review_graph/parser.py` by extracting language-specific logic into private helper methods.

## Why
The original implementation had deeply nested blocks for each supported language, making it hard to follow and maintain. Extracting these into separate methods reduces cognitive load and adheres to the project's code health standards.

## Verification
- Ran existing tests: `uv run pytest tests/test_parser.py tests/test_parser_extra.py` (43 passed).
- Verified formatting and linting: `uv run ruff check --fix .` and `uv run ruff format .`.
- Checked types: `uv run ty check src/better_code_review_graph/parser.py`.

## Result
The `_get_bases` method is now a clean dispatcher, and each language's extraction logic is isolated in its own method.

---
*PR created automatically by Jules for task [13402717813453416894](https://jules.google.com/task/13402717813453416894) started by @n24q02m*