### PR TITLE
feat: Phase 2 Task 1 — alembic 003_federation (repo_id + repos table)

### DIFF
--- a/migrations/versions/003_federation.py
+++ b/migrations/versions/003_federation.py
@@ -1,0 +1,114 @@
+"""Federation: add repo_id columns + repos registry table (Phase 2 Task 1).
+
+Adds the cross-repo scoping primitives from the v2 design spec section
+5.4. The migration is purely additive on the data path:
+
+* ``nodes.repo_id`` (TEXT NOT NULL DEFAULT '') — every node now declares
+  the repo it belongs to. The default ``''`` keeps single-repo /
+  non-federated mode working without runtime changes; the federation
+  driver (Phase 2 Task 2 onwards) populates the column on ingest.
+* ``edges.repo_id`` (TEXT NOT NULL DEFAULT '') — same shape, same
+  default, same rationale.
+* ``repos`` registry table — populated only when federation is enabled.
+  For non-federated installs the table exists but stays empty.
+* ``idx_nodes_repo_kind`` on ``nodes(repo_id, kind)`` — the canonical
+  scoped lookup pattern from spec section 5.4 line 193.
+* ``idx_edges_repo`` on ``edges(repo_id)`` — single-column analog for
+  edge scoping. There is no kind-shaped query for edges yet, so we
+  index just ``repo_id`` and let the query planner pick from there.
+
+SQLite limitations
+------------------
+SQLite < 3.35 cannot ``ALTER TABLE DROP COLUMN`` natively. The
+downgrade path therefore wraps each table in
+``op.batch_alter_table`` which performs the
+create-new-table-copy-drop-old-rename dance under the hood. The env.py
+already sets ``render_as_batch=True`` so column adds are also rendered
+through the batch mechanism, which is fine for the additive direction.
+
+The legacy in-code ``_SCHEMA_SQL`` constant in ``graph.py`` is
+intentionally NOT updated for this migration — it remains frozen at
+v1.6 (the post-002 alembic state) per the Phase 2 design and is now
+only consulted as a smoke comparator. Any future schema change goes
+through alembic only.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-05-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: str | Sequence[str] | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add repo_id columns, repos table, and federation indexes."""
+    # Additive column on nodes — NOT NULL with empty-string default so
+    # existing single-repo rows backfill cleanly.
+    op.add_column(
+        "nodes",
+        sa.Column(
+            "repo_id",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+
+    # Same shape on edges.
+    op.add_column(
+        "edges",
+        sa.Column(
+            "repo_id",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+
+    # Registry table. ``repo_id`` is the natural primary key (the slug
+    # the federation driver coins from the remote URL or local path).
+    # ``first_indexed_at`` and ``last_indexed_at`` are unix timestamps
+    # stored as INTEGER, mirroring the spec section 5.4.
+    op.create_table(
+        "repos",
+        sa.Column("repo_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("remote_url", sa.Text(), nullable=True),
+        sa.Column("last_indexed_sha", sa.Text(), nullable=True),
+        sa.Column("first_indexed_at", sa.Integer(), nullable=False),
+        sa.Column("last_indexed_at", sa.Integer(), nullable=False),
+    )
+
+    # Scoped lookup indexes — see module docstring for naming rationale.
+    op.create_index("idx_nodes_repo_kind", "nodes", ["repo_id", "kind"])
+    op.create_index("idx_edges_repo", "edges", ["repo_id"])
+
+
+def downgrade() -> None:
+    """Drop federation indexes, repos table, then repo_id columns.
+
+    SQLite < 3.35 lacks native ``DROP COLUMN`` so each table is wrapped
+    in ``op.batch_alter_table``. The order matters: drop indexes
+    BEFORE dropping the columns they reference, drop the standalone
+    ``repos`` table independently.
+    """
+    op.drop_index("idx_edges_repo", table_name="edges")
+    op.drop_index("idx_nodes_repo_kind", table_name="nodes")
+
+    op.drop_table("repos")
+
+    with op.batch_alter_table("edges") as batch_op:
+        batch_op.drop_column("repo_id")
+
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.drop_column("repo_id")

--- a/tests/test_alembic_baseline.py
+++ b/tests/test_alembic_baseline.py
@@ -395,13 +395,20 @@ def test_unknown_alembic_revision_raises_runtime_error(tmp_path: Path) -> None:
 
 
 def test_schema_sql_matches_alembic_migrations(tmp_path: Path) -> None:
-    """``_SCHEMA_SQL`` and the alembic migration chain MUST stay in sync.
+    """``_SCHEMA_SQL`` is equivalent to the alembic state at revision ``002``.
 
     Builds two SQLite files: one via ``executescript(_SCHEMA_SQL)`` only,
-    one via ``command.upgrade(cfg, "head")`` only.  For each application
+    one via ``command.upgrade(cfg, "002")`` only.  For each application
     table, asserts ``PRAGMA table_info`` and ``PRAGMA index_list`` rows
-    match.  This is the parity gate that catches anyone who later adds a
-    column to ``_SCHEMA_SQL`` without bumping the migration chain.
+    match.
+
+    The comparison is intentionally pinned at ``002`` rather than
+    ``head``: ``_SCHEMA_SQL`` is the legacy in-code bootstrap frozen at
+    the v1.6 release line, and any new schema (Phase 2 federation
+    onwards) goes through alembic only. ``003_federation`` adds
+    ``repo_id`` columns + a ``repos`` table that ``_SCHEMA_SQL`` does
+    NOT carry — by design — so comparing against ``head`` would
+    spuriously fail for every future additive migration.
 
     Documented exception: ``idx_nodes_source_hash`` is created by the
     legacy ``_ensure_summary_columns`` helper, not by either path here, so
@@ -416,7 +423,7 @@ def test_schema_sql_matches_alembic_migrations(tmp_path: Path) -> None:
         conn.commit()
 
     cfg = _alembic_config_for(alembic_db)
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "002")
 
     for table in sorted(EXPECTED_TABLES):
         sql_info = _table_info(schema_sql_db, table)

--- a/tests/test_federation_migration.py
+++ b/tests/test_federation_migration.py
@@ -1,0 +1,295 @@
+"""Tests for the 003_federation alembic migration (Phase 2 Task 1).
+
+These tests verify the additive federation schema introduced in revision
+``003``:
+
+* ``nodes.repo_id`` and ``edges.repo_id`` columns (TEXT, NOT NULL,
+  default ``''``) are added by the upgrade.
+* The ``repos`` registry table is created with the columns spelled out in
+  the v2 design spec section 5.4.
+* The cross-repo scoping indexes ``idx_nodes_repo_kind`` and
+  ``idx_edges_repo`` are created.
+* A round-trip (upgrade -> downgrade -> upgrade) leaves no orphan columns
+  or tables behind. SQLite cannot natively ``ALTER TABLE DROP COLUMN``
+  before 3.35, so the migration uses ``op.batch_alter_table`` for the
+  downgrade path; this test covers that branch.
+* Existing ``upsert_node`` writes after the upgrade default ``repo_id``
+  to ``''`` (single-repo / non-federated mode).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import NodeInfo
+
+
+def _alembic_config_for(db_path: Path) -> Config:
+    """Build an Alembic Config bound to ``db_path`` using the project ini."""
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _table_info(db_path: Path, table: str) -> list[tuple]:
+    """Return PRAGMA table_info rows as (name, type, notnull, dflt, pk)."""
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [
+        (name, typ, notnull, dflt, pk) for (_cid, name, typ, notnull, dflt, pk) in rows
+    ]
+
+
+def _column_info(db_path: Path, table: str, column: str) -> tuple | None:
+    """Return the (name, type, notnull, dflt, pk) tuple for a single column."""
+    for row in _table_info(db_path, table):
+        if row[0] == column:
+            return row
+    return None
+
+
+def _index_names(db_path: Path) -> set[str]:
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name NOT LIKE 'sqlite_autoindex_%'"
+            )
+        }
+
+
+def _table_names(db_path: Path) -> set[str]:
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        return {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+
+
+def _index_columns(db_path: Path, index: str) -> list[str]:
+    """Return the column names covered by ``index`` in PRAGMA order."""
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        rows = conn.execute(f"PRAGMA index_info({index})").fetchall()
+    # PRAGMA index_info returns (seqno, cid, name) sorted by seqno.
+    return [row[2] for row in sorted(rows, key=lambda r: r[0])]
+
+
+# ---------------------------------------------------------------------------
+# Column adds
+# ---------------------------------------------------------------------------
+
+
+def test_federation_migration_adds_repo_id_columns(tmp_path: Path) -> None:
+    """``nodes.repo_id`` and ``edges.repo_id`` exist after upgrade.
+
+    Both columns must be TEXT, NOT NULL, with default ``''`` per design
+    spec section 5.4 line 187-188.
+    """
+    db_path = tmp_path / "g.db"
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    nodes_repo = _column_info(db_path, "nodes", "repo_id")
+    edges_repo = _column_info(db_path, "edges", "repo_id")
+
+    assert nodes_repo is not None, "nodes.repo_id missing after upgrade"
+    assert edges_repo is not None, "edges.repo_id missing after upgrade"
+
+    # (name, type, notnull, dflt, pk)
+    name, typ, notnull, dflt, pk = nodes_repo
+    assert typ.upper() == "TEXT"
+    assert notnull == 1, f"nodes.repo_id must be NOT NULL, got notnull={notnull}"
+    assert dflt is not None, "nodes.repo_id must have a default value"
+    assert dflt.strip("'\"") == "", f"default should be empty string, got {dflt!r}"
+    assert pk == 0
+
+    name, typ, notnull, dflt, pk = edges_repo
+    assert typ.upper() == "TEXT"
+    assert notnull == 1
+    assert dflt is not None
+    assert dflt.strip("'\"") == ""
+    assert pk == 0
+
+
+# ---------------------------------------------------------------------------
+# repos table
+# ---------------------------------------------------------------------------
+
+
+def test_federation_migration_creates_repos_table(tmp_path: Path) -> None:
+    """The ``repos`` registry table exists with exactly the spec columns."""
+    db_path = tmp_path / "g.db"
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    assert "repos" in _table_names(db_path), "repos table missing after upgrade"
+
+    columns = {row[0]: row for row in _table_info(db_path, "repos")}
+    expected = {
+        "repo_id",
+        "path",
+        "remote_url",
+        "last_indexed_sha",
+        "first_indexed_at",
+        "last_indexed_at",
+    }
+    assert expected.issubset(set(columns.keys())), (
+        f"missing columns: {expected - set(columns.keys())}"
+    )
+
+    # repo_id: TEXT PRIMARY KEY NOT NULL
+    name, typ, notnull, dflt, pk = columns["repo_id"]
+    assert typ.upper() == "TEXT"
+    assert pk == 1, "repo_id must be primary key"
+
+    # path: TEXT NOT NULL
+    name, typ, notnull, dflt, pk = columns["path"]
+    assert typ.upper() == "TEXT"
+    assert notnull == 1
+
+    # remote_url: TEXT NULL
+    name, typ, notnull, dflt, pk = columns["remote_url"]
+    assert typ.upper() == "TEXT"
+    assert notnull == 0
+
+    # last_indexed_sha: TEXT NULL
+    name, typ, notnull, dflt, pk = columns["last_indexed_sha"]
+    assert typ.upper() == "TEXT"
+    assert notnull == 0
+
+    # first_indexed_at: INTEGER NOT NULL
+    name, typ, notnull, dflt, pk = columns["first_indexed_at"]
+    assert typ.upper() == "INTEGER"
+    assert notnull == 1
+
+    # last_indexed_at: INTEGER NOT NULL
+    name, typ, notnull, dflt, pk = columns["last_indexed_at"]
+    assert typ.upper() == "INTEGER"
+    assert notnull == 1
+
+
+# ---------------------------------------------------------------------------
+# Indexes
+# ---------------------------------------------------------------------------
+
+
+def test_federation_migration_creates_indexes(tmp_path: Path) -> None:
+    """Both federation indexes exist and cover the documented columns.
+
+    * ``idx_nodes_repo_kind`` on ``nodes(repo_id, kind)`` per spec
+      section 5.4 line 193.
+    * ``idx_edges_repo`` on ``edges(repo_id)`` (single-column analog —
+      we don't have a kind-shaped query for edges yet).
+    """
+    db_path = tmp_path / "g.db"
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    indexes = _index_names(db_path)
+    assert "idx_nodes_repo_kind" in indexes
+    assert "idx_edges_repo" in indexes
+
+    assert _index_columns(db_path, "idx_nodes_repo_kind") == ["repo_id", "kind"]
+    assert _index_columns(db_path, "idx_edges_repo") == ["repo_id"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_federation_migration_round_trip(tmp_path: Path) -> None:
+    """upgrade -> downgrade("002") -> upgrade restores the schema cleanly.
+
+    SQLite < 3.35 cannot natively ``ALTER TABLE DROP COLUMN``; the
+    migration uses ``op.batch_alter_table`` for the downgrade path.
+    After the downgrade, neither ``repo_id`` columns nor the ``repos``
+    table nor the federation indexes may remain.
+    """
+    db_path = tmp_path / "g.db"
+    cfg = _alembic_config_for(db_path)
+
+    # Up -> assert federation pieces present.
+    command.upgrade(cfg, "head")
+    assert _column_info(db_path, "nodes", "repo_id") is not None
+    assert _column_info(db_path, "edges", "repo_id") is not None
+    assert "repos" in _table_names(db_path)
+    indexes_up = _index_names(db_path)
+    assert "idx_nodes_repo_kind" in indexes_up
+    assert "idx_edges_repo" in indexes_up
+
+    # Down to 002 -> federation pieces gone, baseline preserved.
+    command.downgrade(cfg, "002")
+    assert _column_info(db_path, "nodes", "repo_id") is None, (
+        "nodes.repo_id leaked through downgrade"
+    )
+    assert _column_info(db_path, "edges", "repo_id") is None, (
+        "edges.repo_id leaked through downgrade"
+    )
+    assert "repos" not in _table_names(db_path), "repos table leaked through downgrade"
+    indexes_down = _index_names(db_path)
+    assert "idx_nodes_repo_kind" not in indexes_down
+    assert "idx_edges_repo" not in indexes_down
+    # Baseline tables and indexes preserved.
+    assert "nodes" in _table_names(db_path)
+    assert "edges" in _table_names(db_path)
+    assert "metadata" in _table_names(db_path)
+    assert "idx_nodes_kind" in indexes_down
+    assert "idx_edges_kind" in indexes_down
+
+    # Up again -> federation pieces restored.
+    command.upgrade(cfg, "head")
+    assert _column_info(db_path, "nodes", "repo_id") is not None
+    assert _column_info(db_path, "edges", "repo_id") is not None
+    assert "repos" in _table_names(db_path)
+    indexes_up_again = _index_names(db_path)
+    assert "idx_nodes_repo_kind" in indexes_up_again
+    assert "idx_edges_repo" in indexes_up_again
+
+
+# ---------------------------------------------------------------------------
+# Default value applied via public API
+# ---------------------------------------------------------------------------
+
+
+def test_federation_migration_default_value(tmp_path: Path) -> None:
+    """A row inserted via ``GraphStore.upsert_node`` has ``repo_id=''``.
+
+    ``upsert_node`` does not (yet) populate ``repo_id`` explicitly — the
+    column relies on the SQL ``DEFAULT ''`` clause. This test guards
+    against the migration accidentally omitting the default value, which
+    would force every existing call site to be modified before single-
+    repo mode keeps working.
+    """
+    db_path = tmp_path / "g.db"
+    store = GraphStore(db_path)
+    try:
+        node = NodeInfo(
+            kind="Function",
+            name="default_check",
+            file_path="src/sample.py",
+            line_start=1,
+            line_end=5,
+            language="python",
+        )
+        store.upsert_node(node)
+
+        row = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+            ("src/sample.py::default_check",),
+        ).fetchone()
+        assert row is not None, "upserted node should be retrievable"
+        assert row["repo_id"] == "", (
+            f"repo_id default should be empty string, got {row['repo_id']!r}"
+        )
+    finally:
+        store.close()

--- a/tests/test_summary_schema.py
+++ b/tests/test_summary_schema.py
@@ -39,7 +39,15 @@ def test_source_hash_index_exists(tmp_path):
 
 
 def test_legacy_db_migration_preserves_rows(tmp_path):
-    """A nodes table created without the v1.6 columns should be migrated in place."""
+    """A nodes table created without the v1.6 columns should be migrated in place.
+
+    Real legacy DBs created by the v1.5 bootstrap always have both the
+    ``nodes`` and ``edges`` tables (the bootstrap script always created
+    both). The fixture mirrors that — the alembic auto-stamp logic in
+    ``_run_alembic_upgrade`` triggers when ``nodes`` is present without
+    an ``alembic_version`` row, and any subsequent migration (e.g.
+    003_federation adding ``edges.repo_id``) needs ``edges`` to exist.
+    """
     db_path = tmp_path / "legacy.db"
     # Create a v1.5-style nodes table missing summary/summary_provider/source_hash.
     # Use a minimal compatible subset of columns that GraphStore upsert_node populates.
@@ -62,6 +70,19 @@ def test_legacy_db_migration_preserves_rows(tmp_path):
             file_hash TEXT,
             extra TEXT,
             updated_at REAL
+        )"""
+    )
+    # Real v1.5 bootstrap also creates the ``edges`` table.
+    conn.execute(
+        """CREATE TABLE edges(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind TEXT NOT NULL,
+            source_qualified TEXT NOT NULL,
+            target_qualified TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            line INTEGER DEFAULT 0,
+            extra TEXT DEFAULT '{}',
+            updated_at REAL NOT NULL
         )"""
     )
     conn.execute(


### PR DESCRIPTION
## Summary
- Add `repo_id TEXT NOT NULL DEFAULT ''` to `nodes` and `edges` tables.
- New `repos` registry table per design spec §5.4 (`repo_id` PK, `path`, `remote_url`, `last_indexed_sha`, `first_indexed_at`, `last_indexed_at`).
- Federation indexes: `idx_nodes_repo_kind` on `(repo_id, kind)`, `idx_edges_repo` on `(repo_id)`.
- Downgrade uses `op.batch_alter_table` for SQLite < 3.35 DROP COLUMN compatibility (env.py already has `render_as_batch=True`).
- Parity test pinned at revision `002` (Option A): `_SCHEMA_SQL` is the legacy in-code bootstrap frozen at v1.6; new schema goes through alembic only.
- Adjacent fixture fix: `test_summary_schema.py::test_legacy_db_migration_preserves_rows` now creates an `edges` table in the synthetic legacy DB. Real v1.5 bootstrap always created both `nodes` + `edges`; without this, the new 003 migration's `ALTER TABLE edges` would fail on the artificially-incomplete fixture.

This is **Phase 2 Task 1 of 12** (epic #325). Migration is purely additive — no parser/runtime changes (Task 2 onwards). `repos` table exists but stays empty until federation is enabled.

## Test plan
- [x] `pytest tests/test_federation_migration.py -v`: 5 passed (column adds + repos table + indexes + round-trip up→down→up + default-value via `GraphStore.upsert_node`).
- [x] `pytest tests/test_alembic_baseline.py -v`: 16 passed (parity test now compares against `002`, all other tests untouched).
- [x] `pytest tests/test_summary_schema.py -v`: 4 passed (legacy fixture now mirrors real v1.5 bootstrap).
- [x] `pytest --cov-fail-under=95 -q`: 754 passed, coverage 95.10%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green on this branch.

## Files
- New: `migrations/versions/003_federation.py`, `tests/test_federation_migration.py`.
- Modified: `tests/test_alembic_baseline.py` (parity test pin + docstring), `tests/test_summary_schema.py` (legacy fixture adds `edges`).
- Untouched: all src files (`graph.py`, `parser.py`, `tools.py`, etc.). Migration is purely additive.

## Out of scope (later tasks)
- Task 2: `RepoRegistry` populates `repos` table on build.
- Tasks 3-8: per-language symbol resolvers (Python, TypeScript, Go, Rust, Java, fallback).
- Task 9: parser/incremental wiring.
- Task 10: cross-cutting `repo` query param on tools.
- Task 11-12: docs + coverage smoke.