### PR TITLE
fix: strip [tool.uv.sources] in Dockerfile to fix uv sync --frozen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
+RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && cp uv.lock /tmp/uv.lock.docker
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
 COPY src/ src/
+RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && cp /tmp/uv.lock.docker uv.lock
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 


### PR DESCRIPTION
Fix Docker build failure on CD beta. Per memory feedback_uv_lock_docker_trap.md — same pattern as wet-mcp Dockerfile already uses. Strip local path overrides before uv sync inside container, restore after.