### PR TITLE
fix: bump python-multipart to 0.0.27 (CVE-2026-42561 HIGH)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.15.1b1"
+version = "3.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -1263,11 +1263,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `python-multipart` 0.0.26 → 0.0.27 to patch GHSA-pp6c-gr5w-3c5g / CVE-2026-42561 (HIGH, CVSS 7.5).
- DoS via unbounded multipart part headers (CWE-770) in `MultipartParser`. Transitive via `mcp` / `fastmcp` / `n24q02m-mcp-core`.
- Lock regenerated with `UV_NO_SOURCES=1` to prevent `[tool.uv.sources]` directory pin leaking into Docker build (`feedback_uv_lock_docker_trap.md`).
- Closes Dependabot alert #19 (Dependabot's auto-PR failed because of `[tool.uv.sources]` path dep — manual bump required).

## Test plan
- [x] `UV_NO_SOURCES=1 uv lock --upgrade-package python-multipart` → only python-multipart row + project version drift (`3.15.1b1` → `3.15.1`) updated.
- [x] `grep -c "source = { directory" uv.lock` returns 0.
- [ ] CI green on this branch (Lint & Test 3 OS + CodeQL + Socket + Dependency Review + GitGuardian).
- [ ] Dependabot alert auto-closes after merge.