### PR TITLE
feat: add Method overview section (3 vs 1 method clarification)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -6,6 +6,15 @@
 > 1. Set the env var directly in plugin config (Method 1), OR
 > 2. Switch to HTTP mode (Method 5) for browser-based setup.
 
+## Method overview
+
+This plugin supports **1 install method only**: stdio via plugin install (`uvx`/`npx`). Reason: the plugin needs direct host access to your project files (Godot project / repo path) and doesn't ship Docker or HTTP variants.
+
+For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-email-mcp`, `better-telegram-mcp`, `wet-mcp`, `mnemo-mcp`, `imagine-mcp`) support 3 methods:
+1. **Default** -- Plugin install (`uvx`/`npx`) stdio
+2. **Fallback** -- Docker stdio (Windows/macOS PATH issues)
+3. **Recommended** -- Docker HTTP (multi-device, OAuth/relay form, claude.ai web)
+
 ## Prerequisites
 
 - **Python 3.13** (3.14+ is NOT supported)

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -8,6 +8,15 @@
 > 1. Set the env var directly in plugin config (Option 1), OR
 > 2. Switch to HTTP mode (Option 4) for browser-based setup.
 
+## Method overview
+
+This plugin supports **1 install method only**: stdio via plugin install (`uvx`/`npx`). Reason: the plugin needs direct host access to your project files (Godot project / repo path) and doesn't ship Docker or HTTP variants.
+
+For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-email-mcp`, `better-telegram-mcp`, `wet-mcp`, `mnemo-mcp`, `imagine-mcp`) support 3 methods:
+1. **Default** -- Plugin install (`uvx`/`npx`) stdio
+2. **Fallback** -- Docker stdio (Windows/macOS PATH issues)
+3. **Recommended** -- Docker HTTP (multi-device, OAuth/relay form, claude.ai web)
+
 ## Option 1: Claude Code Plugin (Recommended)
 
 Plugin marketplace install runs the server in **pure stdio mode** with optional API key env vars. No daemon-bridge, no auto-spawn, no relay form. Graph storage is local SQLite -- no external graph database required.


### PR DESCRIPTION
User feedback 2026-05-04: docs list Method 1/2/3 in detail but never state up-front the priority hierarchy or which plugins are stdio-only. Adds an explicit overview table near the top of each setup doc making the 6-vs-2 split + default/fallback/recommended ordering clear at a glance.