### PR TITLE
[SECURITY] Potential SQL Injection in Search Nodes

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -379,7 +379,7 @@ class GraphStore:
         if not words:
             return []
 
-        # Use json_each to avoid dynamic SQL construction.
+        # Use json_each and static SQL to avoid dynamic SQL construction (Bandit B608).
         # The query ensures ALL words match (AND logic).
         sql = """
             SELECT * FROM nodes
@@ -389,15 +389,16 @@ class GraphStore:
                 WHERE LOWER(nodes.name) LIKE '%' || LOWER(value) || '%'
                    OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
+            AND (? IS NULL OR kind = ?)
+            ORDER BY name LIMIT ?
         """
-        params: list[Any] = [json.dumps(words), json.dumps(words)]
-
-        if kind:
-            sql += " AND kind = ?"
-            params.append(kind)
-
-        sql += " ORDER BY name LIMIT ?"
-        params.append(limit)
+        params: list[Any] = [
+            json.dumps(words),
+            json.dumps(words),
+            kind,
+            kind,
+            limit,
+        ]
 
         rows = self._conn.execute(sql, params).fetchall()
         return [self._row_to_node(r) for r in rows]


### PR DESCRIPTION
Fixes a potential SQL injection vulnerability in the `search_nodes` method of `GraphStore`.

The previous implementation used dynamic string concatenation (`sql +=`) to build the query when the optional `kind` filter was provided. This was flagged by security scanners (Bandit B608).

The refactored implementation uses a fully static SQL literal with the `(? IS NULL OR kind = ?)` pattern to handle the optional filter safely. It also maintains the multi-word search logic using SQLite's `json_each` function.

Key changes:
- Replaced `sql +=` logic with a single static SQL statement.
- Used parameterized inputs for all variables including `kind` and `limit`.
- Verified that all existing tests pass and search functionality remains correct.

---
*PR created automatically by Jules for task [17537967909873664146](https://jules.google.com/task/17537967909873664146) started by @n24q02m*