### PR TITLE
feat: stdio-pure + http-multi-user (drop daemon-bridge)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openai>=2.33.0",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core>=1.13.0b1,<2",
+    "n24q02m-mcp-core>=1.13.0b4,<2",
     "Pygments>=2.20.0",
 ]
 

--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -1,22 +1,16 @@
 """Non-blocking credential state management for better-code-review-graph.
 
-State machine: awaiting_setup -> setup_in_progress -> (configured | local)
+State machine: awaiting_setup -> (configured | local)
 Reset: configured/local -> awaiting_setup (via setup tool).
 
 CRG has a local fallback (qwen3-embed ONNX) so all tools work without
 cloud credentials. Cloud keys are optional enhancements.
 
-When no credentials are present, ``trigger_relay_setup`` spawns a LOCAL
-HTTP credential form on ``http://127.0.0.1:<random>`` via
-``mcp_core.start_local_server_background`` with the CRG relay schema.
-The user pastes API keys into that local form; ``save_credentials``
-persists to ``~/.better-code-review-graph-mcp/config.json`` via
-``PerPluginStore``.
-
-This fallback is LOCAL-ONLY. We never hit the remote relay URL here --
-that is reserved for explicit ``MCP_MODE`` HTTP deployments. See
-``~/.claude/skills/mcp-dev/references/mode-matrix.md`` section
-``stdio proxy`` for the canonical rule.
+After the stdio-pure + http-multi-user split (spec
+2026-05-01-stdio-pure-http-multiuser.md), the daemon-bridge auto-spawn
+flow has been removed. In stdio mode the server reads cloud API keys
+from env vars only; in HTTP mode the relay form lives on the HTTP
+server itself at ``<PUBLIC_URL>/authorize``.
 
 Migrated from mcp_core.storage.config_file (shared config.enc) to
 mcp_core.storage.per_plugin_store (per-plugin encrypted store) for
@@ -25,21 +19,16 @@ trust model alignment per spec 2026-04-30-trust-model-alignment.md.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 from mcp_core.storage.per_plugin_store import PerPluginStore
 
 SERVER_NAME = "better-code-review-graph"
 PLUGIN_NAME = "better-code-review-graph"
-
-# Grace window so the browser renders "Setup complete!" before the local spawn closes.
-_SPAWN_CLEANUP_S = 5.0
 
 CLOUD_KEYS = [
     "GEMINI_API_KEY",
@@ -61,7 +50,6 @@ class CredentialState(Enum):
 # Module-level state
 _state: CredentialState = CredentialState.AWAITING_SETUP
 _setup_url: str | None = None
-_active_handle: Any | None = None  # LocalServerHandle
 
 
 def get_state() -> CredentialState:
@@ -70,7 +58,11 @@ def get_state() -> CredentialState:
 
 
 def get_setup_url() -> str | None:
-    """Return current relay setup URL (if any)."""
+    """Return current relay setup URL (if any).
+
+    After stdio-pure + http-multi-user split, this is always ``None``
+    in stdio mode and only set externally by HTTP-mode entry points.
+    """
     return _setup_url
 
 
@@ -118,99 +110,6 @@ def resolve_credential_state() -> CredentialState:
     logger.info("No credentials found -- server starting in awaiting_setup mode")
     _state = CredentialState.AWAITING_SETUP
     return _state
-
-
-async def _close_active_handle() -> None:
-    """Best-effort close of the module-level local credential-form handle."""
-    global _active_handle
-
-    handle = _active_handle
-    _active_handle = None
-    if handle is None:
-        return
-    try:
-        await handle.close()
-    except Exception:  # pragma: no cover - best-effort cleanup, hard to fault-inject
-        logger.opt(exception=True).debug(
-            "Best-effort close of credential-form handle failed"
-        )
-
-
-def _schedule_spawn_cleanup(grace_s: float = _SPAWN_CLEANUP_S) -> None:
-    """Schedule detached cleanup of the local credential-form spawn."""
-    if _active_handle is None:
-        return
-
-    async def _delayed_close() -> None:  # pragma: no cover - timer-based detached task
-        try:
-            await asyncio.sleep(grace_s)
-            await _close_active_handle()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.opt(exception=True).debug("Delayed spawn cleanup failed")
-
-    try:  # pragma: no cover - detached task scheduling
-        task = asyncio.create_task(_delayed_close())
-        task.add_done_callback(lambda _t: None)
-    except RuntimeError:
-        pass
-
-
-async def trigger_relay_setup(
-    *,
-    force: bool = False,
-    timeout: float | None = None,  # noqa: ARG001
-) -> str | None:
-    """Spawn a local credential form (stdio fallback) and return its URL.
-
-    The spawn is LOCAL ONLY -- ``mcp_core.start_local_server_background``
-    binds ``127.0.0.1:<random>`` and renders the CRG relay schema in a
-    browser form. ``timeout`` is accepted for backward compatibility but
-    unused.
-    """
-    global _state, _setup_url, _active_handle
-
-    if not force and _state not in (CredentialState.AWAITING_SETUP,):
-        return _setup_url
-
-    if _active_handle is not None and _setup_url:
-        _state = CredentialState.SETUP_IN_PROGRESS
-        return _setup_url
-
-    _state = CredentialState.SETUP_IN_PROGRESS
-
-    try:
-        from fastmcp import FastMCP
-        from mcp_core import start_local_server_background, try_open_browser
-
-        from better_code_review_graph.relay_schema import RELAY_SCHEMA
-
-        stub_mcp = FastMCP(f"{SERVER_NAME}-setup")
-
-        handle = await start_local_server_background(
-            stub_mcp,
-            server_name=SERVER_NAME,
-            relay_schema=RELAY_SCHEMA,
-            port=0,
-            host="127.0.0.1",
-            on_credentials_saved=save_credentials,
-        )
-
-        _active_handle = handle
-        _setup_url = f"http://{handle.host}:{handle.port}/"
-
-        try_open_browser(_setup_url)
-
-        logger.info("Local credential form ready at {}", _setup_url)
-        return _setup_url
-
-    except Exception as e:
-        logger.debug("Relay setup failed: {}. Server continues in awaiting_setup.", e)
-        _state = CredentialState.AWAITING_SETUP
-        await _close_active_handle()
-        _setup_url = None
-        return None
 
 
 def _sub_data_dir(sub: str) -> Path:
@@ -271,7 +170,6 @@ def save_credentials(
         store_for_sub(sub, config)
         _state = CredentialState.CONFIGURED
         logger.info("Credentials saved for sub={} via remote OAuth form", sub)
-        _schedule_spawn_cleanup()
         return None
 
     from better_code_review_graph.relay_setup import apply_config
@@ -280,10 +178,6 @@ def save_credentials(
     apply_config(config)
     _state = CredentialState.CONFIGURED
     logger.info("Credentials saved via local OAuth form")
-
-    # Cloud-only setup is done -- schedule local spawn cleanup so the browser
-    # renders "Setup complete!" then the local server closes.
-    _schedule_spawn_cleanup()
     return None
 
 
@@ -298,15 +192,6 @@ def reset_state() -> None:
     global _state, _setup_url
     _state = CredentialState.AWAITING_SETUP
     _setup_url = None
-
-    # Close any active local credential-form spawn; fire-and-forget so callers
-    # don't need to be async.
-    if _active_handle is not None:  # pragma: no cover - detached task scheduling
-        try:
-            task = asyncio.create_task(_close_active_handle())
-            task.add_done_callback(lambda _t: None)
-        except RuntimeError:
-            pass
 
     try:
         from mcp_core import clear_mode

--- a/src/better_code_review_graph/relay_setup.py
+++ b/src/better_code_review_graph/relay_setup.py
@@ -13,6 +13,8 @@ import logging
 import os
 import sys
 
+from mcp_core.storage.per_plugin_store import PerPluginStore
+
 from .relay_schema import RELAY_SCHEMA
 
 logger = logging.getLogger(__name__)
@@ -60,8 +62,6 @@ async def ensure_config() -> dict[str, str] | None:
 
     # 2. Check saved per-plugin store (any cloud key is sufficient)
     try:
-        from mcp_core.storage.per_plugin_store import PerPluginStore
-
         saved = PerPluginStore(SERVER_NAME).load()
         if saved and any(saved.get(k) for k in CLOUD_KEYS):
             logger.info("Config loaded from per-plugin store")
@@ -107,7 +107,6 @@ async def ensure_config() -> dict[str, str] | None:
     # Poll for result with shorter timeout
     try:
         from mcp_core.relay.client import poll_for_result
-        from mcp_core.storage.per_plugin_store import PerPluginStore
 
         config = await poll_for_result(relay_url, session, timeout_s=RELAY_TIMEOUT_S)
 

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -16,7 +16,6 @@ from mcp_core.relay.tool_helpers import register_open_relay_tool
 
 from .embeddings import EmbeddingStore, init_backend, resolve_backend
 from .incremental import get_db_path
-from .relay_schema import RELAY_SCHEMA
 from .tools import (
     build_or_update_graph,
     embed_graph,
@@ -404,11 +403,7 @@ async def config(
                 }
             )
         case "setup_start":
-            from .credential_state import (
-                CredentialState,
-                get_state,
-                trigger_relay_setup,
-            )
+            from .credential_state import CredentialState, get_state
 
             if get_state() == CredentialState.CONFIGURED and not force:
                 return _json(
@@ -417,8 +412,12 @@ async def config(
                         "message": "Already configured. Use force=true to reconfigure.",
                     }
                 )
-            url = await trigger_relay_setup(force=True)
-            if url:
+            # In stdio mode (default after spec 2026-05-01) the server reads
+            # API keys from env vars only; the browser-based relay form is
+            # served by the HTTP-mode entry point at <PUBLIC_URL>/authorize.
+            public_url = os.environ.get("PUBLIC_URL")
+            if public_url:
+                url = f"{public_url.rstrip('/')}/authorize"
                 return _json(
                     {
                         "status": "setup_started",
@@ -428,8 +427,13 @@ async def config(
                 )
             return _json(
                 {
-                    "status": "error",
-                    "message": "Failed to start relay session.",
+                    "status": "stdio_mode",
+                    "message": (
+                        "Stdio mode reads API keys from env vars only. "
+                        "Set GEMINI_API_KEY / OPENAI_API_KEY / JINA_AI_API_KEY / "
+                        "COHERE_API_KEY in the plugin config, or switch to HTTP "
+                        "mode to use the browser-based setup form."
+                    ),
                 }
             )
         case "setup_skip":
@@ -681,9 +685,10 @@ SERVER_NAME = "better-code-review-graph"
 # ---------------------------------------------------------------------------
 # Registers the standard ``config__open_relay`` MCP tool so the LLM can
 # re-trigger the relay form (e.g. after credential expiry) by tool call.
-# Returns ``{ url, browser_opened, status }``; auto-respawns the daemon if
-# it died. See ``mcp_core.relay.tool_helpers``.
-register_open_relay_tool(mcp, SERVER_NAME, RELAY_SCHEMA)
+# In HTTP mode the tool returns ``<PUBLIC_URL>/authorize``; in stdio mode
+# it returns ``status: 'stdio_unsupported'`` so the caller can surface a
+# "switch to HTTP mode" message. See ``mcp_core.relay.tool_helpers``.
+register_open_relay_tool(mcp, SERVER_NAME, os.environ.get("PUBLIC_URL"))
 
 
 # ---------------------------------------------------------------------------
@@ -694,15 +699,17 @@ register_open_relay_tool(mcp, SERVER_NAME, RELAY_SCHEMA)
 async def run_http(port: int = 0) -> None:
     """Run as HTTP server with local OAuth 2.1 AS.
 
