### PR TITLE
feat: route stdio mode to FastMCP/MCP SDK direct + multi-target Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 # syntax=docker/dockerfile:1
+# Multi-target Dockerfile per spec
+# `~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md`
+# section D6. Build stdio: `docker buildx build --target stdio -t <repo>:stdio .`
+# Build http:  `docker buildx build --target http  -t <repo>:http .`
+# Build latest (= http): `docker buildx build --target http -t <repo>:latest .`
+
+# ========================
+# Stage 1: Builder
+# ========================
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
@@ -6,7 +15,10 @@ COPY src/ src/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
-FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33
+# ========================
+# Stage 2: Runtime base (shared by stdio + http targets)
+# ========================
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 LABEL io.modelcontextprotocol.server.name="io.github.n24q02m/better-code-review-graph"
 RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
 WORKDIR /app
@@ -19,4 +31,19 @@ ENV PATH="/app/.venv/bin:$PATH"
 # JWT issuer crashes at first authorize with FileNotFoundError.
 RUN chown -R appuser:appuser /app
 USER appuser
+
+# ========================
+# Stage 3a: stdio target (default for plugin marketplace & uvx-style usage)
+# ========================
+FROM runtime AS stdio
+ENV MCP_TRANSPORT=stdio
+ENTRYPOINT ["python", "-m", "better_code_review_graph"]
+
+# ========================
+# Stage 3b: http target (multi-user remote daemon)
+# ========================
+FROM runtime AS http
+ENV MCP_TRANSPORT=http \
+    MCP_PORT=8080
+EXPOSE 8080
 ENTRYPOINT ["better-code-review-graph", "serve"]

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -727,18 +727,20 @@ def serve_main(repo_root: str | None = None) -> None:
     global _default_repo_root
     _default_repo_root = repo_root
 
-    # Non-blocking credential resolution (fast, <10ms)
+    if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
+        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
+        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
+        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
+        mcp.run(transport="stdio")
+        return
+
+    # HTTP / local-relay path: resolve credentials so the relay form can hint
+    # current state. Stdio mode resolves lazily inside tool calls.
     from .credential_state import resolve_credential_state
 
     resolve_credential_state()
 
-    if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
-        from mcp_core.transport import run_smart_stdio_proxy
-
-        daemon_cmd = [sys.executable, "-m", "better_code_review_graph"]
-        sys.exit(run_smart_stdio_proxy("better-code-review-graph", daemon_cmd))
-    else:
-        asyncio.run(run_http())
+    asyncio.run(run_http())
 
 
 if __name__ == "__main__":

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -372,23 +372,18 @@ class TestEnsureConfigRelayNotifyFailure:
 
 
 class TestCLIIntegration:
-    def test_main_calls_resolve_credential_state(self):
-        """serve_main calls resolve_credential_state (not old ensure_config)."""
+    def test_main_runs_stdio_directly(self):
+        """serve_main(stdio) invokes FastMCP stdio directly (no bridge layer)."""
+        from better_code_review_graph import server as server_module
+
         with (
-            patch(
-                "better_code_review_graph.credential_state.resolve_credential_state",
-            ) as mock_resolve,
-            patch(
-                "mcp_core.transport.run_smart_stdio_proxy", return_value=0
-            ) as mock_proxy,
+            patch.object(server_module.mcp, "run") as mock_run,
             patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-            pytest.raises(SystemExit, match="0"),
         ):
             from better_code_review_graph.cli import main
 
             main()
