### PR TITLE
feat: note CC scope-by-endpoint mutual exclusivity rule

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -15,6 +15,8 @@ For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-
 2. **Fallback** -- Docker stdio (Windows/macOS PATH issues)
 3. **Recommended** -- Docker HTTP (multi-device, OAuth/relay form, claude.ai web)
 
+> **⚠️ Mutually exclusive — pick ONE per plugin (applies to those 6 plugins, not crg)**: For the 6 plugins above that offer Method 2 (Docker stdio) or Method 3 (HTTP), do NOT stack `/plugin install` AND a user `mcpServers` override — both would load simultaneously and create duplicate entries (plugin's `npx`/`uvx` stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Choosing Method 2 or Method 3 means losing the plugin's skills/agents/hooks/commands. `better-code-review-graph` only offers Method 1, so this note is informational only — there is no Docker stdio or HTTP variant to conflict with the plugin install here.
+
 ## Prerequisites
 
 - **Python 3.13** (3.14+ is NOT supported)

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -17,6 +17,8 @@ For comparison, the other 6 plugins in this stack (`better-notion-mcp`, `better-
 2. **Fallback** -- Docker stdio (Windows/macOS PATH issues)
 3. **Recommended** -- Docker HTTP (multi-device, OAuth/relay form, claude.ai web)
 
+> **⚠️ Mutually exclusive — pick ONE per plugin (applies to those 6 plugins, not crg)**: For the 6 plugins above that offer Method 2 (Docker stdio) or Method 3 (HTTP), do NOT stack `/plugin install` AND a user `mcpServers` override — both would load simultaneously and create duplicate entries (plugin's `npx`/`uvx` stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Choosing Method 2 or Method 3 means losing the plugin's skills/agents/hooks/commands. `better-code-review-graph` only offers Method 1, so this note is informational only — there is no Docker stdio or HTTP variant to conflict with the plugin install here.
+
 ## Option 1: Claude Code Plugin (Recommended)
 
 Plugin marketplace install runs the server in **pure stdio mode** with optional API key env vars. No daemon-bridge, no auto-spawn, no relay form. Graph storage is local SQLite -- no external graph database required.


### PR DESCRIPTION
## Summary

- This plugin only ships Method 1 (stdio plugin install), so the mutual-exclusivity rule for the other 6 plugins (`npx`/`uvx` vs `docker` vs HTTP URL = three distinct endpoints) is informational here.
- Add the warning callout to the Method overview anyway so users picking between the 6 HTTP-capable plugins understand why stacking is wrong.

## Test plan

- [x] Read both updated docs end-to-end for prose flow
- [x] Pre-commit hooks pass
- [ ] CI green before admin merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)