### PR TITLE
[CLEANUP] Unused argument 'batch_size'

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+## 2026-04-10 - N+1 Embedding Metadata Lookups
+**Learning:** Checking for existing embeddings one-by-one in `embed_nodes` created an N+1 query bottleneck during large-scale re-indexing.
+**Action:** Use `batch_size` to chunk node lists and batch-fetch existing metadata using SQLite's `json_each` function to significantly improve performance.

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -19,6 +19,7 @@ Switching backend does NOT invalidate existing vectors.
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import os
 import sqlite3
@@ -583,28 +584,43 @@ class EmbeddingStore:
             return 0
 
         provider_name = self._get_backend_name()
-
-        # Filter to nodes that need embedding
         to_embed: list[tuple[GraphNode, str, str]] = []
 
-        for node in nodes:
-            if node.kind == "File":
-                continue
-            text = _node_to_text(node)
-            text_hash = hashlib.sha256(text.encode()).hexdigest()
+        # Process in chunks to avoid N+1 queries for existing metadata
+        for i in range(0, len(nodes), batch_size):
+            chunk = nodes[i : i + batch_size]
 
-            existing = self._conn.execute(
-                "SELECT text_hash, provider FROM embeddings WHERE qualified_name = ?",
-                (node.qualified_name,),
-            ).fetchone()
+            # Map qualified names to (node, text, text_hash) for this chunk
+            chunk_data: dict[str, tuple[GraphNode, str, str]] = {}
+            for node in chunk:
+                if node.kind == "File":
+                    continue
+                text = _node_to_text(node)
+                text_hash = hashlib.sha256(text.encode()).hexdigest()
+                chunk_data[node.qualified_name] = (node, text, text_hash)
 
-            if (
-                existing
-                and existing["text_hash"] == text_hash
-                and existing["provider"] == provider_name
-            ):
+            if not chunk_data:
                 continue
-            to_embed.append((node, text, text_hash))
+
+            # Batch fetch existing metadata using json_each
+            qns = list(chunk_data.keys())
+            rows = self._conn.execute(
+                """SELECT qualified_name, text_hash, provider FROM embeddings
+                   WHERE qualified_name IN (SELECT value FROM json_each(?))""",
+                (json.dumps(qns),),
+            ).fetchall()
+
+            existing_map = {row["qualified_name"]: row for row in rows}
+
+            for qn, (node, text, text_hash) in chunk_data.items():
+                existing = existing_map.get(qn)
+                if (
+                    existing
+                    and existing["text_hash"] == text_hash
+                    and existing["provider"] == provider_name
+                ):
+                    continue
+                to_embed.append((node, text, text_hash))
 
         if not to_embed:
             return 0


### PR DESCRIPTION
Refactored \`EmbeddingStore.embed_nodes\` to utilize the \`batch_size\` parameter. The function now processes nodes in chunks and uses SQLite's \`json_each\` function to batch-fetch existing embedding metadata. This eliminates an N+1 query bottleneck and significantly improves re-indexing performance.

---
*PR created automatically by Jules for task [1598476344146158345](https://jules.google.com/task/1598476344146158345) started by @n24q02m*