### PR TITLE
[FIX] Unused 'annotations' import in relay_schema.py

### DIFF
--- a/src/better_code_review_graph/relay_schema.py
+++ b/src/better_code_review_graph/relay_schema.py
@@ -8,8 +8,6 @@ runtime, but older wheels of `n24q02m-mcp-core` ship a stricter
 mcp-core catches up; see tracker: see docs/migration-from-mcp-relay-core.md.
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 RELAY_SCHEMA: dict[str, Any] = {


### PR DESCRIPTION
Removed the redundant 'from __future__ import annotations' import from 'src/better_code_review_graph/relay_schema.py'. This import is unnecessary given the project's Python 3.13 requirement and the lack of forward references in this file. Verified the fix with ruff and confirmed the file is still importable.

---
*PR created automatically by Jules for task [6701365134945081723](https://jules.google.com/task/6701365134945081723) started by @n24q02m*