-    Single-user (default): binds ``127.0.0.1`` -- one host, one user, one
-    shared ``config.enc``.
+    Always multi-user remote-style (per spec 2026-05-01-stdio-pure-http-multiuser.md).
+    Binds ``0.0.0.0:<MCP_PORT|8080>`` when ``PUBLIC_URL`` is set and refuses
+    to start without ``MCP_DCR_SERVER_SECRET`` so per-JWT-sub DCR signing is
+    enforced. Each authorize-session's JWT ``sub`` scopes credential storage
+    and graph DB path.
 
-    Multi-user remote (``PUBLIC_URL`` set): binds ``0.0.0.0:<MCP_PORT|8080>``
-    and refuses to start without ``MCP_DCR_SERVER_SECRET`` so per-JWT-sub
-    DCR signing is enforced. Each authorize-session's JWT ``sub`` scopes
-    credential storage and graph DB path.
+    For local self-host without ``PUBLIC_URL`` the server still binds
+    ``127.0.0.1`` and runs the same multi-user code path with a single
+    JWT sub.
     """
-    from mcp_core.transport.local_server import run_local_server
+    from mcp_core.transport.local_server import run_http_server
 
     from .credential_state import save_credentials
     from .relay_schema import RELAY_SCHEMA
@@ -721,7 +728,7 @@ async def run_http(port: int = 0) -> None:
     else:
         host = "127.0.0.1"
 
-    await run_local_server(
+    await run_http_server(
         mcp,
         server_name="better-code-review-graph",
         relay_schema=RELAY_SCHEMA,
@@ -732,27 +739,43 @@ async def run_http(port: int = 0) -> None:
 
 
 def serve_main(repo_root: str | None = None) -> None:
-    """Run the MCP server. Defaults to HTTP, --stdio for backward compat."""
+    """Run the MCP server. Defaults to stdio; opt in to HTTP via flag/env.
+
+    Stdio mode (default): runs FastMCP stdio server directly. Reads cloud
+    API keys from env vars only. Universal MCP client compatibility.
+
+    HTTP mode (opt-in): triggered by ``--http`` argv flag,
+    ``MCP_TRANSPORT=http``, or ``TRANSPORT_MODE=http``. Multi-user JWT-sub
+    server with browser relay form at ``<PUBLIC_URL>/authorize``.
+
+    See: ~/projects/.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md
+    """
     import asyncio
     import sys
 
     global _default_repo_root
     _default_repo_root = repo_root
 
-    if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
-        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
-        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
-        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
-        mcp.run(transport="stdio")
+    is_http = (
+        "--http" in sys.argv
+        or os.environ.get("MCP_TRANSPORT") == "http"
+        or os.environ.get("TRANSPORT_MODE") == "http"
+    )
+
+    if is_http:
+        # HTTP mode: resolve credentials so the relay form can hint current
+        # state. Stdio mode resolves lazily inside tool calls.
+        from .credential_state import resolve_credential_state
+
+        resolve_credential_state()
+
+        asyncio.run(run_http())
         return
 
-    # HTTP / local-relay path: resolve credentials so the relay form can hint
-    # current state. Stdio mode resolves lazily inside tool calls.
-    from .credential_state import resolve_credential_state
-
-    resolve_credential_state()
-
-    asyncio.run(run_http())
+    # Stdio mode (default): run FastMCP stdio server directly. No bridge
+    # layer. Cloud API keys come from env vars only -- CRG has a local
+    # fallback (qwen3-embed ONNX) so missing cloud creds is non-fatal.
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/tests/test_config_open_relay_registered.py
+++ b/tests/test_config_open_relay_registered.py
@@ -33,23 +33,16 @@ class TestConfigOpenRelayRegistered:
         )
         assert "config__open_relay" in names
 
-    async def test_config_open_relay_returns_expected_keys(self, monkeypatch):
+    async def test_config_open_relay_returns_expected_keys(self):
         """Tool handler must return the documented ``url/browser_opened/status`` shape.
 
