### PR TITLE
feat: Phase 2 Task 3 — Python cross-repo resolver

### DIFF
--- a/src/better_code_review_graph/resolver/__init__.py
+++ b/src/better_code_review_graph/resolver/__init__.py
@@ -1,0 +1,8 @@
+"""Cross-repo symbol resolvers (Phase 2).
+
+Per-language modules live alongside this package marker. Task 8 will
+add a language dispatcher; for now callers should import the language
+resolver directly, e.g.::
+
+    from better_code_review_graph.resolver.python import PythonResolver
+"""

--- a/src/better_code_review_graph/resolver/python.py
+++ b/src/better_code_review_graph/resolver/python.py
@@ -1,0 +1,175 @@
+"""Python cross-repo symbol resolver (Phase 2 Task 3).
+
+Resolves ``from lib.utils import retry`` style imports across federated
+repos by:
+
+1. Reading the source repo's ``pyproject.toml`` to confirm the import
+   target is a declared dependency. Cross-repo edges are emitted only
+   for declared deps so we don't spuriously link unrelated packages
+   that happen to share a top-level name.
+2. Walking each target repo's ``src/<package>/`` (PEP 420 namespace
+   packages) to find a matching module path. Both ``module.py`` and
+   ``module/__init__.py`` layouts are supported, and a non-``src``
+   bare-root layout is tried as a fallback.
+3. Returning a qualified-name string
+   ``<target_repo_id>:<file_path>::<symbol>`` on a hit, or ``None``
+   when nothing matches.
+
+Single-repo (non-federated) mode is unaffected: when ``targets`` is
+empty or no match is found, the resolver returns ``None`` and the
+caller leaves the edge as a within-repo bare reference.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TargetRepo:
+    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
+
+    repo_id: str
+    root: Path
+
+
+@dataclass(frozen=True)
+class PythonImport:
+    """Parsed Python import statement.
+
+    ``module`` is the dotted module name being imported from. ``name``
+    is the imported symbol (``from X import Y``) or the trailing
+    component for a dotted ``import X.Y`` (``Y``); for a bare
+    ``import X`` it is ``None`` and the resolver falls back to the
+    module's own basename.
+    """
+
+    module: str
+    name: str | None
+
+
+_FROM_IMPORT_RE = re.compile(r"^from\s+([\w.]+)\s+import\s+(\w+)")
+_BARE_IMPORT_RE = re.compile(r"^import\s+([\w.]+)")
+_DEP_NAME_RE = re.compile(r"^([A-Za-z0-9_.-]+)")
+
+
+def parse_import_statement(stmt: str) -> PythonImport | None:
+    """Parse ``from X import Y`` or ``import X[.Y]``. Returns None on garbage.
+
+    The parser intentionally accepts only the head of an import line so
+    callers can pass either a single source line or a stripped fragment;
+    relative imports (``from .x import y``) and aliased imports
+    (``import x as y``) are out of scope for cross-repo resolution.
+    """
+    stmt = stmt.strip()
+    m = _FROM_IMPORT_RE.match(stmt)
+    if m:
+        return PythonImport(module=m.group(1), name=m.group(2))
+    m = _BARE_IMPORT_RE.match(stmt)
+    if m:
+        full = m.group(1)
+        if "." in full:
+            module, _, name = full.rpartition(".")
+            return PythonImport(module=module, name=name)
+        return PythonImport(module=full, name=None)
+    return None
+
+
+def _read_dependencies(pyproject_path: Path) -> set[str]:
+    """Return the set of normalised top-level dep names from ``[project.dependencies]``.
+
+    Names are lowercased and dashes are replaced with underscores so the
+    set can be compared directly against an import top-level component
+    (``Some-Pkg`` -> ``some_pkg``). Missing files and unparseable TOML
+    yield an empty set so the caller treats both as "no declared deps".
+    """
+    if not pyproject_path.is_file():
+        return set()
+    try:
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return set()
+    project = data.get("project") or {}
+    deps = project.get("dependencies") or []
+    out: set[str] = set()
+    for entry in deps:
+        m = _DEP_NAME_RE.match(str(entry).strip())
+        if m:
+            out.add(m.group(1).lower().replace("-", "_"))
+    return out
+
+
+class PythonResolver:
+    """Resolve Python import statements across federated repos.
+
+    Parameters
+    ----------
+    source_repo_root:
+        Filesystem root of the repo containing the import line. Used to
+        read its ``pyproject.toml`` once at construction time.
+    source_repo_id:
+        Logical id of the source repo. Targets sharing this id are
+        skipped during :meth:`resolve` so a target list including
+        ``self`` never produces a self-referential edge.
+    """
+
+    def __init__(
+        self,
+        source_repo_root: Path,
+        source_repo_id: str,
+    ) -> None:
+        self._source_root = source_repo_root.resolve()
+        self._source_repo_id = source_repo_id
+        self._declared_deps = _read_dependencies(self._source_root / "pyproject.toml")
+
+    def resolve(
+        self,
+        import_stmt: str,
+        targets: list[TargetRepo],
+    ) -> str | None:
+        """Return ``<repo_id>:<file_path>::<symbol>`` on hit, else None."""
+        parsed = parse_import_statement(import_stmt)
+        if parsed is None:
+            return None
+        top_level = parsed.module.split(".")[0].lower().replace("-", "_")
+        if top_level not in self._declared_deps:
+            return None
+        for target in targets:
+            if target.repo_id == self._source_repo_id:
+                continue
+            hit = self._walk_target(target, parsed)
+            if hit is not None:
+                return hit
+        return None
+
+    def _walk_target(
+        self,
+        target: TargetRepo,
+        parsed: PythonImport,
+    ) -> str | None:
+        """Look for ``parsed.module`` under ``target.root``.
+
+        The src-layout (``<root>/src/<pkg>/...``) is preferred and
+        checked first; bare-root layouts (``<root>/<pkg>/...``) act as
+        a fallback so the resolver works for both PEP 420 namespace
+        packages laid out under ``src/`` and legacy flat repos.
+        Returns a qualified name when the module file exists; otherwise
+        ``None``.
+        """
+        target_root = target.root.resolve()
+        module_parts = parsed.module.split(".")
+        symbol = parsed.name or module_parts[-1]
+        for layout_root in (target_root / "src", target_root):
+            module_file = layout_root.joinpath(*module_parts).with_suffix(".py")
+            if module_file.is_file():
+                rel = module_file.relative_to(target_root)
+                return f"{target.repo_id}:{rel.as_posix()}::{symbol}"
+            init_file = layout_root.joinpath(*module_parts) / "__init__.py"
+            if init_file.is_file():
+                rel = init_file.relative_to(target_root)
+                return f"{target.repo_id}:{rel.as_posix()}::{symbol}"
+        return None

--- a/tests/test_resolver_python.py
+++ b/tests/test_resolver_python.py
@@ -1,0 +1,298 @@
+"""Tests for the Python cross-repo resolver (Phase 2 Task 3).
+
+Covers :mod:`better_code_review_graph.resolver.python`:
+
+* ``parse_import_statement`` — turns ``from X import Y`` / ``import X.Y``
+  source lines into a structured :class:`PythonImport`.
+* ``_read_dependencies`` — extracts and normalises top-level deps from
+  ``[project.dependencies]`` in ``pyproject.toml``.
+* ``PythonResolver.resolve`` — gates cross-repo edges by declared deps,
+  walks PEP 420 namespace packages under each target repo, and returns
+  ``<repo_id>:<file_path>::<symbol>`` qualified names on a hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from better_code_review_graph.resolver.python import (
+    PythonImport,
+    PythonResolver,
+    TargetRepo,
+    _read_dependencies,
+    parse_import_statement,
+)
+
+# ---------------------------------------------------------------------------
+# parse_import_statement
+# ---------------------------------------------------------------------------
+
+
+def test_parse_import_from_form() -> None:
+    """``from lib_a.utils import retry`` -> module + name."""
+    parsed = parse_import_statement("from lib_a.utils import retry")
+    assert parsed == PythonImport(module="lib_a.utils", name="retry")
+
+
+def test_parse_import_bare_form() -> None:
+    """``import lib_a.utils`` -> module=lib_a, name=utils (last component)."""
+    parsed = parse_import_statement("import lib_a.utils")
+    assert parsed == PythonImport(module="lib_a", name="utils")
+
+
+def test_parse_import_bare_top_level_only() -> None:
+    """``import lib_a`` (no dot) -> module=lib_a, name=None."""
+    parsed = parse_import_statement("import lib_a")
+    assert parsed == PythonImport(module="lib_a", name=None)
+
+
+def test_parse_import_garbage() -> None:
+    """Non-import strings return None."""
+    assert parse_import_statement("def foo(): pass") is None
+    assert parse_import_statement("") is None
+    assert parse_import_statement("    ") is None
+    assert parse_import_statement("# from lib import x") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_read_dependencies_normalizes_names(tmp_path: Path) -> None:
+    """Lowercase + dash->underscore for PEP 503-ish normalisation."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "consumer"\n'
+        'version = "0.0.0"\n'
+        'dependencies = ["Some-Pkg>=1.0", "another_pkg", "third.pkg"]\n',
+        encoding="utf-8",
+    )
+    deps = _read_dependencies(pyproject)
+    assert deps == {"some_pkg", "another_pkg", "third.pkg"}
+
+
+def test_read_dependencies_missing_file(tmp_path: Path) -> None:
+    """Missing pyproject -> empty set, no exception."""
+    deps = _read_dependencies(tmp_path / "nope.toml")
+    assert deps == set()
+
+
+def test_read_dependencies_invalid_toml(tmp_path: Path) -> None:
+    """Garbled TOML -> empty set (caller treats as 'no declared deps')."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("this is not valid toml [[\n", encoding="utf-8")
+    deps = _read_dependencies(pyproject)
+    assert deps == set()
+
+
+def test_read_dependencies_no_project_table(tmp_path: Path) -> None:
+    """TOML without ``[project]`` is parsed but yields no deps."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.ruff]\nline-length = 88\n", encoding="utf-8")
+    deps = _read_dependencies(pyproject)
+    assert deps == set()
+
+
+# ---------------------------------------------------------------------------
+# PythonResolver.resolve — fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_repo_a(tmp_path: Path) -> Path:
+    """Create ``repo_a/src/lib_a/utils.py`` with a ``retry`` symbol."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "src" / "lib_a"
+    pkg.mkdir(parents=True)
+    (pkg / "utils.py").write_text("def retry():\n    pass\n", encoding="utf-8")
+    # PEP 420 namespace package — no __init__.py at lib_a/.
+    return repo_a
+
+
+def _build_repo_b(tmp_path: Path, deps: list[str]) -> Path:
+    """Create ``repo_b`` with a pyproject declaring ``deps``."""
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    deps_str = ", ".join(f'"{d}"' for d in deps)
+    (repo_b / "pyproject.toml").write_text(
+        f'[project]\nname = "repo_b"\nversion = "0.0.0"\ndependencies = [{deps_str}]\n',
+        encoding="utf-8",
+    )
+    src = repo_b / "src" / "app"
+    src.mkdir(parents=True)
+    (src / "main.py").write_text(
+        "from lib_a.utils import retry\n\nretry()\n",
+        encoding="utf-8",
+    )
+    return repo_b
+
+
+# ---------------------------------------------------------------------------
+# PythonResolver.resolve — behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_finds_target_via_namespace_package(tmp_path: Path) -> None:
+    """The plan-required 2-repo fixture: cross-repo dep + namespace package."""
+    repo_a = _build_repo_a(tmp_path)
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:src/lib_a/utils.py::retry"
+
+
+def test_resolver_returns_none_for_undeclared_dep(tmp_path: Path) -> None:
+    """No cross-repo edge unless the import top-level is in [project.dependencies]."""
+    repo_a = _build_repo_a(tmp_path)
+    # repo_b declares NO deps, so the import is not gated through.
+    repo_b = _build_repo_b(tmp_path, deps=[])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_for_garbage_import(tmp_path: Path) -> None:
+    """Unparseable import line -> None even with valid targets."""
+    repo_a = _build_repo_a(tmp_path)
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    assert (
+        resolver.resolve(
+            "this is not an import",
+            targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+        )
+        is None
+    )
+
+
+def test_resolver_finds_via_init_py(tmp_path: Path) -> None:
+    """When ``module/__init__.py`` exists instead of ``module.py``, still resolves."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "src" / "lib_a" / "utils"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("def retry():\n    pass\n", encoding="utf-8")
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:src/lib_a/utils/__init__.py::retry"
+
+
+def test_resolver_skips_self_repo(tmp_path: Path) -> None:
+    """A target with the same repo_id as source is skipped (no self-references)."""
+    repo_a = _build_repo_a(tmp_path)
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_a_id",  # same as target below -> must be skipped
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_when_no_target_has_file(tmp_path: Path) -> None:
+    """Declared dep but the file isn't in any target -> None."""
+    # Empty repo_a — no lib_a directory at all.
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir()
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_handles_dotted_modules_correctly(tmp_path: Path) -> None:
+    """``from a.b.c import d`` walks ``a/b/c.py``."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "src" / "a" / "b"
+    pkg.mkdir(parents=True)
+    (pkg / "c.py").write_text("def d():\n    pass\n", encoding="utf-8")
+
+    repo_b = _build_repo_b(tmp_path, deps=["a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from a.b.c import d",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:src/a/b/c.py::d"
+
+
+def test_resolver_falls_back_to_bare_root_layout(tmp_path: Path) -> None:
+    """Repos without ``src/`` layout still resolve from the repo root."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "lib_a"
+    pkg.mkdir(parents=True)
+    (pkg / "utils.py").write_text("def retry():\n    pass\n", encoding="utf-8")
+
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "from lib_a.utils import retry",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:lib_a/utils.py::retry"
+
+
+def test_resolver_bare_import_returns_qualified_name(tmp_path: Path) -> None:
+    """``import lib_a.utils`` parses as module=lib_a, name=utils -> resolves to package init/module."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "src" / "lib_a"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    repo_b = _build_repo_b(tmp_path, deps=["lib_a"])
+
+    resolver = PythonResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import lib_a",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    # ``import lib_a`` with no dot has name=None; resolver falls back to
+    # the last module component ("lib_a") as the symbol.
+    assert qualified == "repo_a_id:src/lib_a/__init__.py::lib_a"


### PR DESCRIPTION
## Summary
- New `src/better_code_review_graph/resolver/` package (`__init__.py` placeholder for Task 8 dispatcher).
- `resolver/python.py` — `PythonResolver.resolve(import_stmt, targets)` returns `<repo_id>:<file>::<symbol>` for cross-repo Python imports.
- Reads source repo `pyproject.toml [project.dependencies]` to gate edges (only declared deps emit cross-repo links — avoids spurious matches on unrelated packages sharing a top-level name).
- Walks PEP 420 namespace packages: tries `repo/src/<package>/...py` first (preferred src-layout), then bare-root fallback.
- Skips self-references (target_repos containing source repo_id are filtered out).
- Returns None when import is malformed, dep is undeclared, or no target repo has the file.
- Helpers: `parse_import_statement` (handles `from X import Y` and `import X.Y`), `_read_dependencies` (PEP 508 normalization: lowercase + dash→underscore, defensive on missing/malformed TOML).

This is **Phase 2 Task 3 of 12** (epic #325). Module is importable but not yet wired (Task 8 dispatcher + Task 9 parser wiring).

## Test plan
- [x] `pytest tests/test_resolver_python.py -v`: 17 passed (12 spec cases + 5 branch coverage cases including bare-root fallback, dotted modules, init.py-only modules).
- [x] `pytest --cov-fail-under=95 -q` excluding ONNX-dependent files (test_embeddings, test_tools_full): 638 passed. The 2 ONNX files fail with `bad allocation` on the local Windows dev env (verified pre-existing on main); CI Linux runner doesn't hit this.
- [x] `grep -c "directory" uv.lock`: 0 (committed state).
- [ ] CI green on this branch — should pass since Linux CI doesn't have the ONNX Windows env issue.

## Files
- New: `src/better_code_review_graph/resolver/__init__.py` (8 lines), `resolver/python.py` (175 lines), `tests/test_resolver_python.py` (298 lines, 17 tests).
- Untouched: all existing source files. Module is standalone — no public API changes.

## Out of scope (later tasks)
- Tasks 4-7: TypeScript / Go / Rust / Java per-language resolvers.
- Task 8: fallback resolver + dispatcher (`resolver/__init__.py:resolve_cross_repo_imports`).
- Task 9: parser/incremental wiring.
- Task 10: cross-cutting `repo` query param.
- Tasks 11-12: docs + smoke.

## Note on pre-commit pytest skip
The implementer's local pre-commit run had `SKIP=pytest` (not `--no-verify`) due to environmental ONNX `bad allocation` on this Windows machine when loading the Qwen3-Embedding model. The 17 new tests were verified separately via direct `uv run pytest tests/test_resolver_python.py`. CI will run the full suite cleanly.