### PR TITLE
fix(deps): bump mcp-core to 1.10.0 — Transparent Bridge waves 1-3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openai>=2.32.0",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core>=1.9.0",
+    "n24q02m-mcp-core>=1.10.0",
     "Pygments>=2.20.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.10.0" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic-settings" },
@@ -879,8 +879,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.9.0"
-source = { directory = "../mcp-core/packages/core-py" }
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -892,28 +892,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.9,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.32" },
+sdist = { url = "https://files.pythonhosted.org/packages/bf/76/7db8d34e2b0e452d16cd2275f540d0538d4e5f4140c88ebf0c9d97361f50/n24q02m_mcp_core-1.10.0.tar.gz", hash = "sha256:761f2545d252927d1090bf8222dba566f3789ee4f38e172c2c128ebdd7881f30", size = 177223, upload-time = "2026-04-28T15:24:02.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/f9/b0d79f041ae9af5ffbea4250a29c72f6bf90a8ad1a40ea342af114cbc7dd/n24q02m_mcp_core-1.10.0-py3-none-any.whl", hash = "sha256:8965068bf98597181f3f8944d00d2295b17eceafa1f500fee325a0c5bfd08688", size = 107410, upload-time = "2026-04-28T15:24:00.297Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump mcp-core to v1.10.0, picking up:
- Wave 1: schema-completeness gate + `_setup_complete` flag
- Wave 2: 4-line lock format + sweepStaleLocks + hourly mtime refresh
- Wave 3: fast-handshake stdio-proxy with capabilities cache (Python only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)