### PR TITLE
[TEST] Untested error handling in relay_setup.py ensure_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,10 @@
 **Vulnerability:** Found `subprocess.run` calls that relied on partial executable names (like `"git"`) without an absolute path, which creates a command injection risk (Bandit B607) if the environment's `PATH` variable is manipulated to point to a malicious binary.
 **Learning:** `subprocess.run` searches the `PATH` environment variable when `shell=False` and a relative path is provided, making it susceptible to hijacking.
 **Prevention:** Always resolve the absolute path to system executables using `shutil.which("executable_name")` and raise an error if not found before passing it to `subprocess.run`.
+## 2025-05-14 - [TEST] Untested error handling in relay_setup.py ensure_config
+
+**Vulnerability:** Untested exception handling blocks in credential resolution logic. While not a direct security vulnerability, untested error paths can lead to unexpected behavior or crashes in production environments when external dependencies (like config files or relay servers) fail.
+
+**Learning:** When using internal imports within functions (like `from mcp_relay_core.storage.config_file import read_config`), mocking these dependencies requires patching them at the correct target. In this codebase, patching the full module path `mcp_relay_core.storage.config_file.read_config` worked correctly because `ensure_config` was imported and then called in the test.
+
+**Prevention:** Ensure 100% test coverage for critical setup and configuration logic, especially error handling paths that involve external I/O or network requests.

--- a/tests/test_relay_setup_coverage_fix.py
+++ b/tests/test_relay_setup_coverage_fix.py
@@ -1,0 +1,89 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from better_code_review_graph.relay_setup import (
+    CLOUD_KEYS,
+    ensure_config,
+)
+
+
+@pytest.mark.asyncio
+async def test_read_config_exception(monkeypatch):
+    for key in CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    # Line 64-65: read_config raises Exception
+    with patch(
+        "mcp_relay_core.storage.config_file.read_config",
+        side_effect=Exception("Disk error"),
+    ):
+        # To avoid going into relay setup, we also mock create_session to fail
+        with patch(
+            "mcp_relay_core.relay.client.create_session",
+            side_effect=Exception("no relay"),
+        ):
+            result = await ensure_config()
+            assert result is None
+
+
+@pytest.mark.asyncio
+async def test_httpx_post_exception(monkeypatch):
+    for key in CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    with patch("mcp_relay_core.storage.config_file.read_config", return_value=None):
+        mock_session = MagicMock()
+        mock_session.relay_url = "https://relay.example.com/setup"
+        mock_session.session_id = "test-session"
+
+        # Mock create_session and poll_for_result to succeed
+        with patch(
+            "mcp_relay_core.relay.client.create_session",
+            new_callable=AsyncMock,
+            return_value=mock_session,
+        ):
+            with patch(
+                "mcp_relay_core.relay.client.poll_for_result",
+                new_callable=AsyncMock,
+                return_value={"GEMINI_API_KEY": "new-key"},
+            ):
+                with patch("mcp_relay_core.storage.config_file.write_config"):
+                    # Line 111-112: httpx post raises Exception
+                    with patch("httpx.AsyncClient") as mock_client_class:
+                        mock_client = MagicMock()
+                        mock_client.post = AsyncMock(
+                            side_effect=Exception("Network error")
+                        )
+                        mock_client.__aenter__.return_value = mock_client
+                        mock_client_class.return_value = mock_client
+
+                        result = await ensure_config()
+                        assert result is not None
+                        assert result["GEMINI_API_KEY"] == "new-key"
+                        assert os.environ.get("GEMINI_API_KEY") == "new-key"
+
+
+@pytest.mark.asyncio
+async def test_poll_for_result_runtime_error_unexpected(monkeypatch):
+    for key in CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    with patch("mcp_relay_core.storage.config_file.read_config", return_value=None):
+        mock_session = MagicMock()
+        mock_session.relay_url = "https://relay.example.com/setup"
+
+        with patch(
+            "mcp_relay_core.relay.client.create_session",
+            new_callable=AsyncMock,
+            return_value=mock_session,
+        ):
+            # Line 126: RuntimeError with unexpected message
+            with patch(
+                "mcp_relay_core.relay.client.poll_for_result",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("something went wrong"),
+            ):
+                result = await ensure_config()
+                assert result is None


### PR DESCRIPTION
Added tests for error handling in relay_setup.py to achieve 100% coverage.

---
*PR created automatically by Jules for task [14890693988360359809](https://jules.google.com/task/14890693988360359809) started by @n24q02m*