### PR TITLE
[FIX] Overly long function: watch

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -11,8 +11,12 @@ import hashlib
 import logging
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
 
 from .graph import GraphStore
 from .parser import CodeParser
@@ -291,12 +295,9 @@ def full_build(repo_root: Path, store: GraphStore) -> dict:
         if not full_path.is_relative_to(repo_root.resolve()):
             continue
         try:
-            source = full_path.read_bytes()
-            fhash = hashlib.sha256(source).hexdigest()
-            nodes, edges = parser.parse_bytes(full_path, source)
-            store.store_file_nodes_edges(str(full_path), nodes, edges, fhash)
-            total_nodes += len(nodes)
-            total_edges += len(edges)
+            n_nodes, n_edges = _update_single_file(full_path, parser, store)
+            total_nodes += n_nodes
+            total_edges += n_edges
         except (OSError, PermissionError) as e:
             errors.append({"file": rel_path, "error": str(e)})
         except Exception as e:
@@ -383,18 +384,19 @@ def incremental_update(
             continue
 
         try:
-            source = abs_path.read_bytes()
-            fhash = hashlib.sha256(source).hexdigest()
             # Check if file actually changed (compare against stored file_hash column)
+            source_preview = abs_path.read_bytes()
+            fhash = hashlib.sha256(source_preview).hexdigest()
             existing_nodes = store.get_nodes_by_file(str(abs_path))
             if existing_nodes and existing_nodes[0].file_hash == fhash:
                 # Skip unchanged files (hash match)
                 continue
 
-            nodes, edges = parser.parse_bytes(abs_path, source)
-            store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
-            total_nodes += len(nodes)
-            total_edges += len(edges)
+            n_nodes, n_edges = _update_single_file(
+                abs_path, parser, store, source=source_preview, fhash=fhash
+            )
+            total_nodes += n_nodes
+            total_edges += n_edges
         except (OSError, PermissionError) as e:
             errors.append({"file": rel_path, "error": str(e)})
         except Exception as e:
@@ -436,119 +438,139 @@ def incremental_update_from_hook() -> None:
 _DEBOUNCE_SECONDS = 0.3
 
 
+def _update_single_file(
+    abs_path: Path,
+    parser: CodeParser,
+    store: GraphStore,
+    source: bytes | None = None,
+    fhash: str | None = None,
+) -> tuple[int, int]:
+    """Internal helper to parse and store a single file's data.
+
+    Returns (node_count, edge_count).
+    """
+    if source is None:
+        source = abs_path.read_bytes()
+    if fhash is None:
+        import hashlib
+
+        fhash = hashlib.sha256(source).hexdigest()
+    nodes, edges = parser.parse_bytes(abs_path, source)
+    store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
+    return len(nodes), len(edges)
+
+
+class GraphUpdateHandler(FileSystemEventHandler):
+    """Handles file system events for the watch mode."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        store: GraphStore,
+        parser: CodeParser,
+        ignore_patterns: list[str],
+    ):
+        self.repo_root = repo_root
+        self.store = store
+        self.parser = parser
+        self.ignore_patterns = ignore_patterns
+        self._pending: set[str] = set()
+        self._lock = threading.Lock()
+        self._timer: threading.Timer | None = None
+
+    def _should_handle(self, path: str) -> bool:
+        if Path(path).is_symlink():
+            return False
+        try:
+            rel = str(Path(path).relative_to(self.repo_root))
+        except ValueError:
+            return False
+        if _should_ignore(rel, self.ignore_patterns):
+            return False
+        if self.parser.detect_language(Path(path)) is None:
+            return False
+        return True
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        if self._should_handle(event.src_path):
+            self._schedule(event.src_path)
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        if self._should_handle(event.src_path):
+            self._schedule(event.src_path)
+
+    def on_deleted(self, event):
+        if event.is_directory:
+            return
+        # Only handle files we would normally track
+        try:
+            rel = str(Path(event.src_path).relative_to(self.repo_root))
+        except ValueError:
+            return
+        if _should_ignore(rel, self.ignore_patterns):
+            return
+        self.store.remove_file_data(event.src_path)
+        self.store.commit()
+        logger.info("Removed: %s", rel)
+
+    def _schedule(self, abs_path: str):
+        """Add file to pending set and reset the debounce timer."""
+        with self._lock:
+            self._pending.add(abs_path)
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(_DEBOUNCE_SECONDS, self._flush)
+            self._timer.start()
+
+    def _flush(self):
+        """Process all pending files after the debounce window."""
+        with self._lock:
+            paths = list(self._pending)
+            self._pending.clear()
+            self._timer = None
+
+        for abs_path in paths:
+            self._update_file(abs_path)
+
+    def _update_file(self, abs_path: str):
+        path = Path(abs_path)
+        if not path.is_file():
+            return
+        if path.is_symlink():
+            return
+        if _is_binary(path):
+            return
+        try:
+            n_nodes, n_edges = _update_single_file(path, self.parser, self.store)
+            self.store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
+            self.store.commit()
+            rel = str(path.relative_to(self.repo_root))
+            logger.info("Updated: %s (%d nodes, %d edges)", rel, n_nodes, n_edges)
+        except Exception as e:
+            logger.error("Error updating %s: %s", abs_path, e)
+
+
 def watch(repo_root: Path, store: GraphStore) -> None:
     """Watch for file changes and auto-update the graph.
 
     Uses a 300ms debounce to batch rapid-fire saves into a single update.
     """
-    import threading
-
-    from watchdog.events import FileSystemEventHandler
-    from watchdog.observers import Observer
-
     parser = CodeParser()
     ignore_patterns = _load_ignore_patterns(repo_root)
 
-    class GraphUpdateHandler(FileSystemEventHandler):
-        def __init__(self):
-            self._pending: set[str] = set()
-            self._lock = threading.Lock()
-            self._timer: threading.Timer | None = None
-
-        def _should_handle(self, path: str) -> bool:
-            if Path(path).is_symlink():
-                return False
-            try:
-                rel = str(Path(path).relative_to(repo_root))
-            except ValueError:
-                return False
-            if _should_ignore(rel, ignore_patterns):
-                return False
-            if parser.detect_language(Path(path)) is None:
-                return False
-            return True
-
-        def on_modified(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_created(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_deleted(self, event):
-            if event.is_directory:
-                return
-            # Only handle files we would normally track
-            try:
-                rel = str(Path(event.src_path).relative_to(repo_root))
-            except ValueError:
-                return
-            if _should_ignore(rel, ignore_patterns):
-                return
-            store.remove_file_data(event.src_path)
-            store.commit()
-            logger.info("Removed: %s", rel)
-
-        def _schedule(self, abs_path: str):
-            """Add file to pending set and reset the debounce timer."""
-            with self._lock:
-                self._pending.add(abs_path)
-                if self._timer is not None:
-                    self._timer.cancel()
-                self._timer = threading.Timer(_DEBOUNCE_SECONDS, self._flush)
-                self._timer.start()
-
-        def _flush(self):
-            """Process all pending files after the debounce window."""
-            with self._lock:
-                paths = list(self._pending)
-                self._pending.clear()
-                self._timer = None
-
-            for abs_path in paths:
-                self._update_file(abs_path)
-
-        def _update_file(self, abs_path: str):
-            path = Path(abs_path)
-            if not path.is_file():
-                return
-            if path.is_symlink():
-                return
-            if _is_binary(path):
-                return
-            try:
-                source = path.read_bytes()
-                fhash = hashlib.sha256(source).hexdigest()
-                nodes, edges = parser.parse_bytes(path, source)
-                store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
-                store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
-                store.commit()
-                rel = str(path.relative_to(repo_root))
-                logger.info(
-                    "Updated: %s (%d nodes, %d edges)",
-                    rel,
-                    len(nodes),
-                    len(edges),
-                )
-            except Exception as e:
-                logger.error("Error updating %s: %s", abs_path, e)
-
-    handler = GraphUpdateHandler()
+    handler = GraphUpdateHandler(repo_root, store, parser, ignore_patterns)
     observer = Observer()
     observer.schedule(handler, str(repo_root), recursive=True)
     observer.start()
 
     logger.info("Watching %s for changes... (Ctrl+C to stop)", repo_root)
     try:
-        import time as _time
-
         while True:
-            _time.sleep(1)
+            time.sleep(1)
     except KeyboardInterrupt:
         observer.stop()
     observer.join()

--- a/tests/test_incremental_extra.py
+++ b/tests/test_incremental_extra.py
@@ -413,7 +413,9 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
+        with patch(
+            "better_code_review_graph.incremental.Observer", return_value=FakeObserver()
+        ):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 
@@ -517,7 +519,9 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
+        with patch(
+            "better_code_review_graph.incremental.Observer", return_value=FakeObserver()
+        ):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 

--- a/tests/test_incremental_extra.py
+++ b/tests/test_incremental_extra.py
@@ -413,7 +413,7 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("watchdog.observers.Observer", return_value=FakeObserver()):
+        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 
@@ -517,7 +517,7 @@ class TestWatchMode:
             def join(self):
                 pass
 
-        with patch("watchdog.observers.Observer", return_value=FakeObserver()):
+        with patch("better_code_review_graph.incremental.Observer", return_value=FakeObserver()):
             with patch("time.sleep", side_effect=KeyboardInterrupt()):
                 watch(tmp_path, store)
 


### PR DESCRIPTION
The `watch` function in `src/better_code_review_graph/incremental.py` was previously an overly long monolithic function containing a nested class and local imports. This PR refactors it by:
1. Moving `threading` and `watchdog` imports to the top of the file.
2. Extracting the `GraphUpdateHandler` class to the module level.
3. Creating a `_update_single_file` helper function that encapsulates the "read-hash-parse-store" logic.
4. Updating `full_build` and `incremental_update` to use this new helper, reducing code duplication.
5. Updating `tests/test_incremental_extra.py` to correctly patch the `Observer` class now that it is imported at the module level.

These changes improve maintainability and readability without altering the functionality of the file watcher or build processes.

---
*PR created automatically by Jules for task [11021489876674454401](https://jules.google.com/task/11021489876674454401) started by @n24q02m*