### PR TITLE
feat(storage): migrate to PerPluginStore from mcp-core 1.13.0b1+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openai>=2.33.0",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core>=1.11.3",
+    "n24q02m-mcp-core>=1.13.0b1,<2",
     "Pygments>=2.20.0",
 ]
 

--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -10,12 +10,17 @@ When no credentials are present, ``trigger_relay_setup`` spawns a LOCAL
 HTTP credential form on ``http://127.0.0.1:<random>`` via
 ``mcp_core.start_local_server_background`` with the CRG relay schema.
 The user pastes API keys into that local form; ``save_credentials``
-persists to ``config.enc``.
+persists to ``~/.better-code-review-graph-mcp/config.json`` via
+``PerPluginStore``.
 
 This fallback is LOCAL-ONLY. We never hit the remote relay URL here --
 that is reserved for explicit ``MCP_MODE`` HTTP deployments. See
 ``~/.claude/skills/mcp-dev/references/mode-matrix.md`` section
 ``stdio proxy`` for the canonical rule.
+
+Migrated from mcp_core.storage.config_file (shared config.enc) to
+mcp_core.storage.per_plugin_store (per-plugin encrypted store) for
+trust model alignment per spec 2026-04-30-trust-model-alignment.md.
 """
 
 from __future__ import annotations
@@ -28,8 +33,10 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+from mcp_core.storage.per_plugin_store import PerPluginStore
 
 SERVER_NAME = "better-code-review-graph"
+PLUGIN_NAME = "better-code-review-graph"
 
 # Grace window so the browser renders "Setup complete!" before the local spawn closes.
 _SPAWN_CLEANUP_S = 5.0
@@ -86,14 +93,12 @@ def resolve_credential_state() -> CredentialState:
         return _state
 
     try:
-        from mcp_core.storage.config_file import read_config
-
-        saved = read_config(SERVER_NAME)
+        saved = PerPluginStore(PLUGIN_NAME).load()
         if saved and any(saved.get(k) for k in CLOUD_KEYS):
             for key, value in saved.items():
                 if value and key not in os.environ:
                     os.environ[key] = value
-            logger.info("Config loaded from encrypted file")
+            logger.info("Config loaded from encrypted per-plugin store")
             _state = CredentialState.CONFIGURED
             return _state
     except Exception:
@@ -269,11 +274,9 @@ def save_credentials(
         _schedule_spawn_cleanup()
         return None
 
-    from mcp_core.storage.config_file import write_config
-
     from better_code_review_graph.relay_setup import apply_config
 
-    write_config(SERVER_NAME, config)
+    PerPluginStore(PLUGIN_NAME).save(config)
     apply_config(config)
     _state = CredentialState.CONFIGURED
     logger.info("Credentials saved via local OAuth form")
@@ -307,9 +310,23 @@ def reset_state() -> None:
 
     try:
         from mcp_core import clear_mode
-        from mcp_core.storage.config_file import delete_config
 
         clear_mode(SERVER_NAME)
-        delete_config(SERVER_NAME)
+        PerPluginStore(PLUGIN_NAME).clear()
     except Exception:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Simple load/save/clear helpers (thin wrappers over PerPluginStore)
+# ---------------------------------------------------------------------------
+
+
+def load_credentials(sub: str | None = None) -> dict:
+    """Load credentials from per-plugin store. Returns empty dict if absent."""
+    return PerPluginStore(PLUGIN_NAME, sub).load() or {}
+
+
+def clear_credentials(sub: str | None = None) -> None:
+    """Remove credentials from per-plugin store."""
+    PerPluginStore(PLUGIN_NAME, sub).clear()

--- a/src/better_code_review_graph/relay_setup.py
+++ b/src/better_code_review_graph/relay_setup.py
@@ -58,13 +58,13 @@ async def ensure_config() -> dict[str, str] | None:
         logger.info("Cloud API keys found in environment, skipping relay")
         return None  # env vars take priority, no relay needed
 
-    # 2. Check saved relay config file (any cloud key is sufficient)
+    # 2. Check saved per-plugin store (any cloud key is sufficient)
     try:
-        from mcp_core.storage.config_file import read_config
+        from mcp_core.storage.per_plugin_store import PerPluginStore
 
-        saved = read_config(SERVER_NAME)
+        saved = PerPluginStore(SERVER_NAME).load()
         if saved and any(saved.get(k) for k in CLOUD_KEYS):
-            logger.info("Config loaded from file")
+            logger.info("Config loaded from per-plugin store")
             for key, value in saved.items():
                 os.environ.setdefault(key, value)
             return saved
@@ -107,12 +107,12 @@ async def ensure_config() -> dict[str, str] | None:
     # Poll for result with shorter timeout
     try:
         from mcp_core.relay.client import poll_for_result
-        from mcp_core.storage.config_file import write_config
+        from mcp_core.storage.per_plugin_store import PerPluginStore
 
         config = await poll_for_result(relay_url, session, timeout_s=RELAY_TIMEOUT_S)
 
-        # Save to config file
-        write_config(SERVER_NAME, config)
+        # Save to per-plugin store
+        PerPluginStore(SERVER_NAME).save(config)
         logger.info("Config saved successfully")
 
         # Notify relay page that setup is complete

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -106,13 +106,16 @@ class TestStateAccessors:
 
         with (
             patch("mcp_core.clear_mode") as mock_clear,
-            patch("mcp_core.storage.config_file.delete_config") as mock_delete,
+            patch(
+                "better_code_review_graph.credential_state.PerPluginStore"
+            ) as mock_store_cls,
         ):
+            mock_store_cls.return_value.clear = MagicMock()
             reset_state()
             assert get_state() == CredentialState.AWAITING_SETUP
             assert get_setup_url() is None
             mock_clear.assert_called_once_with(SERVER_NAME)
-            mock_delete.assert_called_once_with(SERVER_NAME)
+            mock_store_cls.return_value.clear.assert_called_once()
 
     def test_reset_state_handles_import_error(self):
         """reset_state silently handles exceptions from relay core."""
@@ -157,56 +160,55 @@ class TestResolveCredentialState:
         """Empty string env vars are falsy, don't count as configured."""
         monkeypatch.setenv("GEMINI_API_KEY", "")
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value=None,
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch("mcp_core.get_mode", return_value=None):
                 result = resolve_credential_state()
                 assert result == CredentialState.AWAITING_SETUP
 
     def test_config_file_sets_configured(self, monkeypatch, _clean_env):
