### PR TITLE
[TEST] Missing error test for `query_graph` invalid pattern

### DIFF
--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -938,6 +938,16 @@ class TestSemanticSearchWithEmbeddings:
 
 
 class TestQueryGraphEdgeCases:
+    def test_query_invalid_pattern(self, repo_with_graph):
+        """Cover line 431: return error for unknown pattern."""
+        result = query_graph(
+            pattern="invalid_pattern",
+            target="some_target",
+            repo_root=str(repo_with_graph),
+        )
+        assert result["status"] == "error"
+        assert "Unknown pattern" in result["error"]
+
     def test_query_search_single_candidate(self, repo_with_graph):
         """When search returns exactly 1 candidate, use it."""
         result = query_graph(


### PR DESCRIPTION
Added a new test case `test_query_invalid_pattern` to `tests/test_tools_full.py` to cover the validation check for unknown patterns in the `query_graph` function. This ensures that the function correctly returns an error status when an unsupported pattern is provided, improving overall test coverage and robustness.

---
*PR created automatically by Jules for task [5419876582220168870](https://jules.google.com/task/5419876582220168870) started by @n24q02m*