### PR TITLE
⚡ Bolt: [performance improvement] Eliminate N+1 queries in embed_nodes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+## 2024-05-24 - N+1 Query Fix in Embeddings
+**Learning:** `EmbeddingStore.embed_nodes` had a significant N+1 query problem because it executed a `SELECT` statement in a loop to check for existing hashes node by node.
+**Action:** When iterating over nodes to check existing database state, pre-fetch all necessary records outside the loop using a batched `SELECT ... WHERE qualified_name IN (SELECT value FROM json_each(?))` with a serialized JSON list to completely eliminate N+1 query bottlenecks.

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -19,6 +19,7 @@ Switching backend does NOT invalidate existing vectors.
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import os
 import sqlite3
@@ -584,6 +585,23 @@ class EmbeddingStore:
 
         provider_name = self._get_backend_name()
 
+        # Pre-fetch existing hashes for all nodes to avoid N+1 query bottleneck
+        qns = [n.qualified_name for n in nodes if n.kind != "File"]
+        existing_data = {}
+        if qns:
+            batch_size = 450
+            for i in range(0, len(qns), batch_size):
+                batch = qns[i : i + batch_size]
+                rows = self._conn.execute(
+                    "SELECT qualified_name, text_hash, provider FROM embeddings WHERE qualified_name IN (SELECT value FROM json_each(?))",
+                    (json.dumps(batch),),
+                ).fetchall()
+                for r in rows:
+                    existing_data[r["qualified_name"]] = {
+                        "text_hash": r["text_hash"],
+                        "provider": r["provider"],
+                    }
+
         # Filter to nodes that need embedding
         to_embed: list[tuple[GraphNode, str, str]] = []
 
@@ -593,10 +611,7 @@ class EmbeddingStore:
             text = _node_to_text(node)
             text_hash = hashlib.sha256(text.encode()).hexdigest()
 
-            existing = self._conn.execute(
-                "SELECT text_hash, provider FROM embeddings WHERE qualified_name = ?",
-                (node.qualified_name,),
-            ).fetchone()
+            existing = existing_data.get(node.qualified_name)
 
             if (
                 existing

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
💡 **What:**
Replaced the individual `SELECT` queries inside the `for node in nodes:` loop in `EmbeddingStore.embed_nodes` with a single, pre-fetching batch query using SQLite's `json_each`. Existing `text_hash` and `provider` data are stored in a dictionary for O(1) lookups.

🎯 **Why:**
When running incremental updates or full builds that process hundreds of nodes, executing a separate `SELECT` query for every single node to check if its embedding is up-to-date causes severe N+1 query lag.

📊 **Impact:**
Substantially reduces database overhead when checking node embedding status. For 1000 nodes, it reduces the query count from ~1000 down to 3 batched queries.

🔬 **Measurement:**
Running `uv run pytest tests/` verifies the logic works perfectly. The performance gain can be measured by timing `embed_all_nodes` on a large repository graph before and after this change.

---
*PR created automatically by Jules for task [12957911053790075283](https://jules.google.com/task/12957911053790075283) started by @n24q02m*