-        Patches the mcp-core daemon helpers so we exercise the closure without
-        spawning a real daemon. Verifies wiring (server name + schema flow
-        through register_open_relay_tool) end-to-end at the tool surface.
+        After spec 2026-05-01-stdio-pure-http-multiuser.md, the
+        ``config__open_relay`` tool is HTTP-only -- it returns
+        ``status: 'stdio_unsupported'`` when the server is running in stdio
+        mode (no ``PUBLIC_URL``). The server module loads with
+        ``PUBLIC_URL`` unset by default, so ``status`` is
+        ``stdio_unsupported`` here.
         """
-        from mcp_core.relay import tool_helpers as th
-
-        monkeypatch.setattr(th, "_daemon_is_alive", lambda name: True)
-        monkeypatch.setattr(
-            th, "_daemon_relay_url", lambda name: f"http://127.0.0.1:9999/{name}/relay"
-        )
-        monkeypatch.setattr(th, "_daemon_cred_state", lambda name: "configured")
-        monkeypatch.setattr(th, "_is_session_active_for_server", lambda name: False)
-        monkeypatch.setattr(th, "_try_open_browser", lambda url: True)
-
         result = await mcp.call_tool("config__open_relay", {})
         # FastMCP wraps the dict in structured/unstructured content; pull the
         # structured payload regardless of tuple/object shape.
@@ -62,9 +55,9 @@ class TestConfigOpenRelayRegistered:
             )
         assert payload is not None, f"No structured payload from tool call: {result!r}"
         assert set(payload.keys()) >= {"url", "browser_opened", "status"}
-        assert "better-code-review-graph" in payload["url"]
-        assert payload["browser_opened"] is True
-        assert payload["status"] == "configured"
+        assert payload["status"] == "stdio_unsupported"
+        assert payload["browser_opened"] is False
+        assert payload["url"] == ""
 
 
 if __name__ == "__main__":

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -1,13 +1,12 @@
 """Tests for credential_state module -- non-blocking credential state machine.
 