-            mock_resolve.assert_called_once()
-            mock_proxy.assert_called_once()
+            mock_run.assert_called_once_with(transport="stdio")
 
     def test_main_continues_on_relay_error(self):
         with (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,8 +7,6 @@ import os
 import subprocess
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from better_code_review_graph.server import (
     config,
     graph,
@@ -429,22 +427,22 @@ class TestHelpTool:
 
 
 class TestServeMain:
-    @patch("mcp_core.transport.run_smart_stdio_proxy", return_value=0)
     @patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"})
-    def test_serve_main_sets_repo_root(self, mock_proxy):
+    def test_serve_main_sets_repo_root(self):
+        """serve_main(stdio) routes to FastMCP stdio server directly (no bridge)."""
         import better_code_review_graph.server as server_module
 
-        with pytest.raises(SystemExit, match="0"):
+        with patch.object(server_module.mcp, "run") as mock_run:
             serve_main(repo_root="/my/repo")
         assert server_module._default_repo_root == "/my/repo"
-        mock_proxy.assert_called_once()
+        mock_run.assert_called_once_with(transport="stdio")
 
-    @patch("mcp_core.transport.run_smart_stdio_proxy", return_value=0)
     @patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"})
-    def test_serve_main_none_repo_root(self, mock_proxy):
+    def test_serve_main_none_repo_root(self):
+        """serve_main(stdio) routes to FastMCP stdio server directly (no bridge)."""
         import better_code_review_graph.server as server_module
 
-        with pytest.raises(SystemExit, match="0"):
+        with patch.object(server_module.mcp, "run") as mock_run:
             serve_main(repo_root=None)
         assert server_module._default_repo_root is None
-        mock_proxy.assert_called_once()
+        mock_run.assert_called_once_with(transport="stdio")

--- a/tests/test_stdio_direct.py
+++ b/tests/test_stdio_direct.py
@@ -1,0 +1,143 @@
+"""Verify better-code-review-graph runs in stdio direct mode (no smart_stdio bridge).
+
+Spawns ``python -m better_code_review_graph`` with ``MCP_TRANSPORT=stdio`` and
+exercises the JSON-RPC handshake plus ``tools/list`` to prove the FastMCP stdio
+server is wired directly (no daemon-spawn bridge layer in front of it).
+
+Marked ``full`` because it spawns a real subprocess and speaks the MCP
+protocol; excluded from the default ``pytest`` invocation but runs under
+``uv run pytest -m full``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.full, pytest.mark.timeout(60)]
+
+
+def _spawn_stdio_server() -> subprocess.Popen[str]:
+    """Start ``python -m better_code_review_graph`` with stdio transport.
+
+    Returns the running subprocess. Caller is responsible for terminating it.
+    """
+    env = {**os.environ, "MCP_TRANSPORT": "stdio"}
+    return subprocess.Popen(
+        [sys.executable, "-m", "better_code_review_graph"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_response(proc: subprocess.Popen[str]) -> dict:
+    """Read one JSON-RPC line from stdout, parsed as dict."""
+    assert proc.stdout is not None and proc.stderr is not None
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read()
+        raise RuntimeError(
+            f"server closed stdout without sending a response. stderr=\n{stderr}"
+        )
+    return json.loads(line)
+
+
+def test_stdio_direct_init_responds():
+    """Spawn the server with MCP_TRANSPORT=stdio; verify init response shape."""
+    proc = _spawn_stdio_server()
+    assert proc.stdin is not None
+    init_request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    try:
+        proc.stdin.write(init_request)
+        proc.stdin.flush()
+        response = _read_response(proc)
+        assert response["id"] == 1
+        assert "result" in response, f"unexpected response: {response}"
+        # FastMCP negotiates protocol version; just assert it returned one.
+        assert "protocolVersion" in response["result"]
+        assert response["result"]["serverInfo"]["name"] == "better-code-review-graph"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_stdio_direct_tools_list_returns_expected_tools():
+    """Verify tools/list returns the expected crg tool set over stdio."""
+    proc = _spawn_stdio_server()
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
+    requests = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    ]
+    try:
+        for r in requests:
+            proc.stdin.write(r + "\n")
+            proc.stdin.flush()
+        responses: dict[int, dict] = {}
+        while len(responses) < 2:
+            line = proc.stdout.readline()
+            if not line:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"server closed stdout before tools/list response. "
+                    f"stderr=\n{stderr}"
+                )
+            data = json.loads(line)
+            if "id" in data:
+                responses[data["id"]] = data
+        assert 2 in responses, f"missing tools/list response: {responses}"
+        tools = responses[2]["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        # Core crg tools that must be exposed in stdio mode. Relay-only tool
+        # ``config__open_relay`` may or may not be registered depending on the
+        # relay-setup state, so we don't assert it here.
+        expected = {"graph", "query", "review", "config", "help"}
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}; got: {tool_names}"
+        )
+        assert len(tools) >= 4
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.12.4"
+version = "3.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
+    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pydantic-settings" },
@@ -879,8 +879,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.11.3"
-source = { registry = "https://pypi.org/simple" }
+version = "1.11.5"
+source = { directory = "../mcp-core/packages/core-py" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -893,9 +893,29 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/ce/2a174b08ea2d6e8bb6913756295e58a35460ca63e89201c58f4e80042fb5/n24q02m_mcp_core-1.11.3.tar.gz", hash = "sha256:55873571bf310d915917ff7ffc742948729215e807c514241b284a720eefa0b3", size = 200469, upload-time = "2026-04-29T10:59:50.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/a8/15d750245bc44bc21cdddb267ec026cf45f3c8c2c400c564e8808ed1f001/n24q02m_mcp_core-1.11.3-py3-none-any.whl", hash = "sha256:fe15f0b0da7152400da7fa6a0663ab1d0141b7d6c1d585d3d32ae40c6e0243fd", size = 123129, upload-time = "2026-04-29T10:59:48.631Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=47.0.0" },
+    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "filelock", specifier = ">=3.16.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
+    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
+    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty", specifier = ">=0.0.33" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate stdio path from smart_stdio bridge to direct FastMCP/MCP SDK stdio. Universal MCP client compat. Multi-target Dockerfile (:stdio + :http). Spec: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md