### PR TITLE
⚡ Bolt: [performance improvement] optimize embed_nodes by batching existing metadata queries

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -19,6 +19,7 @@ Switching backend does NOT invalidate existing vectors.
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import os
 import sqlite3
@@ -584,19 +585,35 @@ class EmbeddingStore:
 
         provider_name = self._get_backend_name()
 
+        # Pre-fetch existing embeddings metadata to prevent N+1 queries
+        valid_nodes = [n for n in nodes if n.kind != "File"]
+        qualified_names = [n.qualified_name for n in valid_nodes]
+
+        existing_metadata = {}
+        for i in range(0, len(qualified_names), batch_size):
+            batch = qualified_names[i : i + batch_size]
+            rows = self._conn.execute(
+                """
+                SELECT qualified_name, text_hash, provider
+                FROM embeddings
+                WHERE qualified_name IN (SELECT value FROM json_each(?))
+                """,
+                (json.dumps(batch),),
+            ).fetchall()
+            for r in rows:
+                existing_metadata[r["qualified_name"]] = {
+                    "text_hash": r["text_hash"],
+                    "provider": r["provider"],
+                }
+
         # Filter to nodes that need embedding
         to_embed: list[tuple[GraphNode, str, str]] = []
 
-        for node in nodes:
-            if node.kind == "File":
-                continue
+        for node in valid_nodes:
             text = _node_to_text(node)
             text_hash = hashlib.sha256(text.encode()).hexdigest()
 
-            existing = self._conn.execute(
-                "SELECT text_hash, provider FROM embeddings WHERE qualified_name = ?",
-                (node.qualified_name,),
-            ).fetchone()
+            existing = existing_metadata.get(node.qualified_name)
 
             if (
                 existing


### PR DESCRIPTION
## 💡 What
Replaced N+1 queries per-node inside `embed_nodes` loop with batched metadata lookups using SQLite `json_each(?)`.

## 🎯 Why
During graph embedding runs via `embed_graph` tool, checking if a node needs embedding required executing one `SELECT` statement per graph node. Large codebases would perform tens of thousands of individual database queries, introducing a severe performance bottleneck.

## 📊 Impact
Eliminates O(N) queries during the node iteration phase. Reduces the number of database calls during embeddings from O(N) queries to O(N / batch_size), significantly reducing overhead and total embedding time for large repositories.

## 🔬 Measurement
Run `uv run pytest tests/test_embeddings.py` to ensure embeddings are successfully verified and updated. 
Measure performance across a large project by inspecting differences in initial and incremental runs via `embed_nodes`.

---
*PR created automatically by Jules for task [2037053054097934480](https://jules.google.com/task/2037053054097934480) started by @n24q02m*