-Covers: CredentialState enum, resolve_credential_state(), trigger_relay_setup(),
-_poll_relay_background(), set_state(), reset_state(),
-get_state(), get_setup_url().
+Covers: CredentialState enum, resolve_credential_state(), set_state(),
+reset_state(), get_state(), get_setup_url().
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -20,7 +19,6 @@ from better_code_review_graph.credential_state import (
     reset_state,
     resolve_credential_state,
     set_state,
-    trigger_relay_setup,
 )
 
 # ---------------------------------------------------------------------------
@@ -35,11 +33,9 @@ def _reset_module_state():
 
     cs._state = CredentialState.AWAITING_SETUP
     cs._setup_url = None
-    cs._active_handle = None
     yield
     cs._state = CredentialState.AWAITING_SETUP
     cs._setup_url = None
-    cs._active_handle = None
 
 
 @pytest.fixture
@@ -267,96 +263,19 @@ class TestCredentialIsolation:
 
 
 # ---------------------------------------------------------------------------
-# trigger_relay_setup
+# trigger_relay_setup removed per spec 2026-05-01-stdio-pure-http-multiuser.md
+# Stdio mode reads creds from env vars only; HTTP mode serves the relay form
+# at <PUBLIC_URL>/authorize. There is no daemon-bridge auto-spawn anymore.
 # ---------------------------------------------------------------------------
 
 