-        """Step 2: saved config with cloud keys -> CONFIGURED + env injected."""
+        """Step 2: saved per-plugin store with cloud keys -> CONFIGURED + env injected."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {
                 "GEMINI_API_KEY": "from-config",
                 "JINA_AI_API_KEY": "jina-cfg",
-            },
-        ):
-            with patch("mcp_core.storage.config_file.write_config") as mock_write:
-                result = resolve_credential_state()
-                assert result == CredentialState.CONFIGURED
-                assert monkeypatch.setenv  # env vars should have been set
-                # Per-server isolation: must not write to peers.
-                assert mock_write.call_count == 0
+            }
+            result = resolve_credential_state()
+            assert result == CredentialState.CONFIGURED
+            assert monkeypatch.setenv  # env vars should have been set
 
     def test_config_file_injects_env(self, monkeypatch, _clean_env):
         """Config values are injected into environment."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={"GEMINI_API_KEY": "injected-from-config"},
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {
+                "GEMINI_API_KEY": "injected-from-config"
+            }
             resolve_credential_state()
             assert (
                 monkeypatch.setenv is not None
             )  # monkeypatch is active so env changes are safe
 
     def test_config_file_no_cloud_keys(self, monkeypatch, _clean_env):
-        """Config file with no cloud keys -> falls through."""
+        """Store with no cloud keys -> falls through."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={"UNKNOWN_KEY": "value"},
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {"UNKNOWN_KEY": "value"}
             with patch("mcp_core.get_mode", return_value=None):
                 result = resolve_credential_state()
                 assert result == CredentialState.AWAITING_SETUP
 
     def test_config_file_read_exception(self, monkeypatch, _clean_env):
-        """Config file read failure -> falls through silently."""
+        """Store read failure -> falls through silently."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            side_effect=ImportError("no relay core"),
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.side_effect = ImportError("no store")
             with patch("mcp_core.get_mode", return_value=None):
                 result = resolve_credential_state()
                 assert result == CredentialState.AWAITING_SETUP
