### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in _sub_data_dir

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -160,7 +160,10 @@ def _sub_data_dir(sub: str) -> Path:
     state never leak across users sharing the same deployment.
     """
     base = Path(os.environ.get("CRG_DATA_DIR", str(Path.home() / ".crg")))
-    d = base / "subs" / sub
+    subs_dir = (base / "subs").resolve()
+    d = (subs_dir / sub).resolve()
+    if not d.is_relative_to(subs_dir):
+        raise ValueError("Invalid subject identifier: path traversal detected")
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_sub_data_dir_valid_sub(tmp_path, monkeypatch):
+    import sys
+
+    sys.modules["mcp_core"] = MagicMock()
+    sys.modules["mcp_core.storage"] = MagicMock()
+    sys.modules["mcp_core.storage.per_plugin_store"] = MagicMock()
+
+    from better_code_review_graph.credential_state import _sub_data_dir
+
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    sub = "user123"
+    result = _sub_data_dir(sub)
+    expected_path = tmp_path / "subs" / sub
+    assert result.resolve() == expected_path.resolve()
+    assert result.exists()
+    assert result.is_dir()
+
+
+def test_sub_data_dir_path_traversal(tmp_path, monkeypatch):
+    import sys
+
+    sys.modules["mcp_core"] = MagicMock()
+    sys.modules["mcp_core.storage"] = MagicMock()
+    sys.modules["mcp_core.storage.per_plugin_store"] = MagicMock()
+
+    from better_code_review_graph.credential_state import _sub_data_dir
+
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    malicious_subs = [
+        "../etc/passwd",
+        "../../tmp",
+        "user/../../etc",
+        "/etc/passwd",
+    ]
+    for sub in malicious_subs:
+        with pytest.raises(
+            ValueError, match="Invalid subject identifier: path traversal detected"
+        ):
+            _sub_data_dir(sub)
+
+
+def test_sub_data_dir_nested_valid(tmp_path, monkeypatch):
+    import sys
+
+    sys.modules["mcp_core"] = MagicMock()
+    sys.modules["mcp_core.storage"] = MagicMock()
+    sys.modules["mcp_core.storage.per_plugin_store"] = MagicMock()
+
+    from better_code_review_graph.credential_state import _sub_data_dir
+
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    sub = "group/user"
+    result = _sub_data_dir(sub)
+    expected_path = tmp_path / "subs" / "group" / "user"
+    assert result.resolve() == expected_path.resolve()
+    assert result.exists()
+    assert result.is_dir()


### PR DESCRIPTION
Fix path traversal vulnerability in `_sub_data_dir`.

Sanitize the user-provided `sub` parameter by using `Path.resolve()` and `Path.is_relative_to()` to ensure the generated directory path remains safely inside the designated user storage directory. Add a regression test to verify malicious payloads are blocked.

---
*PR created automatically by Jules for task [13743673433892293909](https://jules.google.com/task/13743673433892293909) started by @n24q02m*