### PR TITLE
[FIX] Overly long function: _extract_from_tree

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -326,319 +326,63 @@ class CodeParser:
 
         for child in root.children:
             node_type = child.type
+            processed = False
 
-            # --- Classes ---
             if node_type in class_types:
-                name = self._get_name(child, language, "class")
-                if name:
-                    node = NodeInfo(
-                        kind="Class",
-                        name=name,
-                        file_path=file_path,
-                        line_start=child.start_point[0] + 1,
-                        line_end=child.end_point[0] + 1,
-                        language=language,
-                        parent_name=enclosing_class,
-                    )
-                    nodes.append(node)
+                processed = self._handle_class_node(
+                    child,
+                    source,
+                    language,
+                    file_path,
+                    nodes,
+                    edges,
+                    enclosing_class,
+                    import_map,
+                    defined_names,
+                )
+            elif node_type in func_types:
+                processed = self._handle_function_node(
+                    child,
+                    source,
+                    language,
+                    file_path,
+                    nodes,
+                    edges,
+                    enclosing_class,
+                    import_map,
+                    defined_names,
+                )
+            elif node_type in import_types:
+                processed = self._handle_import_node(
+                    child, source, language, file_path, edges
+                )
+            elif node_type in call_types:
+                processed = self._handle_call_node(
+                    child,
+                    source,
+                    language,
+                    file_path,
+                    edges,
+                    enclosing_class,
+                    enclosing_func,
+                    import_map,
+                    defined_names,
+                )
 
-                    # CONTAINS edge
-                    edges.append(
-                        EdgeInfo(
-                            kind="CONTAINS",
-                            source=file_path,
-                            target=self._qualify(name, file_path, enclosing_class),
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                        )
-                    )
+            if not processed and language == "solidity":
+                processed = self._handle_solidity_node(
+                    child,
+                    source,
+                    language,
+                    file_path,
+                    nodes,
+                    edges,
+                    enclosing_class,
+                    enclosing_func,
+                )
 
-                    # Inheritance edges
-                    bases = self._get_bases(child, language, source)
-                    for base in bases:
-                        edges.append(
-                            EdgeInfo(
-                                kind="INHERITS",
-                                source=self._qualify(name, file_path, enclosing_class),
-                                target=base,
-                                file_path=file_path,
-                                line=child.start_point[0] + 1,
-                            )
-                        )
-
-                    # Recurse into class body
-                    self._extract_from_tree(
-                        child,
-                        source,
-                        language,
-                        file_path,
-                        nodes,
-                        edges,
-                        enclosing_class=name,
-                        enclosing_func=None,
-                        import_map=import_map,
-                        defined_names=defined_names,
-                    )
-                    continue
-
-            # --- Functions ---
-            if node_type in func_types:
-                name = self._get_name(child, language, "function")
-                if name:
-                    is_test = _is_test_function(name, file_path)
-                    kind = "Test" if is_test else "Function"
-                    qualified = self._qualify(name, file_path, enclosing_class)
-                    params = self._get_params(child, language, source)
-                    ret_type = self._get_return_type(child, language, source)
-
-                    node = NodeInfo(
-                        kind=kind,
-                        name=name,
-                        file_path=file_path,
-                        line_start=child.start_point[0] + 1,
-                        line_end=child.end_point[0] + 1,
-                        language=language,
-                        parent_name=enclosing_class,
-                        params=params,
-                        return_type=ret_type,
-                        is_test=is_test,
-                    )
-                    nodes.append(node)
-
-                    # CONTAINS edge
-                    container = (
-                        self._qualify(enclosing_class, file_path, None)
-                        if enclosing_class
-                        else file_path
-                    )
-                    edges.append(
-                        EdgeInfo(
-                            kind="CONTAINS",
-                            source=container,
-                            target=qualified,
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                        )
-                    )
-
-                    # Solidity: modifier invocations on functions → CALLS edges
-                    if language == "solidity":
-                        for sub in child.children:
-                            if sub.type == "modifier_invocation":
-                                for ident in sub.children:
-                                    if ident.type == "identifier":
-                                        edges.append(
-                                            EdgeInfo(
-                                                kind="CALLS",
-                                                source=qualified,
-                                                target=ident.text.decode(
-                                                    "utf-8",
-                                                    errors="replace",
-                                                ),
-                                                file_path=file_path,
-                                                line=sub.start_point[0] + 1,
-                                            )
-                                        )
-                                        break
-
-                    # Recurse to find calls inside the function
-                    self._extract_from_tree(
-                        child,
-                        source,
-                        language,
-                        file_path,
-                        nodes,
-                        edges,
-                        enclosing_class=enclosing_class,
-                        enclosing_func=name,
-                        import_map=import_map,
-                        defined_names=defined_names,
-                    )
-                    continue
-
-            # --- Imports ---
-            if node_type in import_types:
-                imports = self._extract_import(child, language, source)
-                for imp_target in imports:
-                    edges.append(
-                        EdgeInfo(
-                            kind="IMPORTS_FROM",
-                            source=file_path,
-                            target=imp_target,
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                        )
-                    )
+            if processed:
                 continue
