### PR TITLE
[CLEANUP] Unused argument 'source' in '_get_call_name'

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -460,7 +460,7 @@ class CodeParser:
 
             # --- Calls ---
             if node_type in call_types:
-                call_name = self._get_call_name(child, language, source)
+                call_name = self._get_call_name(child, language)
                 if call_name and enclosing_func:
                     caller = self._qualify(enclosing_func, file_path, enclosing_class)
                     target = self._resolve_call_target(
@@ -1091,7 +1091,7 @@ class CodeParser:
                 imports.append(match.group(1))
         return imports
 
-    def _get_call_name(self, node, language: str, source: bytes) -> str | None:
+    def _get_call_name(self, node, language: str) -> str | None:
         """Extract the function/method name being called."""
         if not node.children:
             return None

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.7.2"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR removes an unused `source: bytes` argument from the `_get_call_name` method in the `CodeParser` class.

### Changes
- Updated `_get_call_name` signature to remove `source: bytes`.
- Updated the call site in `_extract_from_tree` to reflect the signature change.

### Rationale
The `source` parameter was not used within the `_get_call_name` method, as the method extracts text directly from the Tree-sitter nodes using `node.text`. Removing it simplifies the API and reduces cognitive load.

### Verification
- Ran `uv run pytest` (508 tests passed).
- Verified `ruff` linting and formatting.
- Manually inspected the changes to ensure no other callers were affected.

---
*PR created automatically by Jules for task [7312208719814146374](https://jules.google.com/task/7312208719814146374) started by @n24q02m*