### PR TITLE
feat: merge setup tool into config with setup_* sub-actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 ## Cau truc
 
 - `src/better_code_review_graph/` -- Package chinh (src layout)
-  - `server.py` -- FastMCP server, 6 tools: graph + query + review (3 main) + config + setup + help
+  - `server.py` -- FastMCP server, 5 tools: graph + query + review (3 main) + config (incl. setup_*) + help
   - `tools.py` -- MCP tool implementations (build, query, impact, review, search, embed, stats, docs, large functions)
   - `parser.py` -- Tree-sitter parsing (13 langs) + call target resolution
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
@@ -53,7 +53,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 6 tools (graph + query + review + config + setup + help)
+                                     FastMCP server --> 5 tools (graph + query + review + config + help)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -61,7 +61,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud multi-provider (Jina > Gemini > OpenAI > Cohere, auto-detected from env vars). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 6 tools — graph (build/update/stats/embed), query (query/search/impact/large_functions), review, config, setup (credential relay), help. Returns JSON strings.
+- **Server** (server.py): 5 tools — graph (build/update/stats/embed), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), help. Returns JSON strings.
 
 ## Embedding backends
 

--- a/src/better_code_review_graph/docs/config.md
+++ b/src/better_code_review_graph/docs/config.md
@@ -1,8 +1,8 @@
 # config Tool Documentation
 
-Server configuration, status, and cache management.
+Server configuration, status, cache management, and credential setup.
 
-## Actions
+## Config Actions
 
 ### status
 Show current server status including graph path, node/edge counts, embedding backend, and last update time.
@@ -67,4 +67,59 @@ Remove all computed embeddings from the graph database. After clearing, run `gra
   "status": "cache cleared",
   "embeddings_removed": 890
 }
+```
+
+---
+
+## Setup Actions
+
+### setup_status
+Show current credential state and relay setup URL (if any).
+
+**Example:**
+```json
+{"action": "setup_status"}
+```
+
+---
+
+### setup_start
+Start relay setup session to configure API keys via browser.
+
+**Parameters:**
+- `force`: If true, reconfigure even when already configured (default: false)
+
+**Example:**
+```json
+{"action": "setup_start"}
+```
+
+---
+
+### setup_skip
+Set local mode permanently — relay will not trigger on next restart.
+
+**Example:**
+```json
+{"action": "setup_skip"}
+```
+
+---
+
+### setup_reset
+Clear saved credentials and reset to awaiting_setup state.
+
+**Example:**
+```json
+{"action": "setup_reset"}
+```
+
+---
+
+### setup_complete
+Re-resolve credentials from current environment variables (picks up manually set API keys).
+
+**Example:**
+```json
+{"action": "setup_complete"}
 ```

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -1,6 +1,6 @@
 """MCP server entry point for Better Code Review Graph.
 
-5-tool architecture: graph + query + review (3 main) + config + setup + help.
+5-tool architecture: graph + query + review (3 main) + config + help.
 Run as: better-code-review-graph serve
 """
 
@@ -56,9 +56,9 @@ mcp = FastMCP(
     "better-code-review-graph",
     instructions=(
         "Persistent incremental knowledge graph for token-efficient, "
-        "context-aware code reviews. 6 tools: graph (build/embed/stats), "
+        "context-aware code reviews. 5 tools: graph (build/embed/stats), "
         "query (search/impact/patterns), review (code review context), "
-        "config (status/set), setup (relay/credentials), help (full docs)."
+        "config (status/set/setup_*), help (full docs)."
     ),
 )
 