-
-            # --- Calls ---
-            if node_type in call_types:
-                call_name = self._get_call_name(child, language, source)
-                if call_name and enclosing_func:
-                    caller = self._qualify(enclosing_func, file_path, enclosing_class)
-                    target = self._resolve_call_target(
-                        call_name,
-                        file_path,
-                        language,
-                        import_map or {},
-                        defined_names or set(),
-                    )
-                    edges.append(
-                        EdgeInfo(
-                            kind="CALLS",
-                            source=caller,
-                            target=target,
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                        )
-                    )
-
-            # --- Solidity-specific constructs ---
-            if language == "solidity":
-                # Emit statements: emit EventName(...) → CALLS edge
-                if node_type == "emit_statement" and enclosing_func:
-                    for sub in child.children:
-                        if sub.type == "expression":
-                            for ident in sub.children:
-                                if ident.type == "identifier":
-                                    caller = self._qualify(
-                                        enclosing_func,
-                                        file_path,
-                                        enclosing_class,
-                                    )
-                                    edges.append(
-                                        EdgeInfo(
-                                            kind="CALLS",
-                                            source=caller,
-                                            target=ident.text.decode(
-                                                "utf-8", errors="replace"
-                                            ),
-                                            file_path=file_path,
-                                            line=child.start_point[0] + 1,
-                                        )
-                                    )
-
-                # State variable declarations → Function nodes (public ones
-                # auto-generate getters, and all are critical for reviews)
-                if node_type == "state_variable_declaration" and enclosing_class:
-                    var_name = None
-                    var_visibility = None
-                    var_mutability = None
-                    var_type = None
-                    for sub in child.children:
-                        if sub.type == "identifier":
-                            var_name = sub.text.decode("utf-8", errors="replace")
-                        elif sub.type == "visibility":
-                            var_visibility = sub.text.decode("utf-8", errors="replace")
-                        elif sub.type == "type_name":
-                            var_type = sub.text.decode("utf-8", errors="replace")
-                        elif sub.type in ("constant", "immutable"):
-                            var_mutability = sub.type
-                    if var_name:
-                        qualified = self._qualify(var_name, file_path, enclosing_class)
-                        nodes.append(
-                            NodeInfo(
-                                kind="Function",
-                                name=var_name,
-                                file_path=file_path,
-                                line_start=child.start_point[0] + 1,
-                                line_end=child.end_point[0] + 1,
-                                language=language,
-                                parent_name=enclosing_class,
-                                return_type=var_type,
-                                modifiers=var_visibility,
-                                extra={
-                                    "solidity_kind": "state_variable",
-                                    "mutability": var_mutability,
-                                },
-                            )
-                        )
-                        edges.append(
-                            EdgeInfo(
-                                kind="CONTAINS",
-                                source=self._qualify(
-                                    enclosing_class,
-                                    file_path,
-                                    None,
-                                ),
-                                target=qualified,
-                                file_path=file_path,
-                                line=child.start_point[0] + 1,
-                            )
-                        )
-                        continue
-
-                # File-level and contract-level constant declarations
-                if node_type == "constant_variable_declaration":
-                    var_name = None
-                    var_type = None
-                    for sub in child.children:
-                        if sub.type == "identifier":
-                            var_name = sub.text.decode("utf-8", errors="replace")
-                        elif sub.type == "type_name":
-                            var_type = sub.text.decode("utf-8", errors="replace")
-                    if var_name:
-                        qualified = self._qualify(
-                            var_name,
-                            file_path,
-                            enclosing_class,
-                        )
-                        nodes.append(
-                            NodeInfo(
-                                kind="Function",
-                                name=var_name,
-                                file_path=file_path,
-                                line_start=child.start_point[0] + 1,
-                                line_end=child.end_point[0] + 1,
-                                language=language,
-                                parent_name=enclosing_class,
-                                return_type=var_type,
-                                extra={"solidity_kind": "constant"},
-                            )
-                        )
-                        container = (
-                            self._qualify(enclosing_class, file_path, None)
-                            if enclosing_class
-                            else file_path
-                        )
-                        edges.append(
-                            EdgeInfo(
-                                kind="CONTAINS",
-                                source=container,
-                                target=qualified,
-                                file_path=file_path,
-                                line=child.start_point[0] + 1,
-                            )
-                        )
-                        continue
-
-                # Using directives: using LibName for Type → DEPENDS_ON edge
-                if node_type == "using_directive":
-                    lib_name = None
-                    for sub in child.children:
-                        if sub.type == "type_alias":
-                            for ident in sub.children:
-                                if ident.type == "identifier":
-                                    lib_name = ident.text.decode(
-                                        "utf-8",
-                                        errors="replace",
-                                    )
-                    if lib_name:
-                        source_name = (
-                            self._qualify(enclosing_class, file_path, None)
-                            if enclosing_class
-                            else file_path
-                        )
-                        edges.append(
-                            EdgeInfo(
-                                kind="DEPENDS_ON",
-                                source=source_name,
-                                target=lib_name,
-                                file_path=file_path,
-                                line=child.start_point[0] + 1,
-                            )
-                        )
-                    continue
 
             # Recurse for other node types
             self._extract_from_tree(
@@ -653,6 +397,372 @@ class CodeParser:
                 import_map=import_map,
                 defined_names=defined_names,
             )