-class TestTriggerRelaySetup:
-    """Tests for trigger_relay_setup -- local HTTP fallback (no remote relay)."""
+class TestNoTriggerRelaySetup:
+    """Regression: ``trigger_relay_setup`` must not exist after the spec."""
 
-    async def test_skips_when_already_configured(self):
-        """Does not trigger relay when state is CONFIGURED."""
-        set_state(CredentialState.CONFIGURED)
-        url = await trigger_relay_setup()
-        assert url is None
-
-    async def test_skips_when_local(self):
-        """Does not trigger relay when state is LOCAL."""
-        set_state(CredentialState.LOCAL)
-        url = await trigger_relay_setup()
-        assert url is None
-
-    async def test_force_spawns_local_form(self):
-        """force=True spawns a local credential form even when CONFIGURED."""
-        set_state(CredentialState.CONFIGURED)
-
-        mock_handle = MagicMock(host="127.0.0.1", port=52201)
-
-        with (
-            patch(
-                "mcp_core.start_local_server_background",
-                new_callable=AsyncMock,
-                return_value=mock_handle,
-                create=True,
-            ) as mock_start,
-            patch("mcp_core.try_open_browser"),
-        ):
-            url = await trigger_relay_setup(force=True)
-            assert url == "http://127.0.0.1:52201/"
-            assert get_state() == CredentialState.SETUP_IN_PROGRESS
-            mock_start.assert_awaited_once()
-
-    async def test_reuses_active_handle(self):
-        """When an active handle already exists, reuse its URL."""
+    def test_trigger_relay_setup_removed(self):
         import better_code_review_graph.credential_state as cs
 
