### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "better-code-review-graph",
   "description": "Persistent incremental knowledge graph for token-efficient code reviews",
   "version": "3.13.0",
+  "userConfig": {
+    "JINA_AI_API_KEY": {
+      "type": "string",
+      "title": "Jina AI API key (optional)",
+      "description": "Optional cloud reranker. Without it, server uses local ONNX. https://jina.ai/api-dashboard/",
+      "sensitive": true,
+      "required": false
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -16,7 +25,8 @@
         "better-code-review-graph"
       ],
       "env": {
-        "MCP_TRANSPORT": "stdio"
+        "MCP_TRANSPORT": "stdio",
+        "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}"
       }
     }
   }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -26,15 +26,28 @@ For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-
 
 Plugin marketplace install runs the server in **pure stdio mode** with optional API key env vars. No daemon-bridge, no auto-spawn, no relay form. The graph is stored locally in SQLite -- no external graph database required.
 
-1. Open Claude Code
-2. Install the plugin:
+### Step 0: Credential prompt
+
+When you run `/plugin install better-code-review-graph@n24q02m-plugins`, Claude Code prompts for the optional field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `JINA_AI_API_KEY` | No | Yes | Optional cloud reranker. Without it, the server uses local ONNX (Qwen3, ~570MB downloaded on first use). https://jina.ai/api-dashboard/ |
+
+Press Enter to skip; the server runs entirely with local ONNX. The sensitive value is stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persists across `/plugin update`. Claude Code substitutes the value into `mcpServers.better-code-review-graph.env.JINA_AI_API_KEY` via `${user_config.JINA_AI_API_KEY}` -- you do not edit `env` manually.
+
+> Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `EMBEDDING_BACKEND`, etc.) are not part of the install prompt; if you need them, add them manually to `mcpServers.better-code-review-graph.env` in your settings.
+
+### Steps
+
+1. Open Claude Code.
+2. Install the plugin (Claude Code prompts for `JINA_AI_API_KEY` -- press Enter to skip):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install better-code-review-graph@n24q02m-plugins
    ```
-3. The server starts automatically when Claude Code launches
-4. The SessionStart hook auto-builds the graph for the current project; PostToolUse updates it after edits
-5. **Optional**: set any of `GEMINI_API_KEY`, `OPENAI_API_KEY`, `JINA_AI_API_KEY`, `COHERE_API_KEY` in the plugin config to enable cloud embedding/reranking. Without keys, the server runs in pure local ONNX mode (Qwen3 embedding, ~570MB downloaded on first use).
+3. The server starts automatically when Claude Code launches.
+4. The SessionStart hook auto-builds the graph for the current project; PostToolUse updates it after edits.
 
 ## Credential Setup
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -21,6 +21,18 @@ For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-
 
 Plugin marketplace install runs the server in **pure stdio mode** with optional API key env vars. No daemon-bridge, no auto-spawn, no relay form. Graph storage is local SQLite -- no external graph database required.
 
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the optional field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Source |
+|:------|:---------|:----------|:-------|
+| `JINA_AI_API_KEY` | No | Yes | https://jina.ai/api-dashboard/ |
+
+Press Enter to skip; the server falls back to local ONNX. The plugin manifest substitutes the value into `mcpServers.better-code-review-graph.env.JINA_AI_API_KEY` via `${user_config.JINA_AI_API_KEY}` and stores the sensitive value in the system keychain (persists across `/plugin update`). You do not edit `env` manually.
+
+### Steps
+
 ```bash
 # Install from marketplace (includes skills: /refactor-check, /review-delta, /review-pr + hooks)
 /plugin marketplace add n24q02m/claude-plugins
@@ -29,7 +41,7 @@ Plugin marketplace install runs the server in **pure stdio mode** with optional 
 
 The plugin includes SessionStart and PostToolUse hooks that auto-build and auto-update the code graph.
 
-**Optional**: set any of `GEMINI_API_KEY`, `OPENAI_API_KEY`, `JINA_AI_API_KEY`, `COHERE_API_KEY` in the plugin config to enable cloud embedding/reranking. Without keys, the server runs in pure local ONNX mode (Qwen3 embedding, ~570MB downloaded on first use).
+> Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `EMBEDDING_BACKEND`, etc.) are not part of the `userConfig` prompt; add them manually to `mcpServers.better-code-review-graph.env` in your settings if needed.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

- Add `userConfig.JINA_AI_API_KEY` (sensitive, optional) so `/plugin install` prompts for the optional Jina reranker key. Skippable; the server falls back to bundled local Qwen3 ONNX (~570MB downloaded on first use).
- Substitute via `${user_config.JINA_AI_API_KEY}` into `mcpServers.better-code-review-graph.env`.
- Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `EMBEDDING_BACKEND`) remain manual `mcpServers` config.
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] `/plugin install` prompts for `JINA_AI_API_KEY` (skippable)
- [ ] Local ONNX path works when prompt is skipped

Generated with [Claude Code](https://claude.com/claude-code)