### PR TITLE
⚡ Bolt: [performance improvement] Eliminate N+1 queries with get_nodes_by_files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-code-review-graph",
   "description": "Persistent incremental knowledge graph for token-efficient code reviews",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-04-10 - [SQL Query Optimization for IN Clauses]
-**Learning:** Using SQLite's `json_each(?)` function for variable-length IN clauses is not only more secure but also more performant as it allows for a single prepared statement, reducing query parsing overhead.
-**Action:** Always prefer `json_each` for batch lookups in SQLite.
+## 2026-04-14 - Eliminate N+1 Queries with get_nodes_by_files
+**Learning:** Found N+1 anti-pattern in `get_impact_radius` (`graph.py`) and `embed_all_nodes` (`embeddings.py`), where nodes were fetched individually by file path in loops.
+**Action:** Implemented a new `get_nodes_by_files` method in `GraphStore` utilizing SQLite `json_each` and batched execution (size 450) to efficiently fetch nodes by multiple file paths in a single query. Used it to resolve the bottlenecks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "better-code-review-graph"
-version = "3.8.0"
+version = "3.9.0"
 description = "Knowledge graph for token-efficient code reviews — fixed search, configurable embeddings, qualified call resolution"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"
   },
-  "version": "3.8.0",
+  "version": "3.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "better-code-review-graph",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "runtimeHint": "uvx",
       "runtimeArgs": [
         "--python",

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -694,8 +694,8 @@ def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) ->
 
     all_files = graph_store.get_all_files()
     all_nodes: list[GraphNode] = []
-    for f in all_files:
-        all_nodes.extend(graph_store.get_nodes_by_file(f))
+    if all_files:
+        all_nodes = graph_store.get_nodes_by_files(all_files)
 
     return embedding_store.embed_nodes(all_nodes)
 

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -282,6 +282,29 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
+    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+        """Batch fetch nodes by their file paths to prevent N+1 queries.
+
+        Deduplicates input paths, fetches in batches to respect SQLite limits,
+        and returns all matching nodes.
+        """
+        if not file_paths:
+            return []
+
+        unique_paths = list(set(file_paths))
+        results: list[GraphNode] = []
+        batch_size = 450  # Stay well under SQLite's default limit
+
+        for i in range(0, len(unique_paths), batch_size):
+            batch = unique_paths[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_node(r) for r in rows)
+
+        return results
+
     def get_nodes_by_qualified_names(
         self, qualified_names: list[str]
     ) -> list[GraphNode]:
@@ -421,8 +444,8 @@ class GraphStore:
 
         # Seed: all qualified names in changed files
         seeds = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
+        if changed_files:
+            nodes = self.get_nodes_by_files(changed_files)
             for n in nodes:
                 seeds.add(n.qualified_name)
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.8.0"
+version = "3.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -1574,6 +1574,14 @@ version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/dc/d4a0ad9e466263728f80f9dac399609473af01c1aba2ea3ea8879ce56276/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e87be7572991552606a3155d2f6c2045ded8bce94bfd9f74bf521d949c219a1c", size = 333661, upload-time = "2026-04-14T15:11:14.227Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7a/5c862770460a2e27079e725585ad2718100373c09448c14e36934ef44414/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:86c2fdf178c66474a1be2965602818d30780e4e3ed890e3c206931f65d9a154c", size = 376295, upload-time = "2026-04-14T15:11:15.346Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/0571a3a34c0feda60a9c37cf6dd5edfdbc24f8fcb1e48b6b6eb0f324ad2a/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:035d259e64c41d02cc45afc3b8b46388b232e7d16d84734d851cca7334761da5", size = 358331, upload-time = "2026-04-14T15:11:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/0f7e1f50f6365338eb700f01710da0adc49a49fa9a8443e5a90ea4f29491/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa472cb9de7e14fee9408e144f29f68384cd8e9c677dff0002da19f361a59bdf", size = 359444, upload-time = "2026-04-14T15:11:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/129bd56d5ef22b4ae254940a09b6d3ed873093218868a3f9635d571d514e/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1a0ea86eccff74e85ab4a2cf77c813fad7c84162962ce242dff0c51601028832", size = 358143, upload-time = "2026-04-14T15:11:18.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cd/e12cdca47e0c56151cb4b156d48091b7bc1d968e072c1656cf6b73fe7218/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ab26dc998bbd4b4287b129f67c10ca715deb402ed77d0645674490ea509097e", size = 357524, upload-time = "2026-04-14T15:11:19.717Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2c/f742d60f818cba83760f4975c7158d1c96c36b5807e95a843db7fb8c64b7/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:d4486653feaff3314ef45534dcb6f9ea8ab3aa160896287c6473788f88eb38be", size = 338755, upload-time = "2026-04-14T15:11:20.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e4/8a8642b9bba86248ac2facc81ffb187c06c6768efa56c79d61fab70d736b/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:e7a14b76ec23cc8386cf662d5ea602d81331376c93ca6299a97b174047790345", size = 337261, upload-time = "2026-04-14T15:11:22.111Z" },
     { url = "https://files.pythonhosted.org/packages/58/04/f6c2df4c53a588ccd88d50851155945cff8cd887bd70c175e00aaade7edf/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd", size = 372235, upload-time = "2024-11-11T05:25:19.424Z" },
     { url = "https://files.pythonhosted.org/packages/99/10/1aa9486f1e28fc22810fa92cbdc54e1051e7f5536a5e5b5e9695f609b31e/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e", size = 419046, upload-time = "2024-11-11T05:25:20.679Z" },
     { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },


### PR DESCRIPTION
💡 **What:** Added a `get_nodes_by_files` method in `GraphStore` utilizing SQLite `json_each` with a batch size of 450 to fetch nodes for multiple file paths in a single query. Replaced loops over `changed_files` in `get_impact_radius` and `all_files` in `embed_all_nodes` with this batched operation.
🎯 **Why:** Previously, these functions iterated over arrays of file paths and called `get_nodes_by_file` individually for each path, leading to severe N+1 query bottlenecks when dealing with a large number of files.
📊 **Impact:** Significantly reduces database roundtrips during graph building and node embeddings processes. The performance improves from O(N) database queries to O(N/450) database queries (effectively O(1) for typical pull requests).
🔬 **Measurement:** Verify performance of `get_impact_radius` on a simulated PR modifying hundreds of files, or run tests with tracing enabled to confirm database calls are batched.

---
*PR created automatically by Jules for task [6485987581938521674](https://jules.google.com/task/6485987581938521674) started by @n24q02m*