-        set_state(CredentialState.AWAITING_SETUP)
-        cs._active_handle = MagicMock()
-        cs._setup_url = "http://127.0.0.1:52202/"
-
-        with patch(
-            "mcp_core.start_local_server_background",
-            new_callable=AsyncMock,
-            create=True,
-        ) as mock_start:
-            url = await trigger_relay_setup()
-            assert url == "http://127.0.0.1:52202/"
-            mock_start.assert_not_awaited()
-
-    async def test_creates_new_spawn(self):
-        """AWAITING_SETUP with no handle -> spawn local form, open browser."""
-        set_state(CredentialState.AWAITING_SETUP)
-
-        mock_handle = MagicMock(host="127.0.0.1", port=52203)
-
-        with (
-            patch(
-                "mcp_core.start_local_server_background",
-                new_callable=AsyncMock,
-                return_value=mock_handle,
-                create=True,
-            ) as mock_start,
-            patch("mcp_core.try_open_browser") as mock_browser,
-        ):
-            url = await trigger_relay_setup()
-            assert url == "http://127.0.0.1:52203/"
-            assert get_setup_url() == url
-            mock_start.assert_awaited_once()
-            mock_browser.assert_called_once_with(url)
-
-    async def test_relay_setup_failure_returns_none(self):
-        """Relay setup failure returns None and resets state."""
-        set_state(CredentialState.AWAITING_SETUP)
-
-        with patch(
-            "mcp_core.start_local_server_background",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("bind failed"),
-            create=True,
-        ):
-            url = await trigger_relay_setup()
-            assert url is None
-            assert get_state() == CredentialState.AWAITING_SETUP
+        assert not hasattr(cs, "trigger_relay_setup")
 
 
 class TestSaveCredentials:

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -29,7 +29,9 @@ def _call_config_setup_status_sync() -> dict[str, Any]:
 class TestSetupStatusLiveDerivedState:
     """setup_status derives state from live PerPluginStore, not stale _state."""
 
-    def test_returns_configured_when_store_has_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_configured_when_store_has_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """setup_status returns configured when PerPluginStore has cloud keys."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
@@ -47,7 +49,9 @@ class TestSetupStatusLiveDerivedState:
         assert result["state"] == "configured"
         assert "GEMINI_API_KEY" in result["providers_configured"]
 
-    def test_returns_needs_setup_when_store_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_needs_setup_when_store_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """setup_status returns awaiting_setup when store empty and no env vars."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
@@ -93,7 +97,9 @@ class TestSetupStatusLiveDerivedState:
         assert "OPENAI_API_KEY" in result["providers_configured"]
         assert "OPENAI_API_KEY" in result["cloud_keys_in_env"]
 
