### PR TITLE
fix: bump mcp-core to 1.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openai>=2.32.0",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core>=1.7.4",
+    "n24q02m-mcp-core>=1.7.6",
     "Pygments>=2.20.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.7.4" },
+    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic-settings" },
@@ -879,8 +879,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
+version = "1.7.5"
+source = { directory = "../mcp-core/packages/core-py" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -892,9 +892,28 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/8c/e6af9e56c2974fd40ad1693741b78f28e5e4bb9e73ebb7d946624c0ce532/n24q02m_mcp_core-1.7.4.tar.gz", hash = "sha256:dd90c8b8aba5beb2874ff27bd546224dc9ac15d5e35f8e48b26ee5ab14ceb4f2", size = 157747, upload-time = "2026-04-24T04:07:29.108Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/e7/b07e4316b98fb23e6b630b9c932e911c1b9130bb9e5ac546a0a6ce2037ca/n24q02m_mcp_core-1.7.4-py3-none-any.whl", hash = "sha256:a3c792de2e7bbdd3f999f66765a27182ca8eace5cbbe942b17d6370d2f09b681", size = 97978, upload-time = "2026-04-24T04:07:30.363Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
+    { name = "pydantic", specifier = ">=2.9,<2.13" },
+    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
+    { name = "ty", specifier = ">=0.0.32" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #361. Pulls mcp-core v1.7.6.