### PR TITLE
feat: docs MCP_RELAY_PASSWORD edge auth subsection

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -175,6 +175,20 @@ Point clients to your server:
 
 On first connection, each user opens the relay form at `https://your-domain.com/authorize` and pastes their cloud-embedding API keys (all optional -- empty submission keeps the user on local ONNX). Credentials are encrypted per-JWT-sub and never shared between users.
 
+### Edge auth: relay password
+
+Public HTTP deployments expose `<your-domain>/authorize` to URL discovery. To prevent random Internet users from accessing the relay form, mint a relay password:
+
+```bash
+openssl rand -hex 32
+# Save in your skret / .env as:
+MCP_RELAY_PASSWORD=<generated-32-byte-hex>
+```
+
+Share this password out-of-band (Signal/email/SMS) with anyone you invite to use your server. They will see a login form when first opening `/authorize`; once logged in, the cookie persists 24 hours.
+
+**Single-user dev exception**: If `PUBLIC_URL=http://localhost:8080`, you can leave `MCP_RELAY_PASSWORD` empty to disable the gate. The server logs a warning if you skip the password with a non-localhost `PUBLIC_URL`.
+
 ## Credential Setup
 
 All API keys are **optional**. The server works with local ONNX embeddings out of the box.

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -145,6 +145,20 @@ Client config:
 
 Each user opens `https://your-domain.com/authorize` once, pastes API keys (or leaves empty for local ONNX), and submits. Credentials are encrypted per-JWT-sub.
 
+### Edge auth: relay password
+
+Public HTTP deployments expose `<your-domain>/authorize` to URL discovery. To prevent random Internet users from accessing the relay form, mint a relay password:
+
+```bash
+openssl rand -hex 32
+# Save in your skret / .env as:
+MCP_RELAY_PASSWORD=<generated-32-byte-hex>
+```
+
+Share this password out-of-band (Signal/email/SMS) with anyone you invite to use your server. They will see a login form when first opening `/authorize`; once logged in, the cookie persists 24 hours.
+
+**Single-user dev exception**: If `PUBLIC_URL=http://localhost:8080`, you can leave `MCP_RELAY_PASSWORD` empty to disable the gate. The server logs a warning if you skip the password with a non-localhost `PUBLIC_URL`.
+
 ## Environment Variables
 
 All environment variables are **optional**. The server works with local ONNX embeddings with zero configuration.


### PR DESCRIPTION
Per mcp-core spec 2026-05-01 §4.2.1 — add edge auth setup guidance to HTTP method docs.