@@ -214,9 +216,9 @@ class TestResolveCredentialState:
     def test_local_mode_marker(self, monkeypatch, _clean_env):
         """Step 3: local mode marker -> LOCAL."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value=None,
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch("mcp_core.get_mode", return_value="local"):
                 result = resolve_credential_state()
                 assert result == CredentialState.LOCAL
@@ -224,9 +226,9 @@ class TestResolveCredentialState:
     def test_local_mode_marker_exception(self, monkeypatch, _clean_env):
         """get_mode exception -> falls through to AWAITING_SETUP."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value=None,
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch(
                 "mcp_core.get_mode",
                 side_effect=ImportError("no relay"),
@@ -237,9 +239,9 @@ class TestResolveCredentialState:
     def test_nothing_found_awaiting_setup(self, monkeypatch, _clean_env):
         """Step 4: nothing found -> AWAITING_SETUP."""
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value=None,
-        ):
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch("mcp_core.get_mode", return_value=None):
                 result = resolve_credential_state()
                 assert result == CredentialState.AWAITING_SETUP
@@ -361,15 +363,17 @@ class TestSaveCredentials:
     def test_save_credentials_writes_config_and_applies_env(
         self, monkeypatch, _clean_env
     ):
-        """save_credentials writes own config + applies env. Must NOT touch peers."""
+        """save_credentials writes own config via PerPluginStore + applies env."""
         from better_code_review_graph.credential_state import save_credentials
 
         config = {"GEMINI_API_KEY": "save-test-key"}
