### PR TITLE
feat: Phase 2 Task 2 — RepoRegistry (path-derived repo_id + repos table persistence)

### DIFF
--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -1,0 +1,214 @@
+"""Cross-repo federation registry (Phase 2 Task 2).
+
+Maintains a registry of federated repos backed by the ``repos`` table
+(added in alembic revision ``003_federation``). Generates stable,
+path-derived ``repo_id`` values and provides :meth:`RepoRegistry.assign`
+for parsers / incremental update to map a filesystem path back to its
+owning repo.
+
+The registry is intentionally a thin layer on top of the SQLite
+connection owned by :class:`~better_code_review_graph.graph.GraphStore`.
+Federation concerns live here rather than in ``GraphStore`` so the
+public graph API stays focused on nodes / edges; the connection access
+is package-private (``store._conn``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .graph import GraphStore
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """In-memory snapshot of a row in the ``repos`` table."""
+
+    repo_id: str
+    path: Path
+    remote_url: str | None
+    last_indexed_sha: str | None
+    first_indexed_at: int
+    last_indexed_at: int
+
+
+def derive_repo_id(path: Path) -> str:
+    """Deterministic ``<basename>-<sha256[:8]>`` of the absolute path.
+
+    The id is stable across machines and across time because it depends
+    only on the resolved path, never on filesystem metadata. Empty,
+    ``.``, or ``..`` basenames (which happen for filesystem roots like
+    ``/`` or ``C:\\``) normalise to ``"root"`` so the id stays
+    well-formed.
+    """
+    abs_path = str(path.resolve())
+    basename = path.resolve().name
+    if basename in ("", ".", ".."):
+        basename = "root"
+    digest = hashlib.sha256(abs_path.encode("utf-8")).hexdigest()[:8]
+    return f"{basename}-{digest}"
+
+
+class RepoRegistry:
+    """In-memory + DB-backed cross-repo registry.
+
+    Parameters
+    ----------
+    store:
+        The :class:`GraphStore` whose SQLite connection backs the
+        ``repos`` table.
+    repo_id_map:
+        Optional caller-supplied overrides keyed by absolute path. When
+        :meth:`add` is called with a path present in this map, the
+        mapped value wins over the derived id. The keys are normalised
+        through ``Path.resolve`` on construction so callers may pass
+        either resolved or unresolved paths.
+    """
+
+    def __init__(
+        self,
+        store: GraphStore,
+        *,
+        repo_id_map: dict[Path, str] | None = None,
+    ) -> None:
+        self._store = store
+        self._user_overrides: dict[Path, str] = {
+            p.resolve(): rid for p, rid in (repo_id_map or {}).items()
+        }
+        self._entries: dict[str, RepoEntry] = {}
+        # Path-keyed cache for fast assign() lookups.
+        self._by_path: dict[Path, str] = {}
+        self._load_from_store()
+
+    # --- Construction helper ---
+
+    def _load_from_store(self) -> None:
+        """Populate the in-memory caches from the ``repos`` table."""
+        rows = self._store._conn.execute(
+            "SELECT repo_id, path, remote_url, last_indexed_sha, "
+            "first_indexed_at, last_indexed_at FROM repos"
+        ).fetchall()
+        for row in rows:
+            entry = RepoEntry(
+                repo_id=row["repo_id"],
+                path=Path(row["path"]),
+                remote_url=row["remote_url"],
+                last_indexed_sha=row["last_indexed_sha"],
+                first_indexed_at=row["first_indexed_at"],
+                last_indexed_at=row["last_indexed_at"],
+            )
+            self._entries[entry.repo_id] = entry
+            self._by_path[entry.path] = entry.repo_id
+
+    # --- Public API ---
+
+    def add(
+        self,
+        path: Path,
+        *,
+        remote_url: str | None = None,
+    ) -> str:
+        """Register a repo at ``path``. Returns its ``repo_id`` (idempotent).
+
+        Re-adding an existing path keeps ``first_indexed_at`` intact and
+        bumps ``last_indexed_at`` to the current wall clock. User
+        overrides supplied via the constructor's ``repo_id_map`` take
+        precedence over the derived id.
+        """
+        abs_path = path.resolve()
+        repo_id = self._user_overrides.get(abs_path) or derive_repo_id(path)
+        now = int(time.time())
+
+        existing = self._entries.get(repo_id)
+        if existing is not None:
+            self._store._conn.execute(
+                "UPDATE repos SET last_indexed_at = ?, "
+                "remote_url = COALESCE(?, remote_url) WHERE repo_id = ?",
+                (now, remote_url, repo_id),
+            )
+            self._store._conn.commit()
+            updated = RepoEntry(
+                repo_id=repo_id,
+                path=existing.path,
+                remote_url=remote_url or existing.remote_url,
+                last_indexed_sha=existing.last_indexed_sha,
+                first_indexed_at=existing.first_indexed_at,
+                last_indexed_at=now,
+            )
+            self._entries[repo_id] = updated
+            return repo_id
+
+        self._store._conn.execute(
+            "INSERT INTO repos (repo_id, path, remote_url, last_indexed_sha, "
+            "first_indexed_at, last_indexed_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (repo_id, str(abs_path), remote_url, None, now, now),
+        )
+        self._store._conn.commit()
+        self._entries[repo_id] = RepoEntry(
+            repo_id=repo_id,
+            path=abs_path,
+            remote_url=remote_url,
+            last_indexed_sha=None,
+            first_indexed_at=now,
+            last_indexed_at=now,
+        )
+        self._by_path[abs_path] = repo_id
+        return repo_id
+
+    def assign(self, file_path: Path) -> str:
+        """Return the ``repo_id`` whose root contains ``file_path``.
+
+        The longest matching root wins so a child repo registered under
+        a parent (e.g. a vendored fork inside a monorepo) takes
+        precedence over the parent for files within the child.
+
+        Raises
+        ------
+        ValueError
+            When no registered repo is an ancestor of ``file_path``.
+        """
+        abs_file = file_path.resolve()
+        best: tuple[Path, str] | None = None
+        for root, rid in self._by_path.items():
+            try:
+                abs_file.relative_to(root)
+            except ValueError:
+                continue
+            if best is None or len(root.parts) > len(best[0].parts):
+                best = (root, rid)
+        if best is None:
+            raise ValueError(
+                f"No registered repo contains {abs_file}. "
+                f"Registered roots: {sorted(self._by_path)}"
+            )
+        return best[1]
+
+    def update_last_indexed_sha(self, repo_id: str, sha: str) -> None:
+        """Record the last commit SHA indexed for ``repo_id``."""
+        if repo_id not in self._entries:
+            raise ValueError(f"Unknown repo_id: {repo_id}")
+        now = int(time.time())
+        self._store._conn.execute(
+            "UPDATE repos SET last_indexed_sha = ?, last_indexed_at = ? "
+            "WHERE repo_id = ?",
+            (sha, now, repo_id),
+        )
+        self._store._conn.commit()
+        existing = self._entries[repo_id]
+        self._entries[repo_id] = RepoEntry(
+            repo_id=repo_id,
+            path=existing.path,
+            remote_url=existing.remote_url,
+            last_indexed_sha=sha,
+            first_indexed_at=existing.first_indexed_at,
+            last_indexed_at=now,
+        )
+
+    def entries(self) -> list[RepoEntry]:
+        """Return all registered entries (a copy of the in-memory state)."""
+        return list(self._entries.values())

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,0 +1,363 @@
+"""Tests for the cross-repo federation registry (Phase 2 Task 2).
+
+Covers :mod:`better_code_review_graph.federation`:
+
+* ``derive_repo_id`` — deterministic, path-derived identifier.
+* ``RepoRegistry.add`` — persists a repo to the ``repos`` table, idempotent
+  on re-add, honours user overrides.
+* ``RepoRegistry.assign`` — maps a filesystem path back to its owning
+  repo_id (longest-match-wins) and raises when no registered root is an
+  ancestor.
+* ``RepoRegistry`` reload — pre-existing rows are picked up on init so
+  subsequent builds don't need to re-``add()``.
+* ``RepoRegistry.update_last_indexed_sha`` — round-trips the commit SHA
+  to the ``repos.last_indexed_sha`` column.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from better_code_review_graph.federation import (
+    RepoRegistry,
+    derive_repo_id,
+)
+from better_code_review_graph.graph import GraphStore
+
+# ---------------------------------------------------------------------------
+# derive_repo_id
+# ---------------------------------------------------------------------------
+
+
+def test_derive_repo_id_stable(tmp_path: Path) -> None:
+    """Same path -> same id; different paths -> different ids."""
+    a = tmp_path / "repo-a"
+    b = tmp_path / "repo-b"
+    a.mkdir()
+    b.mkdir()
+
+    id_a1 = derive_repo_id(a)
+    id_a2 = derive_repo_id(a)
+    id_b = derive_repo_id(b)
+
+    assert id_a1 == id_a2, "derive_repo_id must be deterministic for the same path"
+    assert id_a1 != id_b, "different paths must produce different ids"
+
+
+def test_derive_repo_id_basename_format(tmp_path: Path) -> None:
+    """Format: ``<basename>-<8 lowercase hex chars>``."""
+    repo = tmp_path / "my-cool-repo"
+    repo.mkdir()
+
+    rid = derive_repo_id(repo)
+
+    assert rid.startswith("my-cool-repo-"), f"unexpected prefix: {rid!r}"
+    suffix = rid[len("my-cool-repo-") :]
+    assert re.fullmatch(r"[0-9a-f]{8}", suffix), (
+        f"suffix must be 8 lowercase hex chars, got {suffix!r}"
+    )
+
+
+def test_derive_repo_id_handles_root_path() -> None:
+    """Filesystem-root and dot-only paths normalise to the ``root-`` prefix."""
+    rid_root = derive_repo_id(Path("/"))
+    assert rid_root.startswith("root-"), f"got {rid_root!r}"
+    suffix = rid_root[len("root-") :]
+    assert re.fullmatch(r"[0-9a-f]{8}", suffix)
+
+
+# ---------------------------------------------------------------------------
+# RepoRegistry.add — persistence and idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_repo_registry_add_persists_to_repos_table(tmp_path: Path) -> None:
+    """``RepoRegistry.add`` writes a row into the ``repos`` table."""
+    db_path = tmp_path / "graph.db"
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        repo_id = registry.add(repo_dir, remote_url="https://example.com/r.git")
+
+        row = store._conn.execute(
+            "SELECT repo_id, path, remote_url, last_indexed_sha, "
+            "first_indexed_at, last_indexed_at FROM repos WHERE repo_id = ?",
+            (repo_id,),
+        ).fetchone()
+        assert row is not None, "row should exist after add()"
+        assert row["repo_id"] == repo_id
+        assert row["path"] == str(repo_dir.resolve())
+        assert row["remote_url"] == "https://example.com/r.git"
+        assert row["last_indexed_sha"] is None
+        assert isinstance(row["first_indexed_at"], int)
+        assert isinstance(row["last_indexed_at"], int)
+        assert row["first_indexed_at"] == row["last_indexed_at"], (
+            "first/last must coincide on the very first insert"
+        )
+    finally:
+        store.close()
+
+
+def test_repo_registry_add_is_idempotent(tmp_path: Path) -> None:
+    """Re-adding the same path returns the same id and only bumps last_indexed_at."""
+    db_path = tmp_path / "graph.db"
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        rid_first = registry.add(repo_dir)
+        first_row = store._conn.execute(
+            "SELECT first_indexed_at, last_indexed_at FROM repos WHERE repo_id = ?",
+            (rid_first,),
+        ).fetchone()
+        first_at = first_row["first_indexed_at"]
+
+        # Force the wall clock to advance so last_indexed_at can change.
+        import time
+
+        time.sleep(1.05)
+
+        rid_second = registry.add(repo_dir)
+        second_row = store._conn.execute(
+            "SELECT first_indexed_at, last_indexed_at FROM repos WHERE repo_id = ?",
+            (rid_second,),
+        ).fetchone()
+
+        assert rid_first == rid_second, "idempotent re-add must return the same id"
+        assert second_row["first_indexed_at"] == first_at, (
+            "first_indexed_at must be preserved across idempotent re-add"
+        )
+        assert second_row["last_indexed_at"] >= first_at, (
+            "last_indexed_at must move forward (or stay) on re-add"
+        )
+
+        # And there is exactly one row for this repo_id.
+        count = store._conn.execute(
+            "SELECT COUNT(*) FROM repos WHERE repo_id = ?", (rid_first,)
+        ).fetchone()[0]
+        assert count == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Reload semantics
+# ---------------------------------------------------------------------------
+
+
+def test_repo_registry_loads_existing_on_init(tmp_path: Path) -> None:
+    """Pre-populated ``repos`` rows are visible on a freshly constructed registry."""
+    db_path = tmp_path / "graph.db"
+    repo_dir = tmp_path / "preloaded"
+    repo_dir.mkdir()
+    file_inside = repo_dir / "src" / "thing.py"
+    file_inside.parent.mkdir(parents=True)
+    file_inside.write_text("# hi\n", encoding="utf-8")
+
+    store = GraphStore(db_path)
+    try:
+        # Inject a row directly; bypass RepoRegistry.add to simulate an
+        # earlier process having populated the table.
+        store._conn.execute(
+            "INSERT INTO repos (repo_id, path, remote_url, last_indexed_sha, "
+            "first_indexed_at, last_indexed_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "preloaded-12345678",
+                str(repo_dir.resolve()),
+                None,
+                None,
+                111,
+                222,
+            ),
+        )
+        store._conn.commit()
+
+        # Fresh registry — must load the existing row, no add() needed.
+        registry = RepoRegistry(store)
+        assigned = registry.assign(file_inside)
+        assert assigned == "preloaded-12345678"
+
+        entries = registry.entries()
+        assert len(entries) == 1
+        assert entries[0].repo_id == "preloaded-12345678"
+        assert entries[0].first_indexed_at == 111
+        assert entries[0].last_indexed_at == 222
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# assign()
+# ---------------------------------------------------------------------------
+
+
+def test_repo_registry_assign_returns_correct_repo(tmp_path: Path) -> None:
+    """Files under each registered root get the correct repo_id."""
+    db_path = tmp_path / "graph.db"
+    repo_a = tmp_path / "alpha"
+    repo_b = tmp_path / "beta"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    file_a = repo_a / "src" / "a.py"
+    file_b = repo_b / "lib" / "b.py"
+    file_a.parent.mkdir(parents=True)
+    file_b.parent.mkdir(parents=True)
+    file_a.write_text("a\n", encoding="utf-8")
+    file_b.write_text("b\n", encoding="utf-8")
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        rid_a = registry.add(repo_a)
+        rid_b = registry.add(repo_b)
+        assert rid_a != rid_b
+
+        assert registry.assign(file_a) == rid_a
+        assert registry.assign(file_b) == rid_b
+    finally:
+        store.close()
+
+
+def test_repo_registry_assign_raises_when_unregistered(tmp_path: Path) -> None:
+    """Files outside every registered root surface a clear ``ValueError``."""
+    db_path = tmp_path / "graph.db"
+    repo = tmp_path / "registered"
+    outside = tmp_path / "elsewhere"
+    repo.mkdir()
+    outside.mkdir()
+    stray = outside / "stray.py"
+    stray.write_text("x\n", encoding="utf-8")
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        registry.add(repo)
+
+        with pytest.raises(ValueError, match="No registered repo"):
+            registry.assign(stray)
+    finally:
+        store.close()
+
+
+def test_repo_registry_assign_longest_match_wins(tmp_path: Path) -> None:
+    """Nested registration: file under child repo resolves to child id.
+
+    Both insertion orders (parent-then-child and child-then-parent) are
+    exercised so the longest-match-wins logic does not depend on dict
+    iteration order.
+    """
+    db_path = tmp_path / "graph.db"
+    parent = tmp_path / "outer"
+    child = parent / "vendor" / "fork"
+    child.mkdir(parents=True)
+    nested_file = child / "src" / "deep.py"
+    nested_file.parent.mkdir(parents=True)
+    nested_file.write_text("deep\n", encoding="utf-8")
+
+    parent_only_file = parent / "top.py"
+    parent_only_file.write_text("top\n", encoding="utf-8")
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        # Insertion order: parent first.
+        rid_parent = registry.add(parent)
+        rid_child = registry.add(child)
+        assert rid_parent != rid_child
+
+        assert registry.assign(nested_file) == rid_child
+        assert registry.assign(parent_only_file) == rid_parent
+    finally:
+        store.close()
+
+    # Reverse insertion order: child first, then parent. Triggers the
+    # branch where a shallower root is encountered AFTER a deeper one
+    # has already been chosen as best — verifies the comparison is
+    # iteration-order-independent.
+    db_path2 = tmp_path / "graph2.db"
+    store2 = GraphStore(db_path2)
+    try:
+        registry2 = RepoRegistry(store2)
+        rid_child2 = registry2.add(child)
+        rid_parent2 = registry2.add(parent)
+        assert rid_child2 != rid_parent2
+
+        assert registry2.assign(nested_file) == rid_child2
+        assert registry2.assign(parent_only_file) == rid_parent2
+    finally:
+        store2.close()
+
+
+# ---------------------------------------------------------------------------
+# User overrides
+# ---------------------------------------------------------------------------
+
+
+def test_repo_registry_user_override(tmp_path: Path) -> None:
+    """``repo_id_map`` overrides the derived id for matching paths."""
+    db_path = tmp_path / "graph.db"
+    repo = tmp_path / "overridden"
+    repo.mkdir()
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(
+            store,
+            repo_id_map={repo: "custom-id"},
+        )
+        rid = registry.add(repo)
+        assert rid == "custom-id", "user override must take precedence"
+
+        # The custom id is what's persisted, and assign() agrees.
+        row = store._conn.execute(
+            "SELECT repo_id FROM repos WHERE repo_id = ?", ("custom-id",)
+        ).fetchone()
+        assert row is not None
+
+        file_inside = repo / "x.py"
+        file_inside.write_text("x\n", encoding="utf-8")
+        assert registry.assign(file_inside) == "custom-id"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# update_last_indexed_sha
+# ---------------------------------------------------------------------------
+
+
+def test_repo_registry_update_last_indexed_sha(tmp_path: Path) -> None:
+    """``update_last_indexed_sha`` round-trips through the ``repos`` table."""
+    db_path = tmp_path / "graph.db"
+    repo = tmp_path / "shaful"
+    repo.mkdir()
+
+    store = GraphStore(db_path)
+    try:
+        registry = RepoRegistry(store)
+        rid = registry.add(repo)
+
+        registry.update_last_indexed_sha(rid, "deadbeef1234")
+
+        row = store._conn.execute(
+            "SELECT last_indexed_sha FROM repos WHERE repo_id = ?", (rid,)
+        ).fetchone()
+        assert row["last_indexed_sha"] == "deadbeef1234"
+
+        # In-memory entry mirrors the DB.
+        entries = {e.repo_id: e for e in registry.entries()}
+        assert entries[rid].last_indexed_sha == "deadbeef1234"
+
+        # Unknown repo_id raises clearly.
+        with pytest.raises(ValueError, match="Unknown repo_id"):
+            registry.update_last_indexed_sha("does-not-exist", "abc")
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- New `src/better_code_review_graph/federation.py` module with `RepoRegistry` class.
- `derive_repo_id(path)` — deterministic id `<basename>-<sha256[:8]>` from absolute path; stable across machines/time; root-path edge case normalized to `"root"`.
- `RepoRegistry.add(path, remote_url=None)` — registers a repo, persists to `repos` table, idempotent on re-add (bumps `last_indexed_at`, keeps `first_indexed_at`).
- `RepoRegistry.assign(file_path)` — returns repo_id of repo containing the file; longest-match-wins for nested repos; raises `ValueError` when no repo registered for the path.
- `RepoRegistry.update_last_indexed_sha(repo_id, sha)` — record the last commit SHA indexed.
- User-overridable via `repo_id_map: dict[Path, str]` constructor arg (overrides derived ids).
- Auto-loads existing `repos` table rows on init (so subsequent builds reuse the same registry).

This is **Phase 2 Task 2 of 12** (epic #325). The module is importable but not yet wired into `parser.py`/`tools.py` (Tasks 9-10 do the wiring). `repos` table from Task 1 (003_federation) is now usable.

## Test plan
- [x] `pytest tests/test_federation.py -v`: 11 passed (deterministic id, format, root edge case, persistence, idempotency, reload, assign happy path, raises on unregistered, longest-match-wins, user override, last_indexed_sha round-trip).
- [x] `pytest --cov-fail-under=95 -q`: 765 passed, total coverage 95.20%, `federation.py` at 100%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green on this branch.

## Files
- New: `src/better_code_review_graph/federation.py` (214 lines), `tests/test_federation.py` (363 lines).
- Untouched: all existing source files. Module is standalone — no public API surface changes elsewhere.

## Out of scope (later tasks)
- Tasks 3-8: per-language symbol resolvers (Python, TypeScript, Go, Rust, Java, fallback).
- Task 9: parser/incremental wiring — `parse_file()` will consult `RepoRegistry.assign()` to populate `NodeInfo.repo_id`.
- Task 10: cross-cutting `repo` query param.
- Tasks 11-12: docs + smoke tests.