### PR TITLE
[TEST] Missing error path test for build/update failure in `build_or_update_graph`

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -291,6 +291,11 @@ def build_or_update_graph(
                 ),
                 **result,
             }
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": f"Graph build/update failed: {e}",
+        }
     finally:
         store.close()
 

--- a/tests/test_tools_build_error_coverage.py
+++ b/tests/test_tools_build_error_coverage.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock, patch
+
+from better_code_review_graph.tools import build_or_update_graph
+
+
+def test_build_or_update_graph_full_rebuild_error():
+    """Test that build_or_update_graph handles errors during full build."""
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, MagicMock())
+
+        with patch("better_code_review_graph.tools.full_build") as mock_full_build:
+            mock_full_build.side_effect = Exception("Full build failed")
+
+            result = build_or_update_graph(full_rebuild=True)
+
+            assert result["status"] == "error"
+            assert "Graph build/update failed: Full build failed" in result["error"]
+            mock_store.close.assert_called_once()
+
+
+def test_build_or_update_graph_incremental_update_error():
+    """Test that build_or_update_graph handles errors during incremental update."""
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, MagicMock())
+
+        with patch(
+            "better_code_review_graph.tools.incremental_update"
+        ) as mock_inc_update:
+            mock_inc_update.side_effect = Exception("Incremental update failed")
+
+            result = build_or_update_graph(full_rebuild=False)
+
+            assert result["status"] == "error"
+            assert (
+                "Graph build/update failed: Incremental update failed"
+                in result["error"]
+            )
+            mock_store.close.assert_called_once()


### PR DESCRIPTION
This PR addresses the missing error handling in the `build_or_update_graph` tool. 

Previously, if `full_build` or `incremental_update` raised an exception, it would propagate up without being caught by the tool's structured response logic (though it was inside a `try...finally` block for closing the store).

Changes:
- Added an `except Exception as e:` block to `build_or_update_graph` in `src/better_code_review_graph/tools.py`.
- The handler returns a dictionary with `"status": "error"` and a descriptive message including the exception string.
- Created `tests/test_tools_build_error_coverage.py` which mocks the build functions to trigger the new error paths.
- Verified 100% coverage for the new logic and ensured no regressions in existing tests.
- Ran `ruff` for linting and formatting, and `ty` for type checking.

This ensures the MCP server remains robust and returns useful error messages to the client instead of crashing or returning unhandled exceptions.

---
*PR created automatically by Jules for task [14500130314565973971](https://jules.google.com/task/14500130314565973971) started by @n24q02m*