### PR TITLE
[CLEANUP] Unused argument 'changed_files'

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -722,7 +722,7 @@ def get_review_context(
             context["source_snippets"] = snippets
 
         # Generate review guidance
-        guidance = _generate_review_guidance(impact, changed_files)
+        guidance = _generate_review_guidance(impact)
         context["review_guidance"] = guidance
 
         summary_parts = [
@@ -776,7 +776,7 @@ def _extract_relevant_lines(lines: list[str], nodes: list, file_path: str) -> st
     return "\n".join(parts)
 
 
-def _generate_review_guidance(impact: dict, changed_files: list[str]) -> str:
+def _generate_review_guidance(impact: dict) -> str:
     """Generate review guidance based on the impact analysis."""
     guidance_parts = []
 

--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -624,7 +624,7 @@ class TestGenerateReviewGuidance:
             "impacted_files": [],
             "edges": [],
         }
-        result = _generate_review_guidance(impact, ["a.py"])
+        result = _generate_review_guidance(impact)
         assert "well-contained" in result
 
     def test_untested_functions(self):
@@ -639,7 +639,7 @@ class TestGenerateReviewGuidance:
             "impacted_files": [],
             "edges": [],
         }
-        result = _generate_review_guidance(impact, ["a.py"])
+        result = _generate_review_guidance(impact)
         assert "test coverage" in result.lower() or "lack test" in result.lower()
 
     def test_wide_blast_radius(self):
@@ -649,7 +649,7 @@ class TestGenerateReviewGuidance:
             "impacted_files": [],
             "edges": [],
         }
-        result = _generate_review_guidance(impact, ["a.py"])
+        result = _generate_review_guidance(impact)
         assert "Wide blast radius" in result
 
     def test_inheritance_edges(self):
@@ -661,7 +661,7 @@ class TestGenerateReviewGuidance:
             "impacted_files": [],
             "edges": [edge],
         }
-        result = _generate_review_guidance(impact, ["a.py"])
+        result = _generate_review_guidance(impact)
         assert "inheritance" in result.lower() or "Liskov" in result
 
     def test_cross_file_impact(self):
@@ -671,7 +671,7 @@ class TestGenerateReviewGuidance:
             "impacted_files": ["b.py", "c.py", "d.py", "e.py"],
             "edges": [],
         }
-        result = _generate_review_guidance(impact, ["a.py"])
+        result = _generate_review_guidance(impact)
         assert "impact" in result.lower()
 
 


### PR DESCRIPTION
The `changed_files` argument in `_generate_review_guidance` was not being used within the function body. This PR removes it from the function signature and all its caller sites in `src/better_code_review_graph/tools.py` and `tests/test_tools_full.py`.

---
*PR created automatically by Jules for task [14660149930896669368](https://jules.google.com/task/14660149930896669368) started by @n24q02m*