-    def test_response_includes_providers_configured_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_response_includes_providers_configured_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """setup_status always includes providers_configured key in response."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from better_code_review_graph.server import (
     config,
@@ -355,19 +355,22 @@ class TestConfigTool:
         assert "unknown action" not in str(result).lower()
         assert "state" in result
 
-    async def test_setup_start_action(self):
-        """config setup_start dispatches to relay trigger."""
+    async def test_setup_start_action(self, monkeypatch):
+        """config setup_start in HTTP mode returns the authorize URL.
+
+        After spec 2026-05-01-stdio-pure-http-multiuser.md the daemon-bridge
+        relay-form spawn is gone; the relay form lives on the HTTP server
+        itself at ``<PUBLIC_URL>/authorize``.
+        """
         from better_code_review_graph import credential_state as cs
 
         cs._state = cs.CredentialState.AWAITING_SETUP
-        with patch(
-            "better_code_review_graph.credential_state.trigger_relay_setup",
-            new_callable=AsyncMock,
-            return_value="https://relay.example.com/test",
-        ):
-            result = json.loads(await config(action="setup_start"))
-            assert "unknown action" not in str(result).lower()
-            assert result.get("status") == "setup_started"
+        monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
+
+        result = json.loads(await config(action="setup_start"))
+        assert "unknown action" not in str(result).lower()
+        assert result.get("status") == "setup_started"
+        assert result.get("setup_url") == "https://relay.example.com/authorize"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -7,7 +7,7 @@ unknown action variants, and _maybe_include_setup_hint helper.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -104,28 +104,53 @@ class TestMaybeIncludeSetupHint:
 
 
 class TestSetupStatus:
-    async def test_status_returns_state_info(self):
-        """setup_status returns current state and cloud keys in env."""
-        from better_code_review_graph import credential_state as cs
+    async def test_status_returns_state_info(self, monkeypatch):
+        """setup_status derives `configured` from live env keys (G6 UX fix)."""
         from better_code_review_graph.server import config
 
-        cs._state = CredentialState.CONFIGURED
-        cs._setup_url = None
+        for key in (
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "JINA_AI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key-123")
 
-        result = json.loads(await config(action="setup_status"))
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
+            result = json.loads(await config(action="setup_status"))
         assert result["state"] == "configured"
         assert "cloud_keys_in_env" in result
+        assert "GEMINI_API_KEY" in result["cloud_keys_in_env"]
 
-    async def test_status_with_setup_url(self):
-        """setup_status includes setup_url when set."""
+    async def test_status_with_setup_url(self, monkeypatch):
+        """setup_status includes setup_url when set on the module."""
         from better_code_review_graph import credential_state as cs
         from better_code_review_graph.server import config
 
-        cs._state = CredentialState.SETUP_IN_PROGRESS
+        for key in (
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "JINA_AI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        cs._state = CredentialState.AWAITING_SETUP
         cs._setup_url = "https://relay.example.com/setup"
 
-        result = json.loads(await config(action="setup_status"))
-        assert result["state"] == "setup_in_progress"
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore"
+        ) as mock_store_cls:
+            mock_store_cls.return_value.load.return_value = None
+            result = json.loads(await config(action="setup_status"))
+        assert result["state"] == "awaiting_setup"
         assert result["setup_url"] == "https://relay.example.com/setup"
 
 
@@ -146,52 +171,43 @@ class TestSetupStart:
         assert result["status"] == "already_configured"
         assert "force=true" in result["message"]
 
-    async def test_start_triggers_relay_setup(self):
-        """setup_start triggers relay and returns URL."""
+    async def test_start_returns_authorize_url_in_http_mode(self, monkeypatch):
+        """setup_start returns the HTTP server's /authorize URL when PUBLIC_URL set."""
         from better_code_review_graph import credential_state as cs
         from better_code_review_graph.server import config
 
         cs._state = CredentialState.AWAITING_SETUP
+        monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
 
-        with patch(
-            "better_code_review_graph.credential_state.trigger_relay_setup",
-            new_callable=AsyncMock,
-            return_value="https://relay.example.com/setup#k=abc",
-        ):
-            result = json.loads(await config(action="setup_start"))
-            assert result["status"] == "setup_started"
-            assert result["setup_url"] == "https://relay.example.com/setup#k=abc"
+        result = json.loads(await config(action="setup_start"))
+        assert result["status"] == "setup_started"
+        assert result["setup_url"] == "https://relay.example.com/authorize"
 
-    async def test_start_relay_failure(self):
-        """setup_start returns error when relay fails."""
+    async def test_start_returns_stdio_mode_message_when_no_public_url(
+        self, monkeypatch
+    ):
+        """setup_start in stdio mode (no PUBLIC_URL) returns an env-var hint."""
         from better_code_review_graph import credential_state as cs
         from better_code_review_graph.server import config
 
         cs._state = CredentialState.AWAITING_SETUP
+        monkeypatch.delenv("PUBLIC_URL", raising=False)
 
