### PR TITLE
[CLEANUP] Unused arguments in '__exit__'

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -133,7 +133,7 @@ class GraphStore:
     def __enter__(self) -> GraphStore:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, _exc_type, _exc_val, _exc_tb) -> None:
         self.close()
 
     def _init_schema(self) -> None:


### PR DESCRIPTION
Renamed unused context manager parameters in `GraphStore.__exit__` to `_exc_type`, `_exc_val`, and `_exc_tb` to comply with linting standards and improve code quality. This change ensures that the codebase follows best practices for identifying intentionally unused arguments.

---
*PR created automatically by Jules for task [5703509936717539979](https://jules.google.com/task/5703509936717539979) started by @n24q02m*