### PR TITLE
[FIX] Unused 'annotations' import in tools.py

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -12,8 +12,6 @@ Exposes 9 tools:
 9. find_large_functions   - find oversized functions/classes by line count
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
Removed the unused `from __future__ import annotations` import from `src/better_code_review_graph/tools.py`.

Since the project strictly requires Python 3.13 (as specified in `pyproject.toml`), this directive is redundant for postponed evaluation of annotations. Its removal does not affect the runtime logic or type checking.

Verified the fix by:
- Running `ruff check` to ensure no linting issues.
- Running `ruff format` to maintain code style.
- Running unit and functional tests in `tests/test_tools.py` and `tests/test_tools_full.py` using an isolated test runner to handle environment-specific dependencies. All tests passed.

---
*PR created automatically by Jules for task [15427895961293615587](https://jules.google.com/task/15427895961293615587) started by @n24q02m*