### PR TITLE
⚡ Bolt: [performance improvement] Optimize N+1 query in `find_dependents`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+
+## 2024-05-24 - N+1 Query Bottleneck in Edge Traversal
+**Learning:** `find_dependents` had an N+1 query bottleneck because it was fetching nodes by file and then repeatedly calling `get_edges_by_target` for each node's qualified name individually.
+**Action:** Created `get_edges_by_targets` in `GraphStore` to accept a list of targets and used SQLite's `json_each` to batch fetch the edges. Used this batch method in `find_dependents` to reduce DB calls.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -324,6 +324,41 @@ class GraphStore:
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
+    def get_edges_by_targets(self, qualified_names: list[str]) -> list[GraphEdge]:
+        """Batch fetch edges by a list of target qualified names to prevent N+1 queries.
+
+        Deduplicates input names, fetches in batches to respect SQLite limits.
+        """
+        if not qualified_names:
+            return []
+
+        unique_qns = list(set(qualified_names))
+        results: list[GraphEdge] = []
+        batch_size = 450
+
+        for i in range(0, len(unique_qns), batch_size):
+            batch = unique_qns[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM edges WHERE target_qualified IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_edge(r) for r in rows)
+
+            # Replicate fallback logic for targets not found
+            found_targets = {r["target_qualified"] for r in rows}
+            missing_targets = [
+                qn for qn in batch if qn not in found_targets and "::" in qn
+            ]
+            if missing_targets:
+                bare_names = [qn.rsplit("::", 1)[-1] for qn in missing_targets]
+                fallback_rows = self._conn.execute(
+                    "SELECT * FROM edges WHERE target_qualified IN (SELECT value FROM json_each(?))",
+                    (json.dumps(bare_names),),
+                ).fetchall()
+                results.extend(self._row_to_edge(r) for r in fallback_rows)
+
+        return results
+
     def search_edges_by_target_name(
         self, name: str, kind: str = "CALLS"
     ) -> list[GraphEdge]:

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -246,8 +246,9 @@ def find_dependents(store: GraphStore, file_path: str) -> list[str]:
 
     # Also check for DEPENDS_ON edges
     nodes = store.get_nodes_by_file(file_path)
-    for node in nodes:
-        for e in store.get_edges_by_target(node.qualified_name):
+    if nodes:
+        node_qns = [node.qualified_name for node in nodes]
+        for e in store.get_edges_by_targets(node_qns):
             if e.kind in ("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"):
                 dependents.add(e.file_path)
 


### PR DESCRIPTION
💡 **What**: Created `get_edges_by_targets` in `GraphStore` to accept a list of targets and used SQLite's `json_each` to batch fetch the edges. Updated `find_dependents` to collect all node names first, then fetch all relevant edges in a single DB roundtrip.
🎯 **Why**: In `find_dependents`, the method was iterating through all nodes in a file and calling `get_edges_by_target` for each one. For large files with hundreds of nodes, this created hundreds of sequential SQLite database queries, presenting a classic N+1 query bottleneck.
📊 **Impact**: Reduces SQLite queries in `find_dependents` from O(N) (where N is the number of nodes in a file) down to O(1) batched query, dramatically improving graph traversal speed during incremental updates.
🔬 **Measurement**: Execute the test suite `uv run pytest tests/test_incremental.py` to verify functionality. The improvement in speed will be noticeable on repositories with files containing large numbers of functions or classes during `find_dependents` dependency resolution.

---
*PR created automatically by Jules for task [9030723528854687343](https://jules.google.com/task/9030723528854687343) started by @n24q02m*