### PR TITLE
[TEST] Missing error path test for graph build/update

### DIFF
--- a/tests/test_tools_build_error_coverage.py
+++ b/tests/test_tools_build_error_coverage.py
@@ -1,14 +1,8 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-
-# Mock dependencies before importing the module under test
-class MockModule(MagicMock):
-    def __getattr__(self, name):
-        return MagicMock()
-
-
-modules = [
+# Surgical mocking only during import to avoid poisoning CI environment
+modules_to_mock = [
     "networkx",
     "tree_sitter",
     "tree_sitter_language_pack",
@@ -33,10 +27,32 @@ modules = [
     "pygments.formatters",
 ]
 
-for mod in modules:
-    sys.modules[mod] = MockModule()
 
-from better_code_review_graph.tools import build_or_update_graph  # noqa: E402
+class MockModule(MagicMock):
+    def __getattr__(self, name):
+        return MagicMock()
+
+
+def _get_build_or_update_graph():
+    # If already available, just return it
+    try:
+        from better_code_review_graph.tools import build_or_update_graph
+
+        return build_or_update_graph
+    except (ImportError, ModuleNotFoundError):
+        # Mock only the missing ones
+        mocks = {}
+        for mod in modules_to_mock:
+            if mod not in sys.modules:
+                mocks[mod] = MockModule()
+
+        with patch.dict(sys.modules, mocks):
+            from better_code_review_graph.tools import build_or_update_graph
+
+            return build_or_update_graph
+
+
+build_or_update_graph = _get_build_or_update_graph()
 
 
 def test_build_or_update_graph_full_rebuild_error():
@@ -83,4 +99,7 @@ if __name__ == "__main__":
         print("All isolated tests passed!")
     except Exception as e:
         print(f"Tests failed: {e}")
+        import traceback
+
+        traceback.print_exc()
         sys.exit(1)

--- a/tests/test_tools_build_error_coverage.py
+++ b/tests/test_tools_build_error_coverage.py
@@ -1,6 +1,42 @@
+import sys
 from unittest.mock import MagicMock, patch
 
-from better_code_review_graph.tools import build_or_update_graph
+
+# Mock dependencies before importing the module under test
+class MockModule(MagicMock):
+    def __getattr__(self, name):
+        return MagicMock()
+
+
+modules = [
+    "networkx",
+    "tree_sitter",
+    "tree_sitter_language_pack",
+    "watchdog",
+    "watchdog.observers",
+    "watchdog.events",
+    "mcp",
+    "mcp.server",
+    "mcp.server.fastmcp",
+    "fastmcp",
+    "qwen3_embed",
+    "cohere",
+    "google.genai",
+    "openai",
+    "httpx",
+    "pydantic_settings",
+    "n24q02m_mcp_core",
+    "n24q02m_mcp_core.storage",
+    "n24q02m_mcp_core.storage.per_plugin_store",
+    "pygments",
+    "pygments.lexers",
+    "pygments.formatters",
+]
+
+for mod in modules:
+    sys.modules[mod] = MockModule()
+
+from better_code_review_graph.tools import build_or_update_graph  # noqa: E402
 
 
 def test_build_or_update_graph_full_rebuild_error():
@@ -38,3 +74,13 @@ def test_build_or_update_graph_incremental_update_error():
                 in result["error"]
             )
             mock_store.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    try:
+        test_build_or_update_graph_full_rebuild_error()
+        test_build_or_update_graph_incremental_update_error()
+        print("All isolated tests passed!")
+    except Exception as e:
+        print(f"Tests failed: {e}")
+        sys.exit(1)


### PR DESCRIPTION
This PR adds unit test coverage for the error-handling path in the `build_or_update_graph` tool. 

Key changes:
- Created `tests/test_tools_build_error_coverage.py`.
- Implemented isolated unit tests that mock the `full_build` and `incremental_update` functions to raise exceptions.
- Used `sys.modules` to mock heavy/missing dependencies (like `networkx`, `tree-sitter`, etc.) to ensure the test can run in environments without full project dependencies.
- Verified that `build_or_update_graph` correctly catches exceptions, returns an error status, and ensures the `GraphStore` is closed.

---
*PR created automatically by Jules for task [2042521123156232222](https://jules.google.com/task/2042521123156232222) started by @n24q02m*