### PR TITLE
[TEST] Untested config() 'set' action error paths

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -280,10 +280,13 @@ class TestConfigTool:
 
     def test_set_missing_key(self):
         result = json.loads(config(action="set"))
+        assert result["error"] == "key is required for set action"
+        assert result["valid_keys"] == ["log_level"]
         assert "error" in result
 
     def test_set_missing_value(self):
         result = json.loads(config(action="set", key="log_level"))
+        assert result["error"] == "value is required for set action"
         assert "error" in result
 
     def test_set_invalid_key(self):


### PR DESCRIPTION
This PR adds specific assertions to existing tests in `tests/test_server.py` to cover untested error paths in the `config()` tool's 'set' action.

Specifically:
- `test_set_missing_key` now verifies that calling `config(action="set")` returns the error "key is required for set action" and includes the `valid_keys` list.
- `test_set_missing_value` now verifies that calling `config(action="set", key="log_level")` returns the error "value is required for set action".

These changes ensure that these error conditions are not only reached during testing but also return the expected content.

---
*PR created automatically by Jules for task [4343154753498010753](https://jules.google.com/task/4343154753498010753) started by @n24q02m*