### PR TITLE
[CLEANUP] Unused argument 'source' in '_collect_import_names'

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+
+## 2026-04-10 - [CLEANUP] Remove unused source parameter in parser
+**Learning:** Consistently removing unused parameters in internal helper methods improves code readability and maintainability, especially in complex parsing logic.
+**Action:** Identify and remove unused parameters in tree-sitter helper methods when they are no longer needed due to refactoring.

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -689,7 +689,7 @@ class CodeParser:
 
             # Collect import mappings: imported_name → module_path
             if node_type in import_types:
-                self._collect_import_names(child, language, source, import_map)
+                self._collect_import_names(child, language, import_map)
 
         return import_map, defined_names
 
@@ -697,7 +697,6 @@ class CodeParser:
         self,
         node,
         language: str,
-        source: bytes,
         import_map: dict[str, str],
     ) -> None:
         """Extract imported names and their source modules into import_map."""


### PR DESCRIPTION
This pull request removes the unused `source` parameter from the `_collect_import_names` method in `src/better_code_review_graph/parser.py`. 

The parameter was identified as redundant as the method primarily uses `node.text` or delegating to other helpers that don't require the raw source bytes. Removing it simplifies the signature and improves code clarity.

Changes:
- Modified `_collect_import_names` signature in `src/better_code_review_graph/parser.py`.
- Updated the call site in `_get_imports_and_defined_names` within the same file.
- Verified with `ruff` and existing tests.

---
*PR created automatically by Jules for task [6082250824142400490](https://jules.google.com/task/6082250824142400490) started by @n24q02m*