### PR TITLE
fix: regenerate uv.lock with UV_NO_SOURCES=1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.12.5"
+version = "3.13.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pydantic-settings" },
@@ -880,7 +880,7 @@ wheels = [
 [[package]]
 name = "n24q02m-mcp-core"
 version = "1.11.5"
-source = { directory = "../mcp-core/packages/core-py" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -893,29 +893,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.33" },
+sdist = { url = "https://files.pythonhosted.org/packages/0b/6c/e0a40d83d6f205d9d7b82a328c36e4f67fdaf023f24afa24619c9a1d20fd/n24q02m_mcp_core-1.11.5.tar.gz", hash = "sha256:da0bfc839387d4b530218fdd9935cdcaeed5ca32672c8411026fe2aa922ef8c7", size = 200476, upload-time = "2026-04-29T13:39:14.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/43/02d41151dbcc4d195a40f5f8a20f361efe3cc5f7f115ead1d01c4b75cc44/n24q02m_mcp_core-1.11.5-py3-none-any.whl", hash = "sha256:5d6495720ab4d97d701f98a26304857444bd1342fe0ed99104cb2829ea920e07", size = 123128, upload-time = "2026-04-29T13:39:13.335Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Per memory feedback_uv_lock_docker_trap.md — uv.lock had local path references for n24q02m-mcp-core that broke Docker build. Re-locked with UV_NO_SOURCES=1 to use PyPI registry source.