-        with patch(
-            "better_code_review_graph.credential_state.trigger_relay_setup",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
-            result = json.loads(await config(action="setup_start"))
-            assert result["status"] == "error"
-            assert "Failed" in result["message"]
+        result = json.loads(await config(action="setup_start"))
+        assert result["status"] == "stdio_mode"
+        assert "GEMINI_API_KEY" in result["message"]
 
-    async def test_start_force_overrides_configured(self):
+    async def test_start_force_overrides_configured(self, monkeypatch):
         """setup_start with force=true reconfigures even when CONFIGURED."""
         from better_code_review_graph import credential_state as cs
         from better_code_review_graph.server import config
 
         cs._state = CredentialState.CONFIGURED
+        monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
 
-        with patch(
-            "better_code_review_graph.credential_state.trigger_relay_setup",
-            new_callable=AsyncMock,
-            return_value="https://relay.example.com/new-session",
-        ):
-            result = json.loads(await config(action="setup_start", force=True))
-            assert result["status"] == "setup_started"
+        result = json.loads(await config(action="setup_start", force=True))
+        assert result["status"] == "setup_started"
+        assert result["setup_url"] == "https://relay.example.com/authorize"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.13.0b3"
+version = "3.13.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -111,10 +111,10 @@ dev = [
 requires-dist = [
     { name = "cohere", specifier = ">=6.1.0" },
     { name = "fastmcp", specifier = ">=3.2.4,<4" },
-    { name = "google-genai", specifier = ">=1.73.1" },
+    { name = "google-genai", specifier = ">=1.74.0" },
     { name = "httpx" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b1,<2" },
+    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pydantic-settings" },
@@ -133,7 +133,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "ruff", specifier = ">=0.15.12" },
     { name = "syrupy" },
-    { name = "ty", specifier = ">=0.0.33" },
+    { name = "ty", specifier = ">=0.0.34" },
 ]
 
 [[package]]
@@ -504,7 +504,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.1"
+version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -518,9 +518,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c8/4a8f1de0a3268d526a345b8c74456b3e1e6ffd200982626326cf7ca83e5b/google_genai-1.74.0.tar.gz", hash = "sha256:c4c473cebdeb6e5adbb0639326de66a3a85a2209e0d32de7d66bf05c698abae8", size = 536772, upload-time = "2026-04-29T22:16:35.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2b/539c328b66f7bfef2df869371a1789361228e5a7694ba02a642608367b46/google_genai-1.74.0-py3-none-any.whl", hash = "sha256:87d0b311c67d4b2a0ca741e9fc6891330c29defae81d46d8db41079aa1a3d80a", size = 790433, upload-time = "2026-04-29T22:16:33.979Z" },
 ]
 
 [[package]]
@@ -879,8 +879,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.13.0b1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.13.0b3"
+source = { directory = "../mcp-core/packages/core-py" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -893,9 +893,29 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/33/4c95c7e2387d3561101e831ef6a631b5a8ac981ab2e26d212b67a46cb2a4/n24q02m_mcp_core-1.13.0b1.tar.gz", hash = "sha256:738d997a7dbf7abd22f6cee307bf9e1d163dd08c29437aabb9a6325d8f30f81c", size = 211627, upload-time = "2026-04-30T13:59:39.848Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/ae/899110854eacd4b4900ebccc9d6e8e5674389dd2a89e87e45e2626949999/n24q02m_mcp_core-1.13.0b1-py3-none-any.whl", hash = "sha256:ea477a35e0e2dc7861e47617732e91f81ee876dcb5bf22af211b9cdc62f31bf6", size = 132218, upload-time = "2026-04-30T13:59:38.296Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=47.0.0" },
+    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "filelock", specifier = ">=3.16.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
+    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
+    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty", specifier = ">=0.0.33" },
 ]
 
 [[package]]
@@ -1661,26 +1681,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.33"
+version = "0.0.34"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
-    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements Phase 1.3.G of `~/projects/.superpower/mcp-core/plans/2026-05-01-stdio-pure-http-multiuser.md` (better-code-review-graph plugin).

- Flip `serve_main` default to stdio (drop `MCP_MODE` handling); HTTP via `--http` / `MCP_TRANSPORT=http` / `TRANSPORT_MODE=http` per spec §4.1
- Delete `trigger_relay_setup` function + `_active_handle`/`_close_active_handle`/`_schedule_spawn_cleanup` helpers from `credential_state.py` (mcp-core 1.13.0b4 removed `start_local_server_background`)
- Rename `run_local_server` → `run_http_server` import in `server.py:run_http`
- Update `register_open_relay_tool` call to pass `PUBLIC_URL` (HTTP-only helper after spec)
- Rewrite `setup_start` tool action: HTTP mode returns `<PUBLIC_URL>/authorize`, stdio mode returns env-var hint message
- CRG creds (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `JINA_AI_API_KEY`, `COHERE_API_KEY`) are optional — boot proceeds with local qwen3-embed ONNX fallback when missing
- Bump `n24q02m-mcp-core` to `>=1.13.0b4`

## Test plan

- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run pytest` — 572 passed, 1 skipped, 47 deselected
- [x] Pre-commit hooks (gitleaks, ruff, ty, pytest, commit prefix) — all passed locally

Per spec `2026-05-01-stdio-pure-http-multiuser.md §5.2.1`.