+
+    def _handle_class_node(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: str | None,
+        import_map: dict[str, str] | None,
+        defined_names: set[str] | None,
+    ) -> bool:
+        name = self._get_name(node, language, "class")
+        if not name:
+            return False
+
+        node_info = NodeInfo(
+            kind="Class",
+            name=name,
+            file_path=file_path,
+            line_start=node.start_point[0] + 1,
+            line_end=node.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+        )
+        nodes.append(node_info)
+
+        # CONTAINS edge
+        edges.append(
+            EdgeInfo(
+                kind="CONTAINS",
+                source=file_path,
+                target=self._qualify(name, file_path, enclosing_class),
+                file_path=file_path,
+                line=node.start_point[0] + 1,
+            )
+        )
+
+        # Inheritance edges
+        bases = self._get_bases(node, language, source)
+        for base in bases:
+            edges.append(
+                EdgeInfo(
+                    kind="INHERITS",
+                    source=self._qualify(name, file_path, enclosing_class),
+                    target=base,
+                    file_path=file_path,
+                    line=node.start_point[0] + 1,
+                )
+            )
+
+        # Recurse into class body
+        self._extract_from_tree(
+            node,
+            source,
+            language,
+            file_path,
+            nodes,
+            edges,
+            enclosing_class=name,
+            enclosing_func=None,
+            import_map=import_map,
+            defined_names=defined_names,
+        )
+        return True
+
+    def _handle_function_node(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: str | None,
+        import_map: dict[str, str] | None,
+        defined_names: set[str] | None,
+    ) -> bool:
+        name = self._get_name(node, language, "function")
+        if not name:
+            return False
+
+        is_test = _is_test_function(name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(name, file_path, enclosing_class)
+        params = self._get_params(node, language, source)
+        ret_type = self._get_return_type(node, language, source)
+
+        node_info = NodeInfo(
+            kind=kind,
+            name=name,
+            file_path=file_path,
+            line_start=node.start_point[0] + 1,
+            line_end=node.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            params=params,
+            return_type=ret_type,
+            is_test=is_test,
+        )
+        nodes.append(node_info)
+
+        # CONTAINS edge
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class
+            else file_path
+        )
+        edges.append(
+            EdgeInfo(
+                kind="CONTAINS",
+                source=container,
+                target=qualified,
+                file_path=file_path,
+                line=node.start_point[0] + 1,
+            )
+        )
+
+        # Solidity: modifier invocations on functions → CALLS edges
+        if language == "solidity":
+            for sub in node.children:
+                if sub.type == "modifier_invocation":
+                    for ident in sub.children:
+                        if ident.type == "identifier":
+                            edges.append(
+                                EdgeInfo(
+                                    kind="CALLS",
+                                    source=qualified,
+                                    target=ident.text.decode(
+                                        "utf-8",
+                                        errors="replace",
+                                    ),
+                                    file_path=file_path,
+                                    line=sub.start_point[0] + 1,
+                                )
+                            )
+                            break
+
+        # Recurse to find calls inside the function
+        self._extract_from_tree(
+            node,
+            source,
+            language,
+            file_path,
+            nodes,
+            edges,
+            enclosing_class=enclosing_class,
+            enclosing_func=name,
+            import_map=import_map,
+            defined_names=defined_names,
+        )
+        return True
+
+    def _handle_import_node(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+    ) -> bool:
+        imports = self._extract_import(node, language, source)
+        for imp_target in imports:
+            edges.append(
+                EdgeInfo(
+                    kind="IMPORTS_FROM",
+                    source=file_path,
+                    target=imp_target,
+                    file_path=file_path,
+                    line=node.start_point[0] + 1,
+                )
+            )
+        return True
+
+    def _handle_call_node(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        enclosing_class: str | None,
+        enclosing_func: str | None,
+        import_map: dict[str, str] | None,
+        defined_names: set[str] | None,
+    ) -> bool:
+        call_name = self._get_call_name(node, language, source)
+        if call_name and enclosing_func:
+            caller = self._qualify(enclosing_func, file_path, enclosing_class)
+            target = self._resolve_call_target(
+                call_name,
+                file_path,
+                language,
+                import_map or {},
+                defined_names or set(),
+            )
+            edges.append(
+                EdgeInfo(
+                    kind="CALLS",
+                    source=caller,
+                    target=target,
+                    file_path=file_path,
+                    line=node.start_point[0] + 1,
+                )
+            )
+        return False
+
+    def _handle_solidity_node(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: str | None,
+        enclosing_func: str | None,
+    ) -> bool:
+        if language != "solidity":
+            return False
+
+        node_type = node.type
+        # Emit statements: emit EventName(...) → CALLS edge
+        if node_type == "emit_statement" and enclosing_func:
+            for sub in node.children:
+                if sub.type == "expression":
+                    for ident in sub.children:
+                        if ident.type == "identifier":
+                            caller = self._qualify(
+                                enclosing_func,
+                                file_path,
+                                enclosing_class,
+                            )
+                            edges.append(
+                                EdgeInfo(
+                                    kind="CALLS",
+                                    source=caller,
+                                    target=ident.text.decode("utf-8", errors="replace"),
+                                    file_path=file_path,
+                                    line=node.start_point[0] + 1,
+                                )
+                            )
+            return False
+
+        # State variable declarations → Function nodes
+        if node_type == "state_variable_declaration" and enclosing_class:
+            var_name = None
+            var_visibility = None
+            var_mutability = None
+            var_type = None
+            for sub in node.children:
+                if sub.type == "identifier":
+                    var_name = sub.text.decode("utf-8", errors="replace")
+                elif sub.type == "visibility":
+                    var_visibility = sub.text.decode("utf-8", errors="replace")
+                elif sub.type == "type_name":
+                    var_type = sub.text.decode("utf-8", errors="replace")
+                elif sub.type in ("constant", "immutable"):
+                    var_mutability = sub.type
+            if var_name:
+                qualified = self._qualify(var_name, file_path, enclosing_class)
+                nodes.append(
+                    NodeInfo(
+                        kind="Function",
+                        name=var_name,
+                        file_path=file_path,
+                        line_start=node.start_point[0] + 1,
+                        line_end=node.end_point[0] + 1,
+                        language=language,
+                        parent_name=enclosing_class,
+                        return_type=var_type,
+                        modifiers=var_visibility,
+                        extra={
+                            "solidity_kind": "state_variable",
+                            "mutability": var_mutability,
+                        },
+                    )
+                )
+                edges.append(
+                    EdgeInfo(
+                        kind="CONTAINS",
+                        source=self._qualify(
+                            enclosing_class,
+                            file_path,
+                            None,
+                        ),
+                        target=qualified,
+                        file_path=file_path,
+                        line=node.start_point[0] + 1,
+                    )
+                )
+                return True
+
+        # File-level and contract-level constant declarations
+        if node_type == "constant_variable_declaration":
+            var_name = None
+            var_type = None
+            for sub in node.children:
+                if sub.type == "identifier":
+                    var_name = sub.text.decode("utf-8", errors="replace")
+                elif sub.type == "type_name":
+                    var_type = sub.text.decode("utf-8", errors="replace")
+            if var_name:
+                qualified = self._qualify(
+                    var_name,
+                    file_path,
+                    enclosing_class,
+                )
+                nodes.append(
+                    NodeInfo(
+                        kind="Function",
+                        name=var_name,
+                        file_path=file_path,
+                        line_start=node.start_point[0] + 1,
+                        line_end=node.end_point[0] + 1,
+                        language=language,
+                        parent_name=enclosing_class,
+                        return_type=var_type,
+                        extra={"solidity_kind": "constant"},
+                    )
+                )
+                container = (
+                    self._qualify(enclosing_class, file_path, None)
+                    if enclosing_class
+                    else file_path
+                )
+                edges.append(
+                    EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=qualified,
+                        file_path=file_path,
+                        line=node.start_point[0] + 1,
+                    )
+                )
+                return True
+
+        # Using directives: using LibName for Type → DEPENDS_ON edge
+        if node_type == "using_directive":
+            lib_name = None
+            for sub in node.children:
+                if sub.type == "type_alias":
+                    for ident in sub.children:
+                        if ident.type == "identifier":
+                            lib_name = ident.text.decode(
+                                "utf-8",
+                                errors="replace",
+                            )
+            if lib_name:
+                source_name = (
+                    self._qualify(enclosing_class, file_path, None)
+                    if enclosing_class
+                    else file_path
+                )
+                edges.append(
+                    EdgeInfo(
+                        kind="DEPENDS_ON",
+                        source=source_name,
+                        target=lib_name,
+                        file_path=file_path,
+                        line=node.start_point[0] + 1,
+                    )
+                )
+                return True
+        return False
 
     def _collect_file_scope(
         self,


### PR DESCRIPTION
The `_extract_from_tree` method in `src/better_code_review_graph/parser.py` was overly long and complex, handling multiple language constructs and Solidity-specific logic in a single loop.

This PR refactors it by:
1. Extracting class handling into `_handle_class_node`.
2. Extracting function and test handling into `_handle_function_node`.
3. Extracting import handling into `_handle_import_node`.
4. Extracting call handling into `_handle_call_node`.
5. Extracting Solidity-specific constructs (emit, state variables, constants, using directives) into `_handle_solidity_node`.

The main loop now uses these handlers, significantly improving readability and maintainability while preserving all existing functionality and recursion logic. Verification tests (110 passed) confirm no regressions.

---
*PR created automatically by Jules for task [3208555834887420321](https://jules.google.com/task/3208555834887420321) started by @n24q02m*