### PR TITLE
[CLEANUP] Unused argument 'source' in '_get_call_name'

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -460,7 +460,7 @@ class CodeParser:
 
             # --- Calls ---
             if node_type in call_types:
-                call_name = self._get_call_name(child, language, source)
+                call_name = self._get_call_name(child, language)
                 if call_name and enclosing_func:
                     caller = self._qualify(enclosing_func, file_path, enclosing_class)
                     target = self._resolve_call_target(
@@ -1091,7 +1091,7 @@ class CodeParser:
                 imports.append(match.group(1))
         return imports
 
-    def _get_call_name(self, node, language: str, source: bytes) -> str | None:
+    def _get_call_name(self, node, language: str) -> str | None:
         """Extract the function/method name being called."""
         if not node.children:
             return None


### PR DESCRIPTION
Removed the unused `source: bytes` parameter from the `_get_call_name` method in `src/better_code_review_graph/parser.py`. Updated the single call site in `_extract_from_tree` to reflect this change. This cleanup simplifies the method signature and aligns it with other internal helpers that extract information directly from Tree-sitter nodes.

---
*PR created automatically by Jules for task [7587078825282669448](https://jules.google.com/task/7587078825282669448) started by @n24q02m*