@@ -298,15 +298,18 @@ def review(
 
 
 # ---------------------------------------------------------------------------
-# Tool 4: config (status, set, cache_clear)
+# Tool 4: config (status, set, cache_clear, setup_*)
 # ---------------------------------------------------------------------------
 
 
 @mcp.tool(
     description=(
-        "Server configuration and status. "
+        "Server configuration, status, and credential setup. "
         "Actions: status (show state), set (key, value -- keys: log_level), "
-        "cache_clear (wipe embeddings). "
+        "cache_clear (wipe embeddings), "
+        "setup_status (credential state), setup_start (relay browser setup), "
+        "setup_skip (local mode), setup_reset (clear credentials), "
+        "setup_complete (re-resolve from env). "
         "Use `help` tool for full docs."
     ),
     annotations=ToolAnnotations(
@@ -314,20 +317,29 @@ def review(
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=False,
+        openWorldHint=True,
     ),
 )
-def config(
+async def config(
     action: str,
     key: str | None = None,
     value: str | None = None,
     repo_root: str | None = None,
+    force: bool = False,
 ) -> str:
-    """Server configuration and status.
+    """Server configuration, status, and credential setup.
 
+    Config actions:
     - status: Show graph path, node/edge counts, embedding backend, last updated
     - set: Update runtime setting (key + value). Keys: log_level
     - cache_clear: Wipe all embeddings from the graph
+
+    Setup actions:
+    - setup_status: Show current credential state and setup URL
+    - setup_start: Start relay setup to configure API keys via browser
+    - setup_skip: Set local mode (skip relay permanently)
+    - setup_reset: Clear credentials and reset to awaiting_setup
+    - setup_complete: Re-resolve credentials from env vars
     """
     match action:
         case "status":
@@ -345,10 +357,101 @@ def config(
             return _config_set(key, value)
         case "cache_clear":
             return _config_cache_clear(repo_root)
+        case "setup_status":
+            from . import credential_state as _cs
+
+            state = _cs.get_state()
+            return _json(
+                {
+                    "state": state.value,
+                    "setup_url": _cs.get_setup_url(),
+                    "cloud_keys_in_env": [
+                        k for k in _cs.CLOUD_KEYS if os.environ.get(k)
+                    ],
+                }
+            )
+        case "setup_start":
+            from .credential_state import (
+                CredentialState,
+                get_state,
+                trigger_relay_setup,
+            )
+
+            if get_state() == CredentialState.CONFIGURED and not force:
+                return _json(
+                    {
+                        "status": "already_configured",
+                        "message": "Already configured. Use force=true to reconfigure.",
+                    }
+                )
+            url = await trigger_relay_setup(force=True)
+            if url:
+                return _json(
+                    {
+                        "status": "setup_started",
+                        "setup_url": url,
+                        "message": "Open this URL to configure API keys.",
+                    }
+                )
+            return _json(
+                {
+                    "status": "error",
+                    "message": "Failed to start relay session.",
+                }
+            )
+        case "setup_skip":
+            from mcp_core import set_local_mode
+
+            from .credential_state import CredentialState, set_state
+
+            set_local_mode(SERVER_NAME)
+            set_state(CredentialState.LOCAL)
+            return _json(
+                {
+                    "status": "ok",
+                    "message": "Local mode set. Relay will not trigger on restart.",
+                }
+            )
+        case "setup_reset":
+            from .credential_state import reset_state
+
+            reset_state()
+            return _json(
+                {
+                    "status": "ok",
+                    "message": "Credentials cleared. Next tool call will offer setup.",
+                }
+            )
+        case "setup_complete":
+            from .credential_state import (
+                get_state as _get_state,
+            )
+            from .credential_state import (
+                resolve_credential_state,
+            )
+
+            resolve_credential_state()
+            state = _get_state()
+            return _json(
+                {
+                    "status": "ok",
+                    "state": state.value,
+                    "message": "Credential state refreshed.",
+                }
+            )
         case _:
             import difflib
 
-            valid_actions = ["cache_clear", "set", "status"]
+            valid_actions = [
+                "cache_clear",
+                "set",
+                "setup_complete",
+                "setup_reset",
+                "setup_skip",
+                "setup_start",
+                "setup_status",
+                "status",
+            ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
             return _json(
@@ -469,151 +572,7 @@ def _config_cache_clear(repo_root: str | None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Tool 5: setup (credential relay management)
-# ---------------------------------------------------------------------------
-
-
-@mcp.tool(
-    description=(
-        "Credential setup and relay management. Actions: "
-        "status|start|skip|reset|complete. "
-        "status: Show current credential state. "
-        "start: Start relay setup to configure API keys via browser. "
-        "skip: Set local mode (skip relay permanently). "
-        "reset: Clear credentials and reset state. "
-        "complete: Re-resolve credentials from env vars."
-    ),
-    annotations=ToolAnnotations(
-        title="Setup",
-        readOnlyHint=False,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=True,
-    ),
-)
-async def setup(
-    action: str,
-    force: bool = False,
-) -> str:
-    """Credential setup and relay management.
-
-    Actions:
-    - status: Show current credential state and setup URL
-    - start: Start relay setup to configure API keys via browser
-    - skip: Set local mode (skip relay permanently)
-    - reset: Clear credentials and reset to awaiting_setup
-    - complete: Re-resolve credentials from env vars (pick up manually set keys)
-    """
-    match action:
-        case "status":
-            from . import credential_state as _cs
-
-            state = _cs.get_state()
-            return _json(
-                {
-                    "state": state.value,
-                    "setup_url": _cs.get_setup_url(),
-                    "cloud_keys_in_env": [
-                        k for k in _cs.CLOUD_KEYS if os.environ.get(k)
-                    ],
-                }
-            )
-
-        case "start":
-            from .credential_state import (
-                CredentialState,
-                get_state,
-                trigger_relay_setup,
-            )
-
-            if get_state() == CredentialState.CONFIGURED and not force:
-                return _json(
-                    {
-                        "status": "already_configured",
-                        "message": "Already configured. Use force=true to reconfigure.",
-                    }
-                )
-            url = await trigger_relay_setup(force=True)
-            if url:
-                return _json(
-                    {
-                        "status": "setup_started",
-                        "setup_url": url,
-                        "message": "Open this URL to configure API keys.",
-                    }
-                )
-            return _json(
-                {
-                    "status": "error",
-                    "message": "Failed to start relay session.",
-                }
-            )
-
-        case "skip":
-            from mcp_core import set_local_mode
-
-            from .credential_state import CredentialState, set_state
-
-            set_local_mode(SERVER_NAME)
-            set_state(CredentialState.LOCAL)
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Local mode set. Relay will not trigger on restart.",
-                }
-            )
-
-        case "reset":
-            from .credential_state import reset_state
-
-            reset_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Credentials cleared. Next tool call will offer setup.",
-                }
-            )
-
-        case "complete":
-            from .credential_state import (
-                get_state as _get_state,
-            )
-            from .credential_state import (
-                resolve_credential_state,
-            )
-
-            resolve_credential_state()
-            state = _get_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "state": state.value,
-                    "message": "Credential state refreshed.",
-                }
-            )
-
-        case _:
-            import difflib
-
-            valid_actions = [
-                "complete",
-                "reset",
-                "skip",
-                "start",
-                "status",
-            ]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
-
-
-# ---------------------------------------------------------------------------
-# Tool 6: help (documentation)
+# Tool 5: help (documentation)
 # ---------------------------------------------------------------------------
 
 
@@ -678,7 +637,7 @@ def help(topic: str = "graph") -> str:
 
 
 # ---------------------------------------------------------------------------
-# Constants (used by setup tool)
+# Constants
 # ---------------------------------------------------------------------------
 
 SERVER_NAME = "better-code-review-graph"

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -328,13 +328,13 @@ class TestIsRetryable:
 
 
 class TestConfigStatusVersionFallback:
-    def test_version_dev_fallback(self):
+    async def test_version_dev_fallback(self):
         """Cover lines 350-351: version = 'dev' when package not installed."""
         from better_code_review_graph.server import config
 
         with patch("better_code_review_graph.server._config_status") as mock_status:
             mock_status.return_value = json.dumps({"status": "ok", "version": "dev"})
-            result = json.loads(config(action="status"))
+            result = json.loads(await config(action="status"))
             assert result["version"] == "dev"
 
     def test_version_fallback_direct(self):
@@ -665,13 +665,13 @@ class TestIncrementalNonParseableFile:
 
 
 class TestConfigCacheClearFallback:
-    def test_cache_clear_runtime_error(self):
+    async def test_cache_clear_runtime_error(self):
         """Cover lines 447-448: cache_clear handles RuntimeError."""
         from better_code_review_graph.server import config
 
         # Use a nonexistent path that will trigger RuntimeError
         result = json.loads(
-            config(action="cache_clear", repo_root="/nonexistent/path/xyz")
+            await config(action="cache_clear", repo_root="/nonexistent/path/xyz")
         )
         assert result["status"] == "cache cleared"
         assert result["embeddings_removed"] == 0
@@ -683,11 +683,13 @@ class TestConfigCacheClearFallback:
 
 
 class TestConfigStatusFallback:
-    def test_status_runtime_error(self):
+    async def test_status_runtime_error(self):
         """Cover lines 381-382: _config_status handles RuntimeError."""
         from better_code_review_graph.server import config
 
-        result = json.loads(config(action="status", repo_root="/nonexistent/path/xyz"))
+        result = json.loads(
+            await config(action="status", repo_root="/nonexistent/path/xyz")
+        )
         # Should return ok with 0 nodes (no graph found)
         assert result["status"] == "ok"
         assert result.get("total_nodes", 0) == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from better_code_review_graph.server import (
     config,
@@ -34,7 +34,7 @@ class TestMCPServerSetup:
             assert "knowledge graph" in instructions.lower()
 
     def test_five_tools_registered(self):
-        """Server should expose 5 tools: graph, query, review, config, help."""
+        """Server should expose exactly 5 tools: graph, query, review, config, help."""
         tool_names = set()
         manager = getattr(mcp, "_tool_manager", None)
         if manager:
@@ -43,6 +43,7 @@ class TestMCPServerSetup:
         if not tool_names:
             tool_names = {"graph", "query", "review", "config", "help"}
         assert {"graph", "query", "review", "config", "help"}.issubset(tool_names)
+        assert "setup" not in tool_names
 
 
 # ---------------------------------------------------------------------------
@@ -274,75 +275,97 @@ def _make_mini_repo(tmp_path):
 
 
 class TestConfigTool:
-    def test_unknown_action(self):
-        result = json.loads(config(action="nonexistent"))
+    async def test_unknown_action(self):
+        result = json.loads(await config(action="nonexistent"))
         assert "error" in result
         assert "valid_actions" in result
 
-    def test_set_missing_key(self):
-        result = json.loads(config(action="set"))
+    async def test_set_missing_key(self):
+        result = json.loads(await config(action="set"))
         assert result["error"] == "key is required for set action"
         assert result["valid_keys"] == ["log_level"]
         assert "error" in result
 
-    def test_set_missing_value(self):
-        result = json.loads(config(action="set", key="log_level"))
+    async def test_set_missing_value(self):
+        result = json.loads(await config(action="set", key="log_level"))
         assert result["error"] == "value is required for set action"
         assert "error" in result
 
-    def test_set_invalid_key(self):
-        result = json.loads(config(action="set", key="invalid_key", value="x"))
+    async def test_set_invalid_key(self):
+        result = json.loads(await config(action="set", key="invalid_key", value="x"))
         assert "error" in result
         assert "valid_keys" in result
 
-    def test_set_log_level(self):
-        result = json.loads(config(action="set", key="log_level", value="DEBUG"))
+    async def test_set_log_level(self):
+        result = json.loads(await config(action="set", key="log_level", value="DEBUG"))
         assert result["status"] == "updated"
         assert result["value"] == "DEBUG"
 
-    def test_set_invalid_log_level(self):
-        result = json.loads(config(action="set", key="log_level", value="INVALID"))
+    async def test_set_invalid_log_level(self):
+        result = json.loads(
+            await config(action="set", key="log_level", value="INVALID")
+        )
         assert "error" in result
 
-    def test_status_no_graph(self):
-        result = json.loads(config(action="status"))
+    async def test_status_no_graph(self):
+        result = json.loads(await config(action="status"))
         assert result["status"] == "ok"
         assert "version" in result
 
-    def test_status_with_repo(self, tmp_path):
+    async def test_status_with_repo(self, tmp_path):
         repo = _make_mini_repo(tmp_path)
-        result = json.loads(config(action="status", repo_root=str(repo)))
+        result = json.loads(await config(action="status", repo_root=str(repo)))
         assert result["status"] == "ok"
         assert result["total_nodes"] > 0
         assert "embedding_backend" in result
 
-    def test_status_error_handling(self):
+    async def test_status_error_handling(self):
         with patch(
             "better_code_review_graph.tools._get_store",
             side_effect=ValueError("No graph found"),
         ):
-            result = json.loads(config(action="status"))
+            result = json.loads(await config(action="status"))
             assert result["status"] == "ok"
             assert result["graph_path"] is None
             assert "No graph found" in result["message"]
 
-    def test_cache_clear_no_graph(self):
-        result = json.loads(config(action="cache_clear"))
+    async def test_cache_clear_no_graph(self):
+        result = json.loads(await config(action="cache_clear"))
         assert result["status"] == "cache cleared"
 
-    def test_cache_clear_error_handling(self):
+    async def test_cache_clear_error_handling(self):
         with patch(
             "better_code_review_graph.tools._get_store",
             side_effect=ValueError("No repo found"),
         ):
-            result = json.loads(config(action="cache_clear"))
+            result = json.loads(await config(action="cache_clear"))
             assert result["status"] == "cache cleared"
             assert result["embeddings_removed"] == 0
 
-    def test_cache_clear_with_repo(self, tmp_path):
+    async def test_cache_clear_with_repo(self, tmp_path):
         repo = _make_mini_repo(tmp_path)
-        result = json.loads(config(action="cache_clear", repo_root=str(repo)))
+        result = json.loads(await config(action="cache_clear", repo_root=str(repo)))
         assert result["status"] == "cache cleared"
+
+    async def test_setup_status_action(self):
+        """config setup_status dispatches to credential state status."""
+        result = json.loads(await config(action="setup_status"))
+        assert "unknown action" not in str(result).lower()
+        assert "state" in result
+
+    async def test_setup_start_action(self):
+        """config setup_start dispatches to relay trigger."""
+        from better_code_review_graph import credential_state as cs
+
+        cs._state = cs.CredentialState.AWAITING_SETUP
+        with patch(
+            "better_code_review_graph.credential_state.trigger_relay_setup",
+            new_callable=AsyncMock,
+            return_value="https://relay.example.com/test",
+        ):
+            result = json.loads(await config(action="setup_start"))
+            assert "unknown action" not in str(result).lower()
+            assert result.get("status") == "setup_started"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -1,7 +1,7 @@
-"""Tests for the server setup tool (server.py lines 494-612).
+"""Tests for setup_* sub-actions of the config tool (server.py).
 
-Covers: setup(action=status|start|skip|reset|complete), unknown action,
-and _maybe_include_setup_hint helper.
+Covers: config(action=setup_status|setup_start|setup_skip|setup_reset|setup_complete),
+unknown action variants, and _maybe_include_setup_hint helper.
 """
 
 from __future__ import annotations
@@ -40,8 +40,6 @@ class TestMaybeIncludeSetupHint:
 
     def _real_hint_fn(self):
         """Import the real function from server module source."""
-        # The conftest patches server._maybe_include_setup_hint at the module level.
-        # We re-import the original implementation directly to test it.
         from better_code_review_graph.credential_state import (
             CredentialState as _CS,
         )
@@ -101,57 +99,57 @@ class TestMaybeIncludeSetupHint:
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- status action
+# config setup_status action
 # ---------------------------------------------------------------------------
 
 
 class TestSetupStatus:
     async def test_status_returns_state_info(self):
-        """Status returns current state and cloud keys in env."""
+        """setup_status returns current state and cloud keys in env."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.CONFIGURED
         cs._setup_url = None
 
-        result = json.loads(await setup(action="status"))
+        result = json.loads(await config(action="setup_status"))
         assert result["state"] == "configured"
         assert "cloud_keys_in_env" in result
 
     async def test_status_with_setup_url(self):
-        """Status includes setup_url when set."""
+        """setup_status includes setup_url when set."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.SETUP_IN_PROGRESS
         cs._setup_url = "https://relay.example.com/setup"
 
-        result = json.loads(await setup(action="status"))
+        result = json.loads(await config(action="setup_status"))
         assert result["state"] == "setup_in_progress"
         assert result["setup_url"] == "https://relay.example.com/setup"
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- start action
+# config setup_start action
 # ---------------------------------------------------------------------------
 
 
 class TestSetupStart:
     async def test_start_already_configured_no_force(self):
-        """Start with already configured state and no force returns already_configured."""
+        """setup_start with already configured state and no force returns already_configured."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.CONFIGURED
 
-        result = json.loads(await setup(action="start"))
+        result = json.loads(await config(action="setup_start"))
         assert result["status"] == "already_configured"
         assert "force=true" in result["message"]
 
     async def test_start_triggers_relay_setup(self):
-        """Start triggers relay and returns URL."""
+        """setup_start triggers relay and returns URL."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.AWAITING_SETUP
 
@@ -160,14 +158,14 @@ class TestSetupStart:
             new_callable=AsyncMock,
             return_value="https://relay.example.com/setup#k=abc",
         ):
-            result = json.loads(await setup(action="start"))
+            result = json.loads(await config(action="setup_start"))
             assert result["status"] == "setup_started"
             assert result["setup_url"] == "https://relay.example.com/setup#k=abc"
 
     async def test_start_relay_failure(self):
-        """Start returns error when relay fails."""
+        """setup_start returns error when relay fails."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.AWAITING_SETUP
 
@@ -176,14 +174,14 @@ class TestSetupStart:
             new_callable=AsyncMock,
             return_value=None,
         ):
-            result = json.loads(await setup(action="start"))
+            result = json.loads(await config(action="setup_start"))
             assert result["status"] == "error"
             assert "Failed" in result["message"]
 
     async def test_start_force_overrides_configured(self):
-        """Start with force=true reconfigures even when CONFIGURED."""
+        """setup_start with force=true reconfigures even when CONFIGURED."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.CONFIGURED
 
@@ -192,37 +190,37 @@ class TestSetupStart:
             new_callable=AsyncMock,
             return_value="https://relay.example.com/new-session",
         ):
-            result = json.loads(await setup(action="start", force=True))
+            result = json.loads(await config(action="setup_start", force=True))
             assert result["status"] == "setup_started"
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- skip action
+# config setup_skip action
 # ---------------------------------------------------------------------------
 
 
 class TestSetupSkip:
     async def test_skip_sets_local_mode(self):
-        """Skip sets LOCAL mode and calls set_local_mode."""
-        from better_code_review_graph.server import setup
+        """setup_skip sets LOCAL mode and calls set_local_mode."""
+        from better_code_review_graph.server import config
 
         with patch("mcp_core.set_local_mode") as mock_local:
-            result = json.loads(await setup(action="skip"))
+            result = json.loads(await config(action="setup_skip"))
             assert result["status"] == "ok"
             assert "Local mode" in result["message"]
             mock_local.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- reset action
+# config setup_reset action
 # ---------------------------------------------------------------------------
 
 
 class TestSetupReset:
     async def test_reset_clears_state(self):
-        """Reset clears credentials and resets state."""
+        """setup_reset clears credentials and resets state."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.CONFIGURED
 
@@ -230,48 +228,48 @@ class TestSetupReset:
             patch("mcp_core.clear_mode"),
             patch("mcp_core.storage.config_file.delete_config"),
         ):
-            result = json.loads(await setup(action="reset"))
+            result = json.loads(await config(action="setup_reset"))
             assert result["status"] == "ok"
             assert cs._state == CredentialState.AWAITING_SETUP
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- complete action
+# config setup_complete action
 # ---------------------------------------------------------------------------
 
 
 class TestSetupComplete:
     async def test_complete_refreshes_state(self, monkeypatch):
-        """Complete re-resolves credential state."""
+        """setup_complete re-resolves credential state."""
         from better_code_review_graph import credential_state as cs
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
         cs._state = CredentialState.AWAITING_SETUP
         monkeypatch.setenv("GEMINI_API_KEY", "test-key")
 
-        result = json.loads(await setup(action="complete"))
+        result = json.loads(await config(action="setup_complete"))
         assert result["status"] == "ok"
         assert result["state"] == "configured"
 
 
 # ---------------------------------------------------------------------------
-# setup tool -- unknown action
+# config setup_* unknown action (via config unknown action path)
 # ---------------------------------------------------------------------------
 
 
 class TestSetupUnknownAction:
     async def test_unknown_action_returns_error(self):
         """Unknown action returns error with valid actions."""
-        from better_code_review_graph.server import setup
+        from better_code_review_graph.server import config
 
-        result = json.loads(await setup(action="nonexistent"))
+        result = json.loads(await config(action="nonexistent_setup_action"))
         assert "error" in result
         assert "valid_actions" in result
 
-    async def test_close_match_suggestion(self):
-        """Typo in action returns a suggestion."""
-        from better_code_review_graph.server import setup
+    async def test_setup_prefix_typo_suggestion(self):
+        """Typo in setup_ action returns a suggestion."""
+        from better_code_review_graph.server import config
 
-        result = json.loads(await setup(action="statu"))
+        result = json.loads(await config(action="setup_statu"))
         assert "error" in result
-        assert "status" in result["error"]
+        assert "setup_status" in result["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.9.0"
+version = "3.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -113,7 +113,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.1.1" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.2.0" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
Unify auxiliary tools to match 7-MCP matrix: each server exposes exactly `help` + `config`. Previously crg had both `config` + `setup` tools — merged into single `config` with setup_* prefixed actions.

Actions in unified config tool:
- Runtime: status, set, cache_clear
- Setup flow: setup_status, setup_start, setup_reset, setup_complete

Commit: 6108f14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)