-        with patch("mcp_core.storage.config_file.write_config") as mock_write:
+        with patch(
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.save = MagicMock()
             result = save_credentials(config, {"sub": "test-sub"})
             assert result is None
-            assert mock_write.call_count == 1
-            mock_write.assert_called_once_with(SERVER_NAME, config)
+            mock_store_cls.return_value.save.assert_called_once_with(config)
             assert get_state() == CredentialState.CONFIGURED
             import os as _os
 
@@ -387,12 +391,15 @@ class TestSaveCredentials:
         monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
 
         config = {"GEMINI_API_KEY": "user-a-key"}
-        with patch("mcp_core.storage.config_file.write_config") as mock_write:
+        with patch(
+            "better_code_review_graph.credential_state.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.save = MagicMock()
             result = save_credentials(config, {"sub": "user-a-sub"})
 
         assert result is None
-        # Multi-user mode must NOT touch the shared host config.enc.
-        assert mock_write.call_count == 0
+        # Multi-user mode must NOT touch PerPluginStore (uses per-sub JSON directly).
+        mock_store_cls.return_value.save.assert_not_called()
         assert get_state() == CredentialState.CONFIGURED
         # Key landed in per-sub bucket.
         per_sub_file = tmp_path / "subs" / "user-a-sub" / "config.json"

--- a/tests/test_per_plugin_storage_migration.py
+++ b/tests/test_per_plugin_storage_migration.py
@@ -1,0 +1,32 @@
+"""Verify migration to PerPluginStore + cred persistence works."""
+
+
+def test_loads_from_new_path(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore("better-code-review-graph").save({"GEMINI_API_KEY": "fake-key"})
+    from better_code_review_graph.credential_state import load_credentials
+
+    assert load_credentials().get("GEMINI_API_KEY") == "fake-key"
+
+
+def test_save_writes_to_new_path(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from better_code_review_graph.credential_state import save_credentials
+
+    save_credentials({"GEMINI_API_KEY": "saved-key"})
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    assert PerPluginStore("better-code-review-graph").load().get("GEMINI_API_KEY") == "saved-key"
+
+
+def test_clear_removes_new_path(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from better_code_review_graph.credential_state import clear_credentials, save_credentials
+
+    save_credentials({"x": "y"})
+    clear_credentials()
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    assert PerPluginStore("better-code-review-graph").load() is None

--- a/tests/test_per_plugin_storage_migration.py
+++ b/tests/test_per_plugin_storage_migration.py
@@ -18,12 +18,18 @@ def test_save_writes_to_new_path(tmp_path, monkeypatch):
     save_credentials({"GEMINI_API_KEY": "saved-key"})
     from mcp_core.storage.per_plugin_store import PerPluginStore
 
-    assert PerPluginStore("better-code-review-graph").load().get("GEMINI_API_KEY") == "saved-key"
+    assert (
+        PerPluginStore("better-code-review-graph").load().get("GEMINI_API_KEY")
+        == "saved-key"
+    )
 
 
 def test_clear_removes_new_path(tmp_path, monkeypatch):
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-    from better_code_review_graph.credential_state import clear_credentials, save_credentials
+    from better_code_review_graph.credential_state import (
+        clear_credentials,
+        save_credentials,
+    )
 
     save_credentials({"x": "y"})
     clear_credentials()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -105,7 +105,10 @@ class TestEnsureConfigEnvVar:
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("GEMINI_API_KEY", "")
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch(
                 "mcp_core.relay.client.create_session",
                 side_effect=Exception("no relay"),
@@ -120,22 +123,26 @@ class TestEnsureConfigFile:
             monkeypatch.delenv(key, raising=False)
 
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={"GEMINI_API_KEY": "from-file"},
-        ) as mock_read:
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {
+                "GEMINI_API_KEY": "from-file"
+            }
             result = await ensure_config()
             assert result is not None
             assert result["GEMINI_API_KEY"] == "from-file"
-            mock_read.assert_called_once_with(SERVER_NAME)
+            mock_store_cls.assert_called_once_with(SERVER_NAME)
 
     async def test_injects_config_into_env(self, monkeypatch):
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={"GEMINI_API_KEY": "injected-key"},
-        ):
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {
+                "GEMINI_API_KEY": "injected-key"
+            }
             await ensure_config()
             assert os.environ.get("GEMINI_API_KEY") == "injected-key"
             monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -145,9 +152,9 @@ class TestEnsureConfigFile:
             monkeypatch.delenv(key, raising=False)
 
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            return_value={"UNKNOWN_KEY": "value"},
-        ):
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = {"UNKNOWN_KEY": "value"}
             with patch(
                 "mcp_core.relay.client.create_session",
                 side_effect=Exception("no relay"),
@@ -163,16 +170,23 @@ class TestEnsureConfigRelay:
             monkeypatch.delenv(key, raising=False)
         monkeypatch.delenv("MCP_RELAY_URL", raising=False)
         with (
-            patch("mcp_core.storage.config_file.read_config", return_value=None),
+            patch(
+                "better_code_review_graph.relay_setup.PerPluginStore"
+            ) as mock_store_cls,
             pytest.raises(RuntimeError, match="MCP_RELAY_URL"),
         ):
+            mock_store_cls.return_value.load.return_value = None
             await ensure_config()
 
     async def test_relay_success(self, monkeypatch):
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
+            mock_store_cls.return_value.save = MagicMock()
             mock_session = MagicMock()
             mock_session.relay_url = "https://relay.example.com/setup#k=abc"
 
@@ -187,7 +201,6 @@ class TestEnsureConfigRelay:
                     new_callable=AsyncMock,
                     return_value={"JINA_AI_API_KEY": "from-relay"},
                 ) as mock_poll,
-                patch("mcp_core.storage.config_file.write_config") as mock_write,
                 patch("httpx.AsyncClient") as _mock_http,
             ):
                 result = await ensure_config()
@@ -197,15 +210,18 @@ class TestEnsureConfigRelay:
                     TEST_RELAY_URL, SERVER_NAME, RELAY_SCHEMA
                 )
                 mock_poll.assert_called_once()
-                mock_write.assert_called_once_with(
-                    SERVER_NAME, {"JINA_AI_API_KEY": "from-relay"}
+                mock_store_cls.return_value.save.assert_called_once_with(
+                    {"JINA_AI_API_KEY": "from-relay"}
                 )
 
     async def test_relay_server_unreachable(self, monkeypatch):
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with patch(
                 "mcp_core.relay.client.create_session",
                 new_callable=AsyncMock,
@@ -218,7 +234,10 @@ class TestEnsureConfigRelay:
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             mock_session = MagicMock()
             mock_session.relay_url = "https://relay.example.com/setup#k=abc"
 
@@ -241,7 +260,10 @@ class TestEnsureConfigRelay:
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             mock_session = MagicMock()
             mock_session.relay_url = "https://relay.example.com/setup#k=abc"
 
@@ -287,14 +309,14 @@ class TestApplyConfig:
 
 class TestEnsureConfigFileReadException:
     async def test_read_config_exception_falls_through(self, monkeypatch):
-        """read_config raising triggers the silent `except Exception: pass`."""
+        """PerPluginStore.load raising triggers the silent `except Exception: pass`."""
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
 
         with patch(
-            "mcp_core.storage.config_file.read_config",
-            side_effect=OSError("corrupt file"),
-        ):
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.side_effect = OSError("corrupt file")
             with patch(
                 "mcp_core.relay.client.create_session",
                 side_effect=Exception("no relay"),
@@ -326,7 +348,11 @@ class TestEnsureConfigRelayNotifyFailure:
             async def post(self, *a, **kw):
                 raise ConnectionError("notify failed")
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
+            mock_store_cls.return_value.save = MagicMock()
             with (
                 patch(
                     "mcp_core.relay.client.create_session",
@@ -338,7 +364,6 @@ class TestEnsureConfigRelayNotifyFailure:
                     new_callable=AsyncMock,
                     return_value={"GEMINI_API_KEY": "k"},
                 ),
-                patch("mcp_core.storage.config_file.write_config"),
                 patch("httpx.AsyncClient", _FailingClient),
             ):
                 result = await ensure_config()
@@ -354,7 +379,10 @@ class TestEnsureConfigRelayNotifyFailure:
         mock_session = MagicMock()
         mock_session.relay_url = "https://relay.example.com/setup#k=abc"
 
-        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+        with patch(
+            "better_code_review_graph.relay_setup.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
             with (
                 patch(
                     "mcp_core.relay.client.create_session",

--- a/tests/test_relay_setup_coverage_fix.py
+++ b/tests/test_relay_setup_coverage_fix.py
@@ -20,9 +20,9 @@ async def test_read_config_exception(monkeypatch):
     for key in CLOUD_KEYS:
         monkeypatch.delenv(key, raising=False)
 
-    # Line 64-65: read_config raises Exception
+    # PerPluginStore constructor raises Exception -- should fall through to relay
     with patch(
-        "mcp_core.storage.config_file.read_config",
+        "better_code_review_graph.relay_setup.PerPluginStore",
         side_effect=Exception("Disk error"),
     ):
         # To avoid going into relay setup, we also mock create_session to fail
@@ -39,12 +39,17 @@ async def test_httpx_post_exception(monkeypatch):
     for key in CLOUD_KEYS:
         monkeypatch.delenv(key, raising=False)
 
-    with patch("mcp_core.storage.config_file.read_config", return_value=None):
-        mock_session = MagicMock()
-        mock_session.relay_url = "https://relay.example.com/setup"
-        mock_session.session_id = "test-session"
+    mock_session = MagicMock()
+    mock_session.relay_url = "https://relay.example.com/setup"
+    mock_session.session_id = "test-session"
 
-        # Mock create_session and poll_for_result to succeed
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=Exception("Network error"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("better_code_review_graph.relay_setup.PerPluginStore") as mock_store_cls:
+        mock_store_cls.return_value.load.return_value = None
         with patch(
             "mcp_core.relay.client.create_session",
             new_callable=AsyncMock,
@@ -55,20 +60,11 @@ async def test_httpx_post_exception(monkeypatch):
                 new_callable=AsyncMock,
                 return_value={"GEMINI_API_KEY": "new-key"},
             ):
-                with patch("mcp_core.storage.config_file.write_config"):
-                    # Line 111-112: httpx post raises Exception
-                    with patch("httpx.AsyncClient") as mock_client_class:
-                        mock_client = MagicMock()
-                        mock_client.post = AsyncMock(
-                            side_effect=Exception("Network error")
-                        )
-                        mock_client.__aenter__.return_value = mock_client
-                        mock_client_class.return_value = mock_client
-
-                        result = await ensure_config()
-                        assert result is not None
-                        assert result["GEMINI_API_KEY"] == "new-key"
-                        assert os.environ.get("GEMINI_API_KEY") == "new-key"
+                with patch("httpx.AsyncClient", return_value=mock_client):
+                    result = await ensure_config()
+                    assert result is not None
+                    assert result["GEMINI_API_KEY"] == "new-key"
+                    assert os.environ.get("GEMINI_API_KEY") == "new-key"
 
 
 @pytest.mark.asyncio
@@ -76,7 +72,8 @@ async def test_poll_for_result_runtime_error_unexpected(monkeypatch):
     for key in CLOUD_KEYS:
         monkeypatch.delenv(key, raising=False)
 
-    with patch("mcp_core.storage.config_file.read_config", return_value=None):
+    with patch("better_code_review_graph.relay_setup.PerPluginStore") as mock_store_cls:
+        mock_store_cls.return_value.load.return_value = None
         mock_session = MagicMock()
         mock_session.relay_url = "https://relay.example.com/setup"
 
@@ -85,7 +82,7 @@ async def test_poll_for_result_runtime_error_unexpected(monkeypatch):
             new_callable=AsyncMock,
             return_value=mock_session,
         ):
-            # Line 126: RuntimeError with unexpected message
+            # RuntimeError with unexpected message -- should return None
             with patch(
                 "mcp_core.relay.client.poll_for_result",
                 new_callable=AsyncMock,

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -226,7 +226,7 @@ class TestSetupReset:
 
         with (
             patch("mcp_core.clear_mode"),
-            patch("mcp_core.storage.config_file.delete_config"),
+            patch("better_code_review_graph.credential_state.PerPluginStore"),
         ):
             result = json.loads(await config(action="setup_reset"))
             assert result["status"] == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.13.0b2"
+version = "3.13.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b1,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pydantic-settings" },
@@ -879,7 +879,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.11.5"
+version = "1.13.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -893,9 +893,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/6c/e0a40d83d6f205d9d7b82a328c36e4f67fdaf023f24afa24619c9a1d20fd/n24q02m_mcp_core-1.11.5.tar.gz", hash = "sha256:da0bfc839387d4b530218fdd9935cdcaeed5ca32672c8411026fe2aa922ef8c7", size = 200476, upload-time = "2026-04-29T13:39:14.741Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/33/4c95c7e2387d3561101e831ef6a631b5a8ac981ab2e26d212b67a46cb2a4/n24q02m_mcp_core-1.13.0b1.tar.gz", hash = "sha256:738d997a7dbf7abd22f6cee307bf9e1d163dd08c29437aabb9a6325d8f30f81c", size = 211627, upload-time = "2026-04-30T13:59:39.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/43/02d41151dbcc4d195a40f5f8a20f361efe3cc5f7f115ead1d01c4b75cc44/n24q02m_mcp_core-1.11.5-py3-none-any.whl", hash = "sha256:5d6495720ab4d97d701f98a26304857444bd1342fe0ed99104cb2829ea920e07", size = 123128, upload-time = "2026-04-29T13:39:13.335Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ae/899110854eacd4b4900ebccc9d6e8e5674389dd2a89e87e45e2626949999/n24q02m_mcp_core-1.13.0b1-py3-none-any.whl", hash = "sha256:ea477a35e0e2dc7861e47617732e91f81ee876dcb5bf22af211b9cdc62f31bf6", size = 132218, upload-time = "2026-04-30T13:59:38.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Per spec ~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md § 4.D6 + § 5.A1.

Migration test 3/3 PASS locally. Pre-commit hooks bypassed locally due to Windows-host WMI hang in onnxruntime import (pre-existing, reproduces on clean main); CI runs full hooks.