### PR TITLE
feat: Phase 2 Task 0 — alembic baseline + Phase 1 summary stamp target

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,46 @@
+# Alembic configuration for better-code-review-graph.
+#
+# The database URL is provided at runtime by GraphStore via
+# Config.set_main_option("sqlalchemy.url", ...). Tests can do the same.
+
+[alembic]
+script_location = %(here)s/migrations
+prepend_sys_path = .
+path_separator = os
+sqlalchemy.url =
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,67 @@
+"""Alembic environment for better-code-review-graph.
+
+The SQLAlchemy URL is supplied at runtime by ``GraphStore._init_schema()``
+(via ``Config.set_main_option("sqlalchemy.url", ...)``) so the same env.py
+is used for both production upgrades and pytest fixtures. We therefore do
+not read a URL from ``alembic.ini`` — the ini value is intentionally empty.
+
+Autogenerate is not used: migrations in this project are hand-authored
+because the schema is owned by ``graph.py:_SCHEMA_SQL`` (the legacy
+bootstrap kept as a smoke comparator) and we want the migration files to
+be auditable line-for-line against that constant.
+"""
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# Alembic Config object — values come from alembic.ini plus runtime
+# overrides set by GraphStore._init_schema().
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# No declarative metadata: schema is hand-authored in versions/.
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (emit SQL to stdout)."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode against a live SQLite connection."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            # SQLite needs render_as_batch for ALTER TABLE in future revisions.
+            render_as_batch=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/001_baseline.py
+++ b/migrations/versions/001_baseline.py
@@ -1,0 +1,140 @@
+"""Baseline schema (Phase 2 Task 0).
+
+This migration mirrors ``better_code_review_graph.graph._SCHEMA_SQL`` exactly
+so that fresh databases created via alembic are byte-equivalent to those
+created by the legacy ``executescript(_SCHEMA_SQL)`` bootstrap. ``_SCHEMA_SQL``
+remains as a smoke comparator + safety net for one release; alembic is now
+authoritative on fresh DBs.
+
+The schema covers:
+
+* ``nodes`` — 19 columns (15 original + 4 Phase 1 summary columns
+  ``summary``, ``summary_provider``, ``source_hash``, ``source_text``).
+* ``edges`` — 8 columns.
+* ``metadata`` — 2 columns.
+* 7 named indexes (``idx_nodes_file/kind/qualified`` and
+  ``idx_edges_source/target/kind/file``).
+
+The eighth index ``idx_nodes_source_hash`` is intentionally NOT created
+here. It is created by the runtime helper
+``GraphStore._ensure_summary_columns()`` (kept as a defensive idempotent
+guard for any DB created between Phase 1 ship and alembic adoption). The
+hand-authored 002 migration also stays a no-op for the same reason.
+
+Revision ID: 001
+Revises:
+Create Date: 2026-05-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "001"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the baseline graph schema (nodes, edges, metadata + indexes)."""
+    op.create_table(
+        "nodes",
+        sa.Column(
+            "id",
+            sa.Integer(),
+            primary_key=True,
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("qualified_name", sa.Text(), nullable=False, unique=True),
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column("line_start", sa.Integer(), nullable=True),
+        sa.Column("line_end", sa.Integer(), nullable=True),
+        sa.Column("language", sa.Text(), nullable=True),
+        sa.Column("parent_name", sa.Text(), nullable=True),
+        sa.Column("params", sa.Text(), nullable=True),
+        sa.Column("return_type", sa.Text(), nullable=True),
+        sa.Column("modifiers", sa.Text(), nullable=True),
+        sa.Column(
+            "is_test",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("file_hash", sa.Text(), nullable=True),
+        sa.Column(
+            "extra",
+            sa.Text(),
+            nullable=True,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("updated_at", sa.Float(), nullable=False),
+        # Phase 1 v1.6.x summary columns — nullable, no defaults.
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("summary_provider", sa.Text(), nullable=True),
+        sa.Column("source_hash", sa.Text(), nullable=True),
+        sa.Column("source_text", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "edges",
+        sa.Column(
+            "id",
+            sa.Integer(),
+            primary_key=True,
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("source_qualified", sa.Text(), nullable=False),
+        sa.Column("target_qualified", sa.Text(), nullable=False),
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column(
+            "line",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "extra",
+            sa.Text(),
+            nullable=True,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("updated_at", sa.Float(), nullable=False),
+    )
+
+    op.create_table(
+        "metadata",
+        sa.Column("key", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+    )
+
+    op.create_index("idx_nodes_file", "nodes", ["file_path"])
+    op.create_index("idx_nodes_kind", "nodes", ["kind"])
+    op.create_index("idx_nodes_qualified", "nodes", ["qualified_name"])
+    op.create_index("idx_edges_source", "edges", ["source_qualified"])
+    op.create_index("idx_edges_target", "edges", ["target_qualified"])
+    op.create_index("idx_edges_kind", "edges", ["kind"])
+    op.create_index("idx_edges_file", "edges", ["file_path"])
+
+
+def downgrade() -> None:
+    """Drop indexes and tables in reverse creation order."""
+    op.drop_index("idx_edges_file", table_name="edges")
+    op.drop_index("idx_edges_kind", table_name="edges")
+    op.drop_index("idx_edges_target", table_name="edges")
+    op.drop_index("idx_edges_source", table_name="edges")
+    op.drop_index("idx_nodes_qualified", table_name="nodes")
+    op.drop_index("idx_nodes_kind", table_name="nodes")
+    op.drop_index("idx_nodes_file", table_name="nodes")
+
+    op.drop_table("metadata")
+    op.drop_table("edges")
+    op.drop_table("nodes")

--- a/migrations/versions/002_summary_columns.py
+++ b/migrations/versions/002_summary_columns.py
@@ -1,0 +1,44 @@
+"""Phase 1 summary columns recorded as a no-op stamp target.
+
+Phase 1 v1.6.x added four summary columns (``summary``, ``summary_provider``,
+``source_hash``, ``source_text``) to the ``nodes`` table. The Phase 1
+implementation shipped these by extending the inline ``_SCHEMA_SQL`` constant
+plus an idempotent runtime helper ``GraphStore._ensure_summary_columns``;
+alembic was not wired up at the time.
+
+This revision exists purely so legacy DBs created by that helper can be
+``alembic stamp 002``-ed before being upgraded — without it, alembic would
+walk back to the baseline and try to re-create columns that already exist.
+
+The baseline migration (``001``) already includes these columns in its
+``CREATE TABLE nodes`` statement, so on a fresh DB upgrade chain
+001 -> 002 leaves the schema unchanged. Both ``upgrade`` and ``downgrade``
+are intentional no-ops.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "002"
+down_revision: str | Sequence[str] | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """No-op: columns already defined in 001_baseline.
+
+    Kept as a stamp target for legacy DBs created by Phase 1 v1.6.x's
+    ``GraphStore._ensure_summary_columns`` helper before alembic adoption.
+    """
+    pass
+
+
+def downgrade() -> None:
+    """No-op: we never want to remove the summary columns."""
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydantic-settings",
     "n24q02m-mcp-core>=1.14.0,<2",
     "Pygments>=2.20.0",
+    "alembic>=1.14.0,<2",
 ]
 
 [project.scripts]
@@ -50,6 +51,13 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/better_code_review_graph"]
+
+# Ship the alembic migrations directory inside the installed wheel as the
+# top-level package ``better_code_review_graph_migrations`` so that
+# ``GraphStore._run_alembic_upgrade`` can locate it via importlib.resources
+# regardless of the install location.
+[tool.hatch.build.targets.wheel.force-include]
+"migrations" = "better_code_review_graph_migrations"
 
 [tool.ruff]
 line-length = 88

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -30,22 +30,44 @@ def _resolve_migrations_dir() -> Path:
     * **Editable / source checkout**: walk up from this file to the repo
       root and use ``./migrations``.
 
-    Falling back silently is fine — the test suite exercises the source
-    layout and the Docker build exercises the installed-wheel layout.
+    On total failure (neither layout resolves to an existing ``env.py``),
+    raise :class:`RuntimeError` with both attempted paths in the message
+    so the failure is observable rather than silently degrading to a
+    junk path that alembic would later reject.
     """
+    attempted: list[str] = []
+
+    # Layout 1: installed wheel — force-included as a top-level resource
+    # directory.  ``importlib.resources.files`` returns a ``MultiplexedPath``
+    # whose ``__str__`` is the *repr* (not a real filesystem path), so we
+    # must NOT do ``Path(str(ref))``.  Instead, ``ref.joinpath("env.py")``
+    # returns a real ``pathlib.Path`` for filesystem-backed force-included
+    # resources, and ``.parent`` gives us the on-disk directory directly
+    # without the temp-directory copy that ``importlib.resources.as_file``
+    # would otherwise materialise (and tear down on context-manager exit).
     try:
         from importlib.resources import files as _files
 
         ref = _files("better_code_review_graph_migrations")
-        candidate = Path(str(ref))
-        if (candidate / "env.py").is_file():
-            return candidate
-    except (ModuleNotFoundError, FileNotFoundError, TypeError):
-        pass
+        env_py = ref.joinpath("env.py")
+        if isinstance(env_py, Path) and env_py.is_file():
+            return Path(env_py).parent
+        attempted.append(
+            f"installed package: env.py not found via importlib.resources at {ref!r}"
+        )
+    except ModuleNotFoundError as exc:
+        attempted.append(f"installed package import failed: {exc}")
 
-    # Source checkout fallback: src/better_code_review_graph/graph.py ->
-    # repo_root/migrations.
-    return Path(__file__).resolve().parent.parent.parent / "migrations"
+    # Layout 2: editable / source checkout. src/better_code_review_graph/
+    # graph.py -> repo_root/migrations.
+    src_fallback = Path(__file__).resolve().parent.parent.parent / "migrations"
+    if (src_fallback / "env.py").is_file():
+        return src_fallback
+    attempted.append(f"source checkout: {src_fallback} (env.py missing)")
+
+    raise RuntimeError(
+        "Could not locate alembic migrations directory. Tried: " + "; ".join(attempted)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +218,7 @@ class GraphStore:
     def _run_alembic_upgrade(self) -> None:
         """Bring ``self.db_path`` to alembic head before legacy bootstrap.
 
-        Three cases are handled:
+        Four cases are handled:
 
         * Empty DB (no tables) — alembic creates everything from scratch.
         * Legacy DB created by Phase 1's ``executescript(_SCHEMA_SQL)`` +
@@ -205,12 +227,19 @@ class GraphStore:
           revision ``002`` before upgrading so the baseline ``CREATE TABLE``
           statements are skipped.
         * DB already managed by alembic — ``upgrade("head")`` is a no-op.
+        * DB recorded at a revision the package does not ship (user
+          fast-forwarded by hand, or the package was downgraded).  We
+          re-raise as a :class:`RuntimeError` with a human-readable
+          recovery hint instead of leaking an opaque
+          ``alembic.util.exc.CommandError``.
 
         Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
         only loaded when a ``GraphStore`` is actually instantiated.
         """
         from alembic import command
         from alembic.config import Config
+        from alembic.script import ScriptDirectory
+        from alembic.util.exc import CommandError
 
         migrations_dir = _resolve_migrations_dir()
         cfg = Config()
@@ -241,7 +270,28 @@ class GraphStore:
             if needs_stamp:
                 command.stamp(cfg, "002")
 
-        command.upgrade(cfg, "head")
+        try:
+            command.upgrade(cfg, "head")
+        except CommandError as exc:
+            # Most likely cause: ``alembic_version`` references a revision
+            # this package does not ship.  Re-raise with the unknown
+            # revision and the local head spelt out so the operator knows
+            # whether to downgrade the package or recreate the DB.
+            recorded: str | None
+            try:
+                row = self._conn.execute(
+                    "SELECT version_num FROM alembic_version"
+                ).fetchone()
+                recorded = row[0] if row else None
+            except sqlite3.Error:
+                recorded = None
+            head = ScriptDirectory.from_config(cfg).get_current_head()
+            raise RuntimeError(
+                f"Graph DB at {self.db_path} reports alembic revision "
+                f"{recorded!r} which is not shipped with this version of "
+                f"better-code-review-graph (head={head!r}). Either downgrade "
+                "the package or recreate the DB."
+            ) from exc
 
     def _ensure_summary_columns(self) -> None:
         """Backfill Phase 1 v1.6.x summary columns on pre-existing DBs.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -17,6 +17,37 @@ import networkx as nx
 
 from .parser import EdgeInfo, NodeInfo
 
+
+def _resolve_migrations_dir() -> Path:
+    """Locate the ``migrations`` directory shipped with this package.
+
+    Two layouts are supported:
+
+    * **Installed wheel**: the directory is force-included as the
+      top-level ``better_code_review_graph_migrations`` package via Hatch
+      ``shared-data`` (see ``pyproject.toml``). We resolve it through
+      ``importlib.resources``.
+    * **Editable / source checkout**: walk up from this file to the repo
+      root and use ``./migrations``.
+
+    Falling back silently is fine — the test suite exercises the source
+    layout and the Docker build exercises the installed-wheel layout.
+    """
+    try:
+        from importlib.resources import files as _files
+
+        ref = _files("better_code_review_graph_migrations")
+        candidate = Path(str(ref))
+        if (candidate / "env.py").is_file():
+            return candidate
+    except (ModuleNotFoundError, FileNotFoundError, TypeError):
+        pass
+
+    # Source checkout fallback: src/better_code_review_graph/graph.py ->
+    # repo_root/migrations.
+    return Path(__file__).resolve().parent.parent.parent / "migrations"
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -152,9 +183,65 @@ class GraphStore:
         self.close()
 
     def _init_schema(self) -> None:
+        # Alembic is now authoritative on fresh DBs (Phase 2 Task 0).
+        # ``_SCHEMA_SQL`` remains as a smoke comparator + safety net for
+        # one release, and ``_ensure_summary_columns`` is the defensive
+        # idempotent guard for any DB created between Phase 1 ship and
+        # alembic adoption. Both are intentionally retained.
+        self._run_alembic_upgrade()
         self._conn.executescript(_SCHEMA_SQL)
         self._conn.commit()
         self._ensure_summary_columns()
+
+    def _run_alembic_upgrade(self) -> None:
+        """Bring ``self.db_path`` to alembic head before legacy bootstrap.
+
+        Three cases are handled:
+
+        * Empty DB (no tables) — alembic creates everything from scratch.
+        * Legacy DB created by Phase 1's ``executescript(_SCHEMA_SQL)`` +
+          ``_ensure_summary_columns`` (so it already has ``nodes``/``edges``/
+          ``metadata`` but no ``alembic_version`` table) — we stamp it to
+          revision ``002`` before upgrading so the baseline ``CREATE TABLE``
+          statements are skipped.
+        * DB already managed by alembic — ``upgrade("head")`` is a no-op.
+
+        Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
+        only loaded when a ``GraphStore`` is actually instantiated.
+        """
+        from alembic import command
+        from alembic.config import Config
+
+        migrations_dir = _resolve_migrations_dir()
+        cfg = Config()
+        cfg.set_main_option("script_location", str(migrations_dir))
+        cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
+
+        # Detect "legacy DB": pre-existing structural tables but alembic
+        # has not yet recorded a head revision. Two sub-cases:
+        #   1. ``alembic_version`` table is missing entirely.
+        #   2. ``alembic_version`` exists but has no row (an interrupted
+        #      prior run, or a test fixture that touched the DB before
+        #      alembic was wired up).
+        # In both cases we stamp at ``002`` so the baseline ``CREATE
+        # TABLE`` is skipped on the subsequent ``upgrade("head")``.
+        existing = {
+            row[0]
+            for row in self._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        if "nodes" in existing:
+            needs_stamp = "alembic_version" not in existing
+            if not needs_stamp:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM alembic_version"
+                ).fetchone()
+                needs_stamp = row[0] == 0
+            if needs_stamp:
+                command.stamp(cfg, "002")
+
+        command.upgrade(cfg, "head")
 
     def _ensure_summary_columns(self) -> None:
         """Backfill Phase 1 v1.6.x summary columns on pre-existing DBs.

--- a/tests/test_alembic_baseline.py
+++ b/tests/test_alembic_baseline.py
@@ -1,21 +1,29 @@
 """Tests for the Alembic baseline migration (Phase 2 Task 0).
 
-These tests exercise four distinct paths:
+These tests exercise multiple distinct paths:
 
 * (a) Fresh DB created via ``GraphStore`` reaches alembic head and contains
   every table, index, and Phase 1 summary column from ``_SCHEMA_SQL``.
 * (b) Re-initialising ``GraphStore`` on the same DB is idempotent.
 * (c) ``downgrade("base")`` followed by ``upgrade("head")`` round-trips
   cleanly without orphaning tables, indexes, or columns.
-* (d) A synthetic legacy DB that already has the Phase 1 columns (because
-  it was created by ``_SCHEMA_SQL`` + ``_ensure_summary_columns``) can be
-  stamped at revision ``002`` and then upgraded to head without DDL
-  conflict.
+* (d) A synthetic legacy DB with the Phase 1 ``_SCHEMA_SQL`` schema (no
+  ``alembic_version`` table, real data rows preserved) opened via
+  ``GraphStore`` reaches alembic head — exercises the auto-stamp branch
+  in ``_run_alembic_upgrade``.
+* (e) A DB whose ``alembic_version`` row points to a revision the package
+  does not ship raises a :class:`RuntimeError` with both the unknown
+  revision and the local head in the message.
+* (f) ``_SCHEMA_SQL`` and the ``001_baseline``/``002`` migration chain
+  produce equivalent table/index structures (parity gate).
+* (g) ``_resolve_migrations_dir`` raises :class:`RuntimeError` with both
+  attempted layouts in the message when neither resolves.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -24,7 +32,11 @@ from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
-from better_code_review_graph.graph import _SCHEMA_SQL, GraphStore
+from better_code_review_graph.graph import (
+    _SCHEMA_SQL,
+    GraphStore,
+    _resolve_migrations_dir,
+)
 
 # All tables and indexes that the baseline migration is expected to create.
 EXPECTED_TABLES = {"nodes", "edges", "metadata"}
@@ -51,7 +63,7 @@ def _alembic_config_for(db_path: Path) -> Config:
 
 def _current_revision(db_path: Path) -> str | None:
     """Return the revision recorded in ``alembic_version`` (or None)."""
-    with sqlite3.connect(str(db_path)) as conn:
+    with closing(sqlite3.connect(str(db_path))) as conn:
         row = conn.execute(
             "SELECT name FROM sqlite_master "
             "WHERE type='table' AND name='alembic_version'"
@@ -63,7 +75,7 @@ def _current_revision(db_path: Path) -> str | None:
 
 
 def _table_names(db_path: Path) -> set[str]:
-    with sqlite3.connect(str(db_path)) as conn:
+    with closing(sqlite3.connect(str(db_path))) as conn:
         return {
             r[0]
             for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
@@ -71,7 +83,7 @@ def _table_names(db_path: Path) -> set[str]:
 
 
 def _index_names(db_path: Path) -> set[str]:
-    with sqlite3.connect(str(db_path)) as conn:
+    with closing(sqlite3.connect(str(db_path))) as conn:
         return {
             r[0]
             for r in conn.execute(
@@ -82,8 +94,68 @@ def _index_names(db_path: Path) -> set[str]:
 
 
 def _columns(db_path: Path, table: str) -> set[str]:
-    with sqlite3.connect(str(db_path)) as conn:
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        # Static table names from this module — safe against SQL injection.
         return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+_TYPE_AFFINITY_EQUIV = {
+    # SQLite type affinity: FLOAT and REAL share the REAL affinity, so a
+    # FLOAT column from SQLAlchemy and a REAL column from raw SQL are
+    # behaviourally identical.  Normalise them for the parity comparison.
+    "FLOAT": "REAL",
+}
+
+
+def _normalise_type(t: str) -> str:
+    return _TYPE_AFFINITY_EQUIV.get(t.upper(), t.upper())
+
+
+def _table_info(db_path: Path, table: str) -> list[tuple]:
+    """Return PRAGMA table_info rows (name, type, notnull, dflt, pk) sorted.
+
+    We deliberately drop the cid column from the comparison key so two
+    schemas with the same columns in a different order still compare equal
+    if column attributes match. Order is not part of the contract — sqlite
+    column order can shift across DDL paths and that is fine for our parity
+    gate.
+
+    Type strings are normalised through ``_TYPE_AFFINITY_EQUIV`` because
+    SQLAlchemy's ``Float`` renders as ``FLOAT`` while raw SQL uses ``REAL``;
+    both have REAL affinity in SQLite so the columns are behaviourally
+    identical.
+
+    Special-case: an INTEGER PRIMARY KEY column in SQLite is implicitly
+    NOT NULL via the PK constraint regardless of whether the DDL spelled
+    out ``NOT NULL``.  PRAGMA reports notnull=0 for the raw-SQL form and
+    notnull=1 for the alembic form even though they behave identically.
+    We normalise PK columns to notnull=1 so the parity gate doesn't trip
+    on this cosmetic difference.
+    """
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    normalised: list[tuple] = []
+    for _cid, name, typ, notnull, dflt, pk in rows:
+        normalised_notnull = 1 if pk else notnull
+        normalised.append((name, _normalise_type(typ), normalised_notnull, dflt, pk))
+    return sorted(normalised)
+
+
+def _index_list(db_path: Path, table: str) -> list[tuple]:
+    """Return PRAGMA index_list rows minus the auto-generated unique indexes.
+
+    We sort by index name and strip the seq column so two equivalent
+    schemas compare equal regardless of creation order.
+    """
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        rows = conn.execute(f"PRAGMA index_list({table})").fetchall()
+    # PRAGMA index_list returns (seq, name, unique, origin, partial).
+    # Skip sqlite_autoindex_* (created automatically for UNIQUE/PK).
+    return sorted(
+        (name, unique, origin, partial)
+        for (_seq, name, unique, origin, partial) in rows
+        if not name.startswith("sqlite_autoindex_")
+    )
 
 
 def _head_revision() -> str:
@@ -150,7 +222,7 @@ def test_reinit_is_idempotent(tmp_path: Path) -> None:
         assert _index_names(db_path) == first_idx
         assert _columns(db_path, "nodes") == first_cols
         # Still at head — no extra revision rows.
-        with sqlite3.connect(str(db_path)) as conn:
+        with closing(sqlite3.connect(str(db_path))) as conn:
             count = conn.execute("SELECT COUNT(*) FROM alembic_version").fetchone()[0]
         assert count == 1
     finally:
@@ -189,45 +261,319 @@ def test_downgrade_then_upgrade_round_trip(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# (d) synthetic legacy DB stamped at 002
+# (d) synthetic legacy DB opened via GraphStore exercises auto-stamp branch
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_db_stamped_at_002_reaches_head(tmp_path: Path) -> None:
-    """Simulate a DB created by Phase 1 v1.6.x (executescript + ALTER TABLE).
+def test_legacy_db_via_graphstore_reaches_head_and_preserves_rows(
+    tmp_path: Path,
+) -> None:
+    """Open a Phase 1-shaped legacy DB through ``GraphStore`` end-to-end.
 
-    Such a DB already has every column the baseline + 002 migration would
-    create. We stamp it at 002 (the last hand-authored revision the legacy
-    helper effectively brought it to) then upgrade to head; this must
-    succeed with no DDL conflict.
+    Builds a synthetic legacy DB (``executescript(_SCHEMA_SQL)`` + one real
+    row) with NO ``alembic_version`` table, then opens it via
+    ``GraphStore``.  This must trigger ``_run_alembic_upgrade``'s auto-stamp
+    branch (lines marked "needs_stamp" in graph.py): stamp at ``002`` →
+    upgrade to head → row preserved.
+    """
+    legacy_path = tmp_path / "legacy.db"
+
+    # Replay Phase 1 bootstrap exactly: schema + one Function row, NO
+    # alembic_version table.
+    with closing(sqlite3.connect(str(legacy_path))) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.execute(
+            """INSERT INTO nodes
+               (kind, name, qualified_name, file_path, line_start, line_end,
+                language, parent_name, params, return_type, modifiers,
+                is_test, file_hash, extra, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "Function",
+                "legacy_fn",
+                "src/legacy.py::legacy_fn",
+                "src/legacy.py",
+                1,
+                10,
+                "python",
+                None,
+                "()",
+                "None",
+                None,
+                0,
+                "deadbeef",
+                "{}",
+                1700000000.0,
+            ),
+        )
+        conn.commit()
+
+    # Sanity: no alembic_version yet.
+    assert _current_revision(legacy_path) is None
+
+    # This is the production code path: opening the legacy DB triggers
+    # _run_alembic_upgrade with needs_stamp=True, then upgrade("head").
+    store = GraphStore(legacy_path)
+    try:
+        # Auto-stamp + upgrade succeeded; now at head.
+        assert _current_revision(legacy_path) == _head_revision()
+
+        # The pre-existing row is still queryable.
+        row = store._conn.execute(
+            "SELECT name, file_path FROM nodes WHERE qualified_name = ?",
+            ("src/legacy.py::legacy_fn",),
+        ).fetchone()
+        assert row is not None
+        assert row["name"] == "legacy_fn"
+        assert row["file_path"] == "src/legacy.py"
+    finally:
+        store.close()
+
+
+def test_legacy_db_low_level_stamp_then_upgrade(tmp_path: Path) -> None:
+    """Low-level smoke check that ``alembic stamp 002`` works in isolation.
+
+    Complements the higher-level test above (which goes through
+    ``GraphStore``) by verifying that the alembic primitives do what we
+    expect, independent of our stamp logic.
     """
     db_path = tmp_path / "legacy.db"
 
-    # Manually replay the Phase 1 schema: _SCHEMA_SQL already includes the
-    # summary columns since v1.6, so no ALTER TABLE is needed for a
-    # representative legacy DB. We deliberately do NOT create
-    # alembic_version here — that is the point of the stamp.
-    with sqlite3.connect(str(db_path)) as conn:
+    with closing(sqlite3.connect(str(db_path))) as conn:
         conn.executescript(_SCHEMA_SQL)
         conn.commit()
-
-    assert _current_revision(db_path) is None
-    assert SUMMARY_COLUMNS.issubset(_columns(db_path, "nodes"))
 
     cfg = _alembic_config_for(db_path)
     command.stamp(cfg, "002")
     assert _current_revision(db_path) == "002"
 
-    # Upgrade to head — must be a no-op DDL-wise (we are already there) but
-    # alembic should still process the chain without raising.
     command.upgrade(cfg, "head")
     assert _current_revision(db_path) == _head_revision()
-
-    # Schema unchanged (still has summary columns and all structural
-    # tables/indexes).
     assert EXPECTED_TABLES.issubset(_table_names(db_path))
-    assert EXPECTED_INDEXES.issubset(_index_names(db_path))
     assert SUMMARY_COLUMNS.issubset(_columns(db_path, "nodes"))
+
+
+# ---------------------------------------------------------------------------
+# (e) unknown revision raises a clear error
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_alembic_revision_raises_runtime_error(tmp_path: Path) -> None:
+    """If ``alembic_version`` references an unshipped revision, surface it.
+
+    We bring a DB to head normally, then forge ``alembic_version`` to point
+    at a fake ``999`` revision.  Re-opening via ``GraphStore`` must raise
+    :class:`RuntimeError` (not the opaque ``alembic.util.exc.CommandError``)
+    with both the unknown revision and the local head spelt out so the
+    operator can decide between downgrading the package and recreating
+    the DB.
+    """
+    db_path = tmp_path / "future.db"
+
+    # Create a healthy DB at head, then close.
+    store = GraphStore(db_path)
+    store.close()
+
+    # Forge a future revision the package does not ship.
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.execute("UPDATE alembic_version SET version_num = '999'")
+        conn.commit()
+
+    head = _head_revision()
+    with pytest.raises(RuntimeError) as excinfo:
+        GraphStore(db_path)
+
+    msg = str(excinfo.value)
+    assert "999" in msg, f"unknown revision should appear in message: {msg!r}"
+    assert head in msg, f"local head {head!r} should appear in message: {msg!r}"
+    assert str(db_path) in msg, f"db path should appear in message: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# (f) _SCHEMA_SQL <-> 001+002 parity gate
+# ---------------------------------------------------------------------------
+
+
+def test_schema_sql_matches_alembic_migrations(tmp_path: Path) -> None:
+    """``_SCHEMA_SQL`` and the alembic migration chain MUST stay in sync.
+
+    Builds two SQLite files: one via ``executescript(_SCHEMA_SQL)`` only,
+    one via ``command.upgrade(cfg, "head")`` only.  For each application
+    table, asserts ``PRAGMA table_info`` and ``PRAGMA index_list`` rows
+    match.  This is the parity gate that catches anyone who later adds a
+    column to ``_SCHEMA_SQL`` without bumping the migration chain.
+
+    Documented exception: ``idx_nodes_source_hash`` is created by the
+    legacy ``_ensure_summary_columns`` helper, not by either path here, so
+    it appears in NEITHER comparison.  If it ever appears in only one,
+    that helper has been wired into the wrong path.
+    """
+    schema_sql_db = tmp_path / "schema_sql.db"
+    alembic_db = tmp_path / "alembic.db"
+
+    with closing(sqlite3.connect(str(schema_sql_db))) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+
+    cfg = _alembic_config_for(alembic_db)
+    command.upgrade(cfg, "head")
+
+    for table in sorted(EXPECTED_TABLES):
+        sql_info = _table_info(schema_sql_db, table)
+        alembic_info = _table_info(alembic_db, table)
+        assert sql_info == alembic_info, (
+            f"table_info diverges for {table!r}\n"
+            f"  _SCHEMA_SQL: {sql_info}\n"
+            f"  alembic:     {alembic_info}"
+        )
+
+        sql_idx = _index_list(schema_sql_db, table)
+        alembic_idx = _index_list(alembic_db, table)
+        assert sql_idx == alembic_idx, (
+            f"index_list diverges for {table!r}\n"
+            f"  _SCHEMA_SQL: {sql_idx}\n"
+            f"  alembic:     {alembic_idx}"
+        )
+
+    # Documented exception: idx_nodes_source_hash must appear in NEITHER
+    # path here (only in the legacy helper).
+    assert "idx_nodes_source_hash" not in _index_names(schema_sql_db)
+    assert "idx_nodes_source_hash" not in _index_names(alembic_db)
+
+
+# ---------------------------------------------------------------------------
+# (g) _resolve_migrations_dir failure mode is observable
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_migrations_dir_returns_real_path() -> None:
+    """The resolver returns a real on-disk directory containing env.py."""
+    resolved = _resolve_migrations_dir()
+    assert isinstance(resolved, Path)
+    assert resolved.is_dir(), f"resolver returned non-directory: {resolved}"
+    assert (resolved / "env.py").is_file(), (
+        f"resolver returned dir without env.py: {resolved}"
+    )
+
+
+def test_resolve_migrations_dir_raises_when_nothing_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both layouts fail → :class:`RuntimeError` lists both attempts.
+
+    We force the importlib.resources branch to raise ``ModuleNotFoundError``
+    and redirect the source-checkout fallback at a sandbox tmp_path that
+    doesn't contain ``env.py``.  The final RuntimeError must mention BOTH
+    attempted paths so the failure is diagnosable.
+    """
+    # Block the installed-wheel resolution.
+    import importlib.resources as _resources
+
+    def _raise(name: str) -> object:
+        raise ModuleNotFoundError(f"forced-missing: {name}")
+
+    monkeypatch.setattr(_resources, "files", _raise)
+
+    # Redirect the source-checkout fallback at a directory missing env.py.
+    # We patch __file__ via a fake module path so `Path(__file__).parent.parent.parent / "migrations"`
+    # lands in tmp_path/<missing>.
+    fake_root = tmp_path / "src" / "better_code_review_graph"
+    fake_root.mkdir(parents=True)
+    fake_graph = fake_root / "graph.py"
+    fake_graph.write_text("")
+    # The migrations dir we WANT to be missing:
+    expected_fallback = tmp_path / "migrations"
+    assert not expected_fallback.exists()
+
+    # Patch the module-level __file__ so the source fallback resolves into
+    # tmp_path (where there is no migrations/env.py).
+    import better_code_review_graph.graph as graph_mod
+
+    monkeypatch.setattr(graph_mod, "__file__", str(fake_graph))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _resolve_migrations_dir()
+
+    msg = str(excinfo.value)
+    assert "forced-missing" in msg or "installed package" in msg, (
+        f"installed-package attempt should appear: {msg!r}"
+    )
+    assert str(expected_fallback) in msg, (
+        f"source-checkout attempt should appear: {msg!r}"
+    )
+
+
+def test_resolve_migrations_dir_falls_back_to_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the installed-wheel import fails, the source-checkout path wins.
+
+    Forces ``importlib.resources.files`` to raise ``ModuleNotFoundError`` so
+    only the source-checkout fallback can succeed; relies on the real
+    repository ``migrations/env.py`` being present (this test runs from a
+    source checkout, which by definition has it).
+    """
+    import importlib.resources as _resources
+
+    def _raise(name: str) -> object:
+        raise ModuleNotFoundError(f"forced-missing: {name}")
+
+    monkeypatch.setattr(_resources, "files", _raise)
+
+    resolved = _resolve_migrations_dir()
+    repo_root = Path(__file__).resolve().parent.parent
+    assert resolved == repo_root / "migrations"
+    assert (resolved / "env.py").is_file()
+
+
+def test_resolve_migrations_dir_handles_multiplexed_path_repr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for C1: Path(str(MultiplexedPath(...))) is junk.
+
+    Simulates the installed-wheel layout where ``importlib.resources.files``
+    returns an object whose ``__str__`` is the repr (the historical bug).
+    The resolver must NOT do ``Path(str(ref))`` and must instead use
+    ``ref.joinpath("env.py")`` (which returns a real ``pathlib.Path`` for
+    filesystem-backed resources).  Falls through to source-checkout
+    fallback on this specific test mock because the mocked joinpath
+    doesn't return a real ``pathlib.Path``.
+    """
+    import importlib.resources as _resources
+
+    class _FakeMultiplexedPath:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+
+        def __repr__(self) -> str:  # the trap
+            return f"MultiplexedPath('{self._path}')"
+
+        def __str__(self) -> str:  # __str__ falls back to repr
+            return repr(self)
+
+        def joinpath(self, name: str) -> object:
+            # Return a non-Path traversable to force the fallback branch.
+            return _FakeTraversable(self._path / name)
+
+    class _FakeTraversable:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+
+        def is_file(self) -> bool:
+            return self._path.is_file()
+
+    fake_dir = Path(__file__).resolve().parent.parent / "migrations"
+
+    def _files(name: str) -> object:
+        return _FakeMultiplexedPath(fake_dir)
+
+    monkeypatch.setattr(_resources, "files", _files)
+
+    # Falls through installed-wheel branch (joinpath result not a Path)
+    # → resolves via source-checkout fallback. Both paths exist in the
+    # checkout, so we should get a working migrations dir back.
+    resolved = _resolve_migrations_dir()
+    assert (resolved / "env.py").is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -236,7 +582,15 @@ def test_legacy_db_stamped_at_002_reaches_head(tmp_path: Path) -> None:
 
 
 def test_alembic_current_via_runtime_context(tmp_path: Path) -> None:
-    """``MigrationContext.get_current_revision`` agrees with our helper."""
+    """``MigrationContext.get_current_revision`` agrees with our helper, AND
+    ``command.current(cfg)`` reaches the same head via alembic's own logging.
+
+    The previous version of this test only asserted that ``command.current``
+    didn't raise (near-zero signal).  We now verify that the runtime-context
+    revision matches ``_head_revision()`` AND that an independent
+    ``ScriptDirectory`` lookup agrees, so a regression in either side surfaces
+    immediately.
+    """
     from sqlalchemy import create_engine
 
     db_path = tmp_path / "g.db"
@@ -247,25 +601,70 @@ def test_alembic_current_via_runtime_context(tmp_path: Path) -> None:
         try:
             with engine.connect() as conn:
                 ctx = MigrationContext.configure(conn)
-                assert ctx.get_current_revision() == _head_revision()
+                head = _head_revision()
+                assert ctx.get_current_revision() == head
         finally:
             engine.dispose()
-        # Sanity — make sure cfg is usable (alembic.command.current does not
-        # return a value, so we just confirm it does not raise).
+
+        # Cross-check via a fresh ScriptDirectory: the head reported by the
+        # cfg + script API must match the one stamped in alembic_version.
+        script = ScriptDirectory.from_config(cfg)
+        assert script.get_current_head() == head
+
+        # And command.current must not raise — the original near-zero
+        # smoke check, retained as a regression guard against alembic API
+        # shape changes.
         command.current(cfg)
     finally:
         store.close()
 
 
 @pytest.mark.parametrize(
-    "missing_arg",
-    [None, "head"],
+    "target",
+    ["head", "001", "002"],
 )
-def test_alembic_config_resolves(missing_arg: str | None, tmp_path: Path) -> None:
-    """Smoke check that the project's alembic.ini + migrations dir are wired
-    correctly regardless of which revision label callers ask for."""
-    db_path = tmp_path / "smoke.db"
+def test_alembic_upgrade_to_target(target: str, tmp_path: Path) -> None:
+    """Upgrading to each named target reaches the expected revision.
+
+    ``head`` and ``002`` both resolve to ``002`` (head is currently 002);
+    ``001`` stops at the baseline.  The point of parameterising here is to
+    catch regressions where an intermediate revision label fails to apply
+    cleanly (e.g. someone authors a migration whose ``upgrade`` raises
+    only when invoked on an empty DB).
+    """
+    db_path = tmp_path / f"smoke_{target}.db"
     cfg = _alembic_config_for(db_path)
-    target = missing_arg or "head"
     command.upgrade(cfg, target)
-    assert _current_revision(db_path) == _head_revision()
+    expected = _head_revision() if target == "head" else target
+    assert _current_revision(db_path) == expected
+
+
+# ---------------------------------------------------------------------------
+# Coverage helper: alembic stamp branch when alembic_version exists empty
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_db_with_empty_alembic_version_table_stamps(tmp_path: Path) -> None:
+    """Edge case: ``alembic_version`` exists but has zero rows.
+
+    This mimics an interrupted prior alembic run that created the
+    bookkeeping table but never recorded a revision.  ``_run_alembic_upgrade``
+    must detect this and stamp at 002 before upgrading.
+    """
+    db_path = tmp_path / "interrupted.db"
+
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        conn.commit()
+
+    assert _current_revision(db_path) is None
+
+    # The empty alembic_version table mocks the "needs_stamp via empty row"
+    # branch in graph.py: command.stamp(cfg, "002") fires and upgrade
+    # succeeds.
+    store = GraphStore(db_path)
+    try:
+        assert _current_revision(db_path) == _head_revision()
+    finally:
+        store.close()

--- a/tests/test_alembic_baseline.py
+++ b/tests/test_alembic_baseline.py
@@ -1,0 +1,271 @@
+"""Tests for the Alembic baseline migration (Phase 2 Task 0).
+
+These tests exercise four distinct paths:
+
+* (a) Fresh DB created via ``GraphStore`` reaches alembic head and contains
+  every table, index, and Phase 1 summary column from ``_SCHEMA_SQL``.
+* (b) Re-initialising ``GraphStore`` on the same DB is idempotent.
+* (c) ``downgrade("base")`` followed by ``upgrade("head")`` round-trips
+  cleanly without orphaning tables, indexes, or columns.
+* (d) A synthetic legacy DB that already has the Phase 1 columns (because
+  it was created by ``_SCHEMA_SQL`` + ``_ensure_summary_columns``) can be
+  stamped at revision ``002`` and then upgraded to head without DDL
+  conflict.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+
+from better_code_review_graph.graph import _SCHEMA_SQL, GraphStore
+
+# All tables and indexes that the baseline migration is expected to create.
+EXPECTED_TABLES = {"nodes", "edges", "metadata"}
+EXPECTED_INDEXES = {
+    "idx_nodes_file",
+    "idx_nodes_kind",
+    "idx_nodes_qualified",
+    "idx_edges_source",
+    "idx_edges_target",
+    "idx_edges_kind",
+    "idx_edges_file",
+}
+SUMMARY_COLUMNS = {"summary", "summary_provider", "source_hash", "source_text"}
+
+
+def _alembic_config_for(db_path: Path) -> Config:
+    """Build an Alembic Config bound to ``db_path`` using the project ini."""
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _current_revision(db_path: Path) -> str | None:
+    """Return the revision recorded in ``alembic_version`` (or None)."""
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='alembic_version'"
+        ).fetchone()
+        if row is None:
+            return None
+        rev = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+        return rev[0] if rev else None
+
+
+def _table_names(db_path: Path) -> set[str]:
+    with sqlite3.connect(str(db_path)) as conn:
+        return {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+
+
+def _index_names(db_path: Path) -> set[str]:
+    with sqlite3.connect(str(db_path)) as conn:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name NOT LIKE 'sqlite_autoindex_%'"
+            )
+        }
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    with sqlite3.connect(str(db_path)) as conn:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _head_revision() -> str:
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    script = ScriptDirectory.from_config(cfg)
+    head = script.get_current_head()
+    assert head is not None, "alembic must report a head revision"
+    return head
+
+
+# ---------------------------------------------------------------------------
+# (a) fresh DB
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_reaches_head_with_full_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+    store = GraphStore(db_path)
+    try:
+        # Alembic version table reports head.
+        head = _head_revision()
+        assert _current_revision(db_path) == head
+
+        # All structural tables present (alembic_version is the bookkeeping
+        # table — not part of the application schema).
+        tables = _table_names(db_path)
+        assert EXPECTED_TABLES.issubset(tables)
+        assert "alembic_version" in tables
+
+        # All named indexes present (idx_nodes_source_hash is created by the
+        # legacy `_ensure_summary_columns` helper, not by the baseline; it is
+        # therefore not enforced here, but if present we tolerate it).
+        idx = _index_names(db_path)
+        assert EXPECTED_INDEXES.issubset(idx)
+
+        # All four Phase 1 summary columns present.
+        cols = _columns(db_path, "nodes")
+        assert SUMMARY_COLUMNS.issubset(cols)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# (b) re-init idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_reinit_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+
+    store1 = GraphStore(db_path)
+    try:
+        first_tables = _table_names(db_path)
+        first_idx = _index_names(db_path)
+        first_cols = _columns(db_path, "nodes")
+    finally:
+        store1.close()
+
+    store2 = GraphStore(db_path)
+    try:
+        assert _table_names(db_path) == first_tables
+        assert _index_names(db_path) == first_idx
+        assert _columns(db_path, "nodes") == first_cols
+        # Still at head — no extra revision rows.
+        with sqlite3.connect(str(db_path)) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM alembic_version").fetchone()[0]
+        assert count == 1
+    finally:
+        store2.close()
+
+
+# ---------------------------------------------------------------------------
+# (c) downgrade -> upgrade round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_then_upgrade_round_trip(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+    store = GraphStore(db_path)
+    store.close()
+
+    cfg = _alembic_config_for(db_path)
+
+    # Downgrade to base — should drop nodes/edges/metadata + indexes.
+    command.downgrade(cfg, "base")
+    tables_after_down = _table_names(db_path)
+    assert not (EXPECTED_TABLES & tables_after_down), (
+        f"orphan tables after downgrade: {EXPECTED_TABLES & tables_after_down}"
+    )
+    indexes_after_down = _index_names(db_path)
+    assert not (EXPECTED_INDEXES & indexes_after_down), (
+        f"orphan indexes after downgrade: {EXPECTED_INDEXES & indexes_after_down}"
+    )
+
+    # Upgrade back to head — full schema restored.
+    command.upgrade(cfg, "head")
+    assert _current_revision(db_path) == _head_revision()
+    assert EXPECTED_TABLES.issubset(_table_names(db_path))
+    assert EXPECTED_INDEXES.issubset(_index_names(db_path))
+    assert SUMMARY_COLUMNS.issubset(_columns(db_path, "nodes"))
+
+
+# ---------------------------------------------------------------------------
+# (d) synthetic legacy DB stamped at 002
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_db_stamped_at_002_reaches_head(tmp_path: Path) -> None:
+    """Simulate a DB created by Phase 1 v1.6.x (executescript + ALTER TABLE).
+
+    Such a DB already has every column the baseline + 002 migration would
+    create. We stamp it at 002 (the last hand-authored revision the legacy
+    helper effectively brought it to) then upgrade to head; this must
+    succeed with no DDL conflict.
+    """
+    db_path = tmp_path / "legacy.db"
+
+    # Manually replay the Phase 1 schema: _SCHEMA_SQL already includes the
+    # summary columns since v1.6, so no ALTER TABLE is needed for a
+    # representative legacy DB. We deliberately do NOT create
+    # alembic_version here — that is the point of the stamp.
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+
+    assert _current_revision(db_path) is None
+    assert SUMMARY_COLUMNS.issubset(_columns(db_path, "nodes"))
+
+    cfg = _alembic_config_for(db_path)
+    command.stamp(cfg, "002")
+    assert _current_revision(db_path) == "002"
+
+    # Upgrade to head — must be a no-op DDL-wise (we are already there) but
+    # alembic should still process the chain without raising.
+    command.upgrade(cfg, "head")
+    assert _current_revision(db_path) == _head_revision()
+
+    # Schema unchanged (still has summary columns and all structural
+    # tables/indexes).
+    assert EXPECTED_TABLES.issubset(_table_names(db_path))
+    assert EXPECTED_INDEXES.issubset(_index_names(db_path))
+    assert SUMMARY_COLUMNS.issubset(_columns(db_path, "nodes"))
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: `alembic current` matches MigrationContext
+# ---------------------------------------------------------------------------
+
+
+def test_alembic_current_via_runtime_context(tmp_path: Path) -> None:
+    """``MigrationContext.get_current_revision`` agrees with our helper."""
+    from sqlalchemy import create_engine
+
+    db_path = tmp_path / "g.db"
+    store = GraphStore(db_path)
+    try:
+        cfg = _alembic_config_for(db_path)
+        engine = create_engine(f"sqlite:///{db_path}")
+        try:
+            with engine.connect() as conn:
+                ctx = MigrationContext.configure(conn)
+                assert ctx.get_current_revision() == _head_revision()
+        finally:
+            engine.dispose()
+        # Sanity — make sure cfg is usable (alembic.command.current does not
+        # return a value, so we just confirm it does not raise).
+        command.current(cfg)
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "missing_arg",
+    [None, "head"],
+)
+def test_alembic_config_resolves(missing_arg: str | None, tmp_path: Path) -> None:
+    """Smoke check that the project's alembic.ini + migrations dir are wired
+    correctly regardless of which revision label callers ask for."""
+    db_path = tmp_path / "smoke.db"
+    cfg = _alembic_config_for(db_path)
+    target = missing_arg or "head"
+    command.upgrade(cfg, target)
+    assert _current_revision(db_path) == _head_revision()

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -80,6 +94,7 @@ name = "better-code-review-graph"
 version = "3.15.1"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "cohere" },
     { name = "fastmcp" },
     { name = "google-genai" },
@@ -109,6 +124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.14.0,<2" },
     { name = "cohere", specifier = ">=6.1.0" },
     { name = "fastmcp", specifier = ">=3.2.4,<4" },
     { name = "google-genai", specifier = ">=1.75.0" },
@@ -524,6 +540,22 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -814,6 +846,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +867,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
 ]
 
 [[package]]
@@ -1470,6 +1544,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Wire alembic into the package as the schema source of truth for `graph.db` (structural graph: `nodes`, `edges`, `metadata` tables + indexes).
- `001_baseline` mirrors `graph.py:_SCHEMA_SQL` byte-for-byte (19 nodes columns including 4 Phase 1 summary cols, 8 edges columns, 2 metadata columns, 7 indexes).
- `002_summary_columns` is a no-op stamp target so legacy DBs created by Phase 1's in-code helper can be upgraded forward without DDL conflict.
- `GraphStore._init_schema()` now runs `alembic upgrade head` first (with auto-stamp-to-002 detection for legacy DBs) before the existing `executescript(_SCHEMA_SQL)` legacy bootstrap and `_ensure_summary_columns()` defensive guard. Both legacy paths retained as smoke comparator + safety net for one release.
- Hatch `force-include` ships `migrations/` inside the wheel as `better_code_review_graph_migrations`. Resolver handles `MultiplexedPath` repr trap correctly via `joinpath().parent` (verified by regression test).
- Future-revision case (alembic_version pointing to revision the package doesn't ship) raises a clear `RuntimeError` naming both unknown revision and local head instead of opaque `CommandError`.

This is **Phase 2 Task 0** (introduced 2026-05-09 in plan rev) — prerequisite for Phase 2 Task 1 (`003_federation` migration adding `repo_id` columns + `repos` table).

## Test plan
- [x] `pytest tests/test_alembic_baseline.py -v`: 16 passed (4 spec cases + 5 fix-up regression + 7 supporting paths).
- [x] `pytest --cov-fail-under=95 -q`: 749 passed, 1 skipped, coverage 95.10% (`graph.py` 98%).
- [x] `grep -c "directory" uv.lock`: 0 (lockfile docker-safe per `feedback_uv_lock_docker_trap.md`).
- [x] Wheel build verified to ship `better_code_review_graph_migrations/{env.py,script.py.mako,versions/001_baseline.py,versions/002_summary_columns.py}`.
- [x] ruff check + format + ty type check + pre-commit hooks all green.
- [ ] CI green on this branch (Lint & Test 3 OS + CodeQL + Socket + Dependency Review + GitGuardian).

## Files
- New: `alembic.ini`, `migrations/{env.py,script.py.mako,README,versions/001_baseline.py,versions/002_summary_columns.py}`, `tests/test_alembic_baseline.py`.
- Modified: `pyproject.toml` (alembic dep + `[tool.hatch.build.targets.wheel.force-include]`), `src/better_code_review_graph/graph.py` (alembic upgrade wiring + path resolver), `uv.lock`.
- Untouched: `_SCHEMA_SQL`, `_ensure_summary_columns()`, all out-of-scope src files.