### PR TITLE
fix: batch file queries with get_nodes_by_files to eliminate N+1

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -693,9 +693,7 @@ def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) ->
         return 0
 
     all_files = graph_store.get_all_files()
-    all_nodes: list[GraphNode] = []
-    for f in all_files:
-        all_nodes.extend(graph_store.get_nodes_by_file(f))
+    all_nodes = graph_store.get_nodes_by_files(all_files)
 
     return embedding_store.embed_nodes(all_nodes)
 

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -282,6 +282,31 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
+    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+        """Batch fetch nodes by their file paths to prevent N+1 queries.
+
+        Deduplicates input file paths, fetches in batches to respect SQLite
+        parameter limits, and returns all matching nodes. Uses the same
+        json_each(?) idiom as get_nodes_by_qualified_names to keep SQL static
+        and satisfy Bandit B608.
+        """
+        if not file_paths:
+            return []
+
+        unique_files = list(set(file_paths))
+        results: list[GraphNode] = []
+        batch_size = 450  # Stay well under SQLite's default limit
+
+        for i in range(0, len(unique_files), batch_size):
+            batch = unique_files[i : i + batch_size]
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
+                (json.dumps(batch),),
+            ).fetchall()
+            results.extend(self._row_to_node(r) for r in rows)
+
+        return results
+
     def get_nodes_by_qualified_names(
         self, qualified_names: list[str]
     ) -> list[GraphNode]:
@@ -419,12 +444,8 @@ class GraphStore:
         """
         nxg = self._build_networkx_graph()
 
-        # Seed: all qualified names in changed files
-        seeds = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
-            for n in nodes:
-                seeds.add(n.qualified_name)
+        # Seed: all qualified names in changed files (batched to avoid N+1)
+        seeds = {n.qualified_name for n in self.get_nodes_by_files(changed_files)}
 
         # BFS outward through all edge types
         visited: set[str] = set()


### PR DESCRIPTION
## Summary

- Supersedes #267 (Bolt branch diverged from main — would re-apply reverts to line_start nullability, CloudEmbeddingBackend retry handling, and removed a B608 security audit comment).
- Cherry-picks the valuable N+1 fix: new `get_nodes_by_files` method using the same `json_each(?)` idiom as `get_nodes_by_qualified_names`, used in `get_impact_radius` and `embed_all_nodes`.

## Test plan

- [x] Pre-commit hooks pass (ruff + format + ty + pytest + gitleaks)
- [ ] CI green on all three OS matrices

Closes #267.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>