### PR TITLE
[TEST] Missing error path test for _list_kinds_in_graph

### DIFF
--- a/tests/test_kinds_error_path.py
+++ b/tests/test_kinds_error_path.py
@@ -1,0 +1,12 @@
+from unittest.mock import MagicMock
+from better_code_review_graph.tools import _list_kinds_in_graph
+
+def test_list_kinds_in_graph_returns_empty_on_exception():
+    """Verify that _list_kinds_in_graph returns an empty list when an exception occurs."""
+    bad_store = MagicMock()
+    # Mocking the execute method to raise an exception
+    bad_store._conn.execute.side_effect = Exception("Database error")
+
+    result = _list_kinds_in_graph(bad_store)
+
+    assert result == []

--- a/tests/test_list_kinds_coverage.py
+++ b/tests/test_list_kinds_coverage.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+from better_code_review_graph.tools import _list_kinds_in_graph
+
+
+def test_list_kinds_in_graph_success():
+    """Verify that _list_kinds_in_graph returns the correct kinds on success."""
+    mock_store = MagicMock()
+    mock_execute = mock_store._conn.execute.return_value
+    mock_execute.fetchall.return_value = [{"kind": "Class"}, {"kind": "Function"}]
+
+    result = _list_kinds_in_graph(mock_store)
+
+    assert result == ["Class", "Function"]
+    mock_store._conn.execute.assert_called_once_with(
+        "SELECT DISTINCT kind FROM nodes ORDER BY kind"
+    )
+
+
+def test_list_kinds_in_graph_execute_exception():
+    """Verify that _list_kinds_in_graph returns an empty list if execute() raises an exception."""
+    mock_store = MagicMock()
+    mock_store._conn.execute.side_effect = RuntimeError("SQL Error")
+
+    result = _list_kinds_in_graph(mock_store)
+
+    assert result == []
+
+
+def test_list_kinds_in_graph_fetchall_exception():
+    """Verify that _list_kinds_in_graph returns an empty list if fetchall() raises an exception."""
+    mock_store = MagicMock()
+    mock_execute = mock_store._conn.execute.return_value
+    mock_execute.fetchall.side_effect = Exception("Fetch Error")
+
+    result = _list_kinds_in_graph(mock_store)
+
+    assert result == []
+
+
+def test_list_kinds_in_graph_processing_exception():
+    """Verify that _list_kinds_in_graph returns an empty list if an exception occurs during list comprehension."""
+    mock_store = MagicMock()
+    mock_execute = mock_store._conn.execute.return_value
+    # Returning rows missing the 'kind' key will trigger a KeyError in the list comprehension
+    mock_execute.fetchall.return_value = [{"not_kind": "foo"}]
+
+    result = _list_kinds_in_graph(mock_store)
+
+    assert result == []


### PR DESCRIPTION
I have added a new test file `tests/test_list_kinds_coverage.py` that provides comprehensive coverage for the `_list_kinds_in_graph` function in `src/better_code_review_graph/tools.py`.

The tests specifically target the error paths by mocking the database store to raise exceptions at different points (execute, fetchall, and result processing). This ensures that the `try...except` block correctly handles these failures by returning an empty list instead of propagating the error.

Verified the new tests and ensured no regressions using a custom test runner that mocks project dependencies suitable for the sandbox environment.

---
*PR created automatically by Jules for task [8747981646035627037](https://jules.google.com/task/8747981646035627037) started by @n24q02m*