### PR TITLE
⚡ Bolt: [performance improvement] batch fetch nodes by file paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Graph Queries Bottleneck
 **Learning:** SQLite backend graph traversal functions in `tools.py` suffer from N+1 query bottlenecks when resolving target node objects one-by-one from edges.
 **Action:** When resolving node relationships, collect target qualified names first and batch fetch using `get_nodes_by_qualified_names` to retrieve nodes, preventing N+1 queries. Note that `imports_of` and `importers_of` only return dictionaries of qualified names or file paths, not full node objects, and thus do not require this optimization.
+
+## 2024-05-24 - N+1 Queries Bottleneck When Finding Nodes by Files
+**Learning:** Functions like `embed_all_nodes` and `get_impact_radius` call `get_nodes_by_file` iteratively for each file in a list, resulting in N+1 queries.
+**Action:** Implement `get_nodes_by_files` to batch fetch nodes by their file paths using SQLite's `json_each` to eliminate N+1 queries when querying for multiple files.

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -689,8 +689,8 @@ def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) ->
 
     all_files = graph_store.get_all_files()
     all_nodes: list[GraphNode] = []
-    for f in all_files:
-        all_nodes.extend(graph_store.get_nodes_by_file(f))
+    if all_files:
+        all_nodes = graph_store.get_nodes_by_files(all_files)
 
     return embedding_store.embed_nodes(all_nodes)
 

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -281,6 +281,29 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
+    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+        """Batch fetch nodes by their file paths to prevent N+1 queries.
+
+        Deduplicates input file paths, fetches in batches to respect SQLite limits,
+        and returns all matching nodes.
+        """
+        if not file_paths:
+            return []
+
+        unique_files = list(set(file_paths))
+        results: list[GraphNode] = []
+        batch_size = 450  # Stay well under SQLite's default limit
+
+        for i in range(0, len(unique_files), batch_size):
+            batch = unique_files[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_node(r) for r in rows)
+
+        return results
+
     def get_nodes_by_qualified_names(
         self, qualified_names: list[str]
     ) -> list[GraphNode]:
@@ -420,8 +443,8 @@ class GraphStore:
 
         # Seed: all qualified names in changed files
         seeds = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
+        if changed_files:
+            nodes = self.get_nodes_by_files(changed_files)
             for n in nodes:
                 seeds.add(n.qualified_name)
 


### PR DESCRIPTION
💡 What: Added a new batch-fetching method `get_nodes_by_files` in `GraphStore` and updated `embed_all_nodes` (in `embeddings.py`) and `get_impact_radius` (in `graph.py`) to use it instead of calling `get_nodes_by_file` iteratively in a loop.

🎯 Why: To eliminate an N+1 queries bottleneck. Previously, functions iterating over multiple files (e.g., all files in the repository or a large list of changed files) would execute a separate SQLite query for every single file. This is highly inefficient.

📊 Impact: Reduces database queries from O(N) (where N is the number of files) to O(N/batch_size) (where batch_size is 450). This significantly improves performance when operating on many files simultaneously.

🔬 Measurement: Run the test suite (`uv run pytest`) and measure the execution time of `get_impact_radius` and `embed_all_nodes` with a large number of changed files or a large repository. The execution time should be measurably lower and scale better with the number of files.

---
*PR created automatically by Jules for task [15267826385528565514](https://jules.google.com/task/15267826385528565514) started by @n24q02m*