### PR TITLE
[FIX] Unused 'annotations' import in graph.py

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -5,8 +5,6 @@ edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_O
 Supports impact-radius queries and subgraph extraction.
 """
 
-from __future__ import annotations
-
 import json
 import sqlite3
 import threading
@@ -131,7 +129,7 @@ class GraphStore:
         self._nxg_cache: nx.DiGraph | None = None
         self._cache_lock = threading.Lock()
 
-    def __enter__(self) -> GraphStore:
+    def __enter__(self) -> "GraphStore":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/better_code_review_graph/graph.py` to align with the project's Python 3.13 requirement. Quoted the self-referencing `GraphStore` type hint in `__enter__` to ensure compatibility with static analysis tools after removing the future import.

---
*PR created automatically by Jules for task [16737136466741920267](https://jules.google.com/task/16737136466741920267) started by @n24q02m*