### PR TITLE
[FIX] N+1 Database Query in Impact Radius Calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+
+## 2026-04-10 - N+1 Query in Impact Radius
+**Learning:** The `get_impact_radius` method performed an N+1 query pattern by calling `get_nodes_by_file` in a loop for each changed file.
+**Action:** Implemented a batch-fetching method `get_nodes_by_files` in `GraphStore` using SQLite's `json_each` and used it to retrieve all seed nodes in a single query.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -281,6 +281,29 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
+    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+        """Batch fetch nodes by their file paths to prevent N+1 queries.
+
+        Deduplicates input paths, fetches in batches to respect SQLite limits,
+        and returns all matching nodes.
+        """
+        if not file_paths:
+            return []
+
+        unique_paths = list(set(file_paths))
+        results: list[GraphNode] = []
+        batch_size = 450  # Stay well under SQLite's default limit
+
+        for i in range(0, len(unique_paths), batch_size):
+            batch = unique_paths[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_node(r) for r in rows)
+
+        return results
+
     def get_nodes_by_qualified_names(
         self, qualified_names: list[str]
     ) -> list[GraphNode]:
@@ -419,11 +442,7 @@ class GraphStore:
         nxg = self._build_networkx_graph()
 
         # Seed: all qualified names in changed files
-        seeds = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
-            for n in nodes:
-                seeds.add(n.qualified_name)
+        seeds = {n.qualified_name for n in self.get_nodes_by_files(changed_files)}
 
         # BFS outward through all edge types
         visited: set[str] = set()


### PR DESCRIPTION
Fixed an N+1 database query pattern in `get_impact_radius` by introducing a batch-fetching method `get_nodes_by_files`. This new method uses SQLite's `json_each` and batching (chunk size of 450) to efficiently retrieve nodes for multiple file paths in a single query, similar to the existing `get_nodes_by_qualified_names` implementation. This significantly improves performance when calculating the impact radius for changes involving multiple files.

---
*PR created automatically by Jules for task [14033597970640462283](https://jules.google.com/task/14033597970640462283) started by @n24q02m*