### PR TITLE
⚡ Bolt: [performance improvement] batch fetch nodes to resolve N+1 queries

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -688,10 +688,10 @@ def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) ->
         return 0
 
     all_files = graph_store.get_all_files()
-    all_nodes: list[GraphNode] = []
-    for f in all_files:
-        all_nodes.extend(graph_store.get_nodes_by_file(f))
+    if not all_files:
+        return 0
 
+    all_nodes = graph_store.get_nodes_by_files(all_files)
     return embedding_store.embed_nodes(all_nodes)
 
 

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -281,6 +281,25 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
+    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+        """Batch fetch nodes matching multiple file paths in a single query."""
+        if not file_paths:
+            return []
+
+        unique_paths = list(set(file_paths))
+        results: list[GraphNode] = []
+        batch_size = 450  # Stay well under SQLite's default limit
+
+        for i in range(0, len(unique_paths), batch_size):
+            batch = unique_paths[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_node(r) for r in rows)
+
+        return results
+
     def get_nodes_by_qualified_names(
         self, qualified_names: list[str]
     ) -> list[GraphNode]:
@@ -401,8 +420,8 @@ class GraphStore:
 
         # Seed: all qualified names in changed files
         seeds = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
+        if changed_files:
+            nodes = self.get_nodes_by_files(changed_files)
             for n in nodes:
                 seeds.add(n.qualified_name)
 

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -392,7 +392,7 @@ def incremental_update(
                     existing_nodes_by_file[node.file_path] = []
                 existing_nodes_by_file[node.file_path].append(node)
 
-        for rel_path, abs_path_raw, abs_path in batch:
+        for rel_path, _abs_path_raw, abs_path in batch:
             try:
                 source = abs_path.read_bytes()
                 fhash = hashlib.sha256(source).hexdigest()

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -351,6 +351,10 @@ def incremental_update(
     total_edges = 0
     errors = []
 
+    # First pass: Resolve paths, filter ignored/invalid, and prepare pre-fetch
+    valid_files_to_process: list[tuple[str, Path, Path]] = []
+    all_abs_paths: list[str] = []
+
     for rel_path in all_files:
         if _should_ignore(rel_path, ignore_patterns):
             continue
@@ -358,33 +362,55 @@ def incremental_update(
         abs_path = abs_path_raw.resolve()
         if not abs_path.is_relative_to(repo_root.resolve()):
             continue
+
         if not abs_path.is_file():
             # File was deleted
             store.remove_file_data(str(abs_path))
             continue
+
         if abs_path_raw.is_symlink() or abs_path.is_symlink():
             continue
+
         if parser.detect_language(abs_path) is None:
             continue
 
-        try:
-            source = abs_path.read_bytes()
-            fhash = hashlib.sha256(source).hexdigest()
-            # Check if file actually changed (compare against stored file_hash column)
-            existing_nodes = store.get_nodes_by_file(str(abs_path))
-            if existing_nodes and existing_nodes[0].file_hash == fhash:
-                # Skip unchanged files (hash match)
-                continue
+        valid_files_to_process.append((rel_path, abs_path_raw, abs_path))
+        all_abs_paths.append(str(abs_path))
 
-            nodes, edges = parser.parse_bytes(abs_path, source)
-            store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
-            total_nodes += len(nodes)
-            total_edges += len(edges)
-        except (OSError, PermissionError) as e:
-            errors.append({"file": rel_path, "error": str(e)})
-        except Exception as e:
-            logger.warning("Error parsing %s: %s", rel_path, e)
-            errors.append({"file": rel_path, "error": str(e)})
+    # Process files in batches to bound memory usage
+    batch_size = 500
+    for i in range(0, len(valid_files_to_process), batch_size):
+        batch = valid_files_to_process[i : i + batch_size]
+        batch_paths = all_abs_paths[i : i + batch_size]
+
+        # Pre-fetch existing nodes for this batch to avoid N+1 queries
+        existing_nodes_by_file = {}
+        if batch_paths:
+            batch_nodes = store.get_nodes_by_files(batch_paths)
+            for node in batch_nodes:
+                if node.file_path not in existing_nodes_by_file:
+                    existing_nodes_by_file[node.file_path] = []
+                existing_nodes_by_file[node.file_path].append(node)
+
+        for rel_path, abs_path_raw, abs_path in batch:
+            try:
+                source = abs_path.read_bytes()
+                fhash = hashlib.sha256(source).hexdigest()
+                # Check if file actually changed (compare against stored file_hash column)
+                existing_nodes = existing_nodes_by_file.get(str(abs_path), [])
+                if existing_nodes and existing_nodes[0].file_hash == fhash:
+                    # Skip unchanged files (hash match)
+                    continue
+
+                nodes, edges = parser.parse_bytes(abs_path, source)
+                store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
+                total_nodes += len(nodes)
+                total_edges += len(edges)
+            except (OSError, PermissionError) as e:
+                errors.append({"file": rel_path, "error": str(e)})
+            except Exception as e:
+                logger.warning("Error parsing %s: %s", rel_path, e)
+                errors.append({"file": rel_path, "error": str(e)})
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
💡 What: Added `get_nodes_by_files` to `GraphStore` which batches fetching nodes by multiple file paths in a single query, and refactored three core workflows (`get_impact_radius`, `embed_all_nodes`, `incremental_update`) to use this method instead of iterating and making an N+1 number of individual `get_nodes_by_file` database queries.
🎯 Why: Iterating over file paths and individually querying nodes was causing an N+1 query performance bottleneck, particularly noticeable on larger repositories when processing many changed files or embedding all nodes. 
📊 Impact: Considerably faster updates and embedding operations since batch fetching prevents numerous individual database round trips.
🔭 Measurement: Verify by measuring time spent in `embed_all_nodes` and `incremental_update` before and after. Tests passed successfully. Memory usage bounds on the batch process were applied to avoid loading all repo nodes in memory at once.

---
*PR created automatically by Jules for task [2612906212648487390](https://jules.google.com/task/2612906212648487390) started by @n24q02m*