### PR TITLE
feat: Phase 2 Task 4 — TypeScript cross-repo resolver

### DIFF
--- a/src/better_code_review_graph/resolver/typescript.py
+++ b/src/better_code_review_graph/resolver/typescript.py
@@ -1,0 +1,260 @@
+"""TypeScript cross-repo symbol resolver (Phase 2 Task 4).
+
+Resolves ``import { foo } from '@/lib/utils'`` style imports across
+federated TypeScript repos by:
+
+1. Reading the source repo's ``tsconfig.json`` ``compilerOptions.paths``
+   to expand path-mapping aliases (``@/foo/*`` -> ``packages/foo/*``).
+2. Reading each target repo's ``package.json`` ``workspaces`` field
+   (string list or ``{packages: [...]}`` object form) to identify
+   monorepo workspace roots.
+3. Walking each target repo's workspace dirs to find the matching
+   ``.ts`` / ``.tsx`` / ``.d.ts`` file (with ``index.ts`` /
+   ``index.tsx`` directory fallback).
+4. Returning ``<target_repo_id>:<file_path>::<symbol>`` on hit, else
+   ``None``.
+
+Single-repo (non-federated) mode is unaffected: when ``targets`` is
+empty or no match is found, the resolver returns ``None`` and the
+caller leaves the edge as a within-repo bare reference.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TargetRepo:
+    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
+
+    repo_id: str
+    root: Path
+
+
+@dataclass(frozen=True)
+class TypeScriptImport:
+    """Parsed TypeScript import declaration.
+
+    ``module`` is the module specifier (``'@/lib/utils'``,
+    ``'lodash'``, etc). ``name`` is the symbol associated with the
+    import: the namespace identifier for ``import * as ns``, the
+    default-import name for ``import x from``, the first named symbol
+    for ``import { x, y }``, or ``None`` for side-effect-only imports
+    (``import 'reflect-metadata'``).
+    """
+
+    module: str
+    name: str | None
+
+
+# Match named imports first (curly braces present) -> capture first symbol.
+_NAMED_IMPORT_RE = re.compile(
+    r"^import\s*\{\s*(\w+)[^}]*\}\s*from\s*['\"]([^'\"]+)['\"]"
+)
+# Match ``import * as ns from 'mod'``.
+_NAMESPACE_IMPORT_RE = re.compile(
+    r"^import\s+\*\s+as\s+(\w+)\s+from\s*['\"]([^'\"]+)['\"]"
+)
+# Match ``import name from 'mod'`` (default).
+_DEFAULT_IMPORT_RE = re.compile(r"^import\s+(\w+)\s+from\s*['\"]([^'\"]+)['\"]")
+# Match ``import 'mod'`` (side effect only).
+_SIDE_EFFECT_IMPORT_RE = re.compile(r"^import\s*['\"]([^'\"]+)['\"]")
+
+
+def parse_import_statement(stmt: str) -> TypeScriptImport | None:
+    """Parse a TypeScript import declaration. Returns None on garbage.
+
+    Supported forms (in matching order):
+
+    * ``import { foo, bar } from 'mod'`` -> ``name='foo'`` (first
+      named symbol)
+    * ``import * as ns from 'mod'`` -> ``name='ns'``
+    * ``import foo from 'mod'`` -> ``name='foo'`` (default import)
+    * ``import 'mod'`` -> ``name=None`` (side-effect only)
+
+    A trailing ``;`` is tolerated. Lines that look like comments,
+    declarations, or anything else return ``None``.
+    """
+    stmt = stmt.strip().rstrip(";").strip()
+    m = _NAMED_IMPORT_RE.match(stmt)
+    if m:
+        return TypeScriptImport(module=m.group(2), name=m.group(1))
+    m = _NAMESPACE_IMPORT_RE.match(stmt)
+    if m:
+        return TypeScriptImport(module=m.group(2), name=m.group(1))
+    m = _DEFAULT_IMPORT_RE.match(stmt)
+    if m:
+        return TypeScriptImport(module=m.group(2), name=m.group(1))
+    m = _SIDE_EFFECT_IMPORT_RE.match(stmt)
+    if m:
+        return TypeScriptImport(module=m.group(1), name=None)
+    return None
+
+
+def _read_tsconfig_paths(tsconfig_path: Path) -> dict[str, list[str]]:
+    """Return ``compilerOptions.paths`` mapping. Empty dict on missing/malformed.
+
+    ``tsconfig.json`` files frequently contain ``//`` line comments
+    which are not strict JSON; this helper strips those before
+    parsing. Non-existent or unparseable files yield an empty dict so
+    the caller treats both as "no path aliases".
+    """
+    if not tsconfig_path.is_file():
+        return {}
+    try:
+        text = tsconfig_path.read_text(encoding="utf-8")
+        # Strip ``//`` line comments (good-enough for the common case;
+        # block comments and string-embedded ``//`` are out of scope).
+        text = re.sub(r"//[^\n]*", "", text)
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    compiler_options = data.get("compilerOptions") or {}
+    paths = compiler_options.get("paths") or {}
+    out: dict[str, list[str]] = {}
+    for alias, target in paths.items():
+        # TypeScript allows either a string or a list of strings.
+        if isinstance(target, str):
+            out[alias] = [target]
+        elif isinstance(target, list):
+            out[alias] = [str(t) for t in target]
+    return out
+
+
+def _read_workspaces(package_json_path: Path) -> list[str]:
+    """Return ``workspaces`` glob list from ``package.json``.
+
+    Both the npm/yarn array form (``"workspaces": ["packages/*"]``) and
+    the yarn classic object form (``"workspaces": {"packages": [...]}``)
+    are supported. Missing files, unparseable JSON, missing field, or
+    the object form without a ``packages`` key all yield an empty list.
+    """
+    if not package_json_path.is_file():
+        return []
+    try:
+        data = json.loads(package_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    ws = data.get("workspaces")
+    if isinstance(ws, list):
+        return [str(w) for w in ws]
+    if isinstance(ws, dict):
+        packages = ws.get("packages") or []
+        return [str(p) for p in packages]
+    return []
+
+
+def _expand_alias(import_module: str, paths: dict[str, list[str]]) -> list[str]:
+    """Expand a tsconfig path alias into candidate filesystem paths.
+
+    ``paths={"@/foo/*": ["packages/foo/*"]}`` with ``import_module =
+    "@/foo/utils"`` yields ``["packages/foo/utils"]``. Aliases ending
+    in ``/*`` glob-match a prefix and substitute the suffix into the
+    target. Aliases without ``/*`` only match the exact module
+    specifier. When no alias matches, the module is returned as the
+    sole candidate (the resolver will then try to find it directly
+    under workspace roots / repo root).
+    """
+    candidates: list[str] = []
+    for alias, targets in paths.items():
+        if alias.endswith("/*"):
+            prefix = alias[:-2]
+            if import_module.startswith(prefix + "/"):
+                suffix = import_module[len(prefix) + 1 :]
+                for t in targets:
+                    if t.endswith("/*"):
+                        candidates.append(t[:-2] + "/" + suffix)
+                    else:
+                        candidates.append(t + "/" + suffix)
+        elif import_module == alias:
+            candidates.extend(targets)
+    if not candidates:
+        candidates.append(import_module)
+    return candidates
+
+
+class TypeScriptResolver:
+    """Resolve TypeScript imports across federated repos.
+
+    Parameters
+    ----------
+    source_repo_root:
+        Filesystem root of the repo containing the import line. Used
+        to read its ``tsconfig.json`` once at construction time.
+    source_repo_id:
+        Logical id of the source repo. Targets sharing this id are
+        skipped during :meth:`resolve` so a target list including
+        ``self`` never produces a self-referential edge.
+    """
+
+    def __init__(
+        self,
+        source_repo_root: Path,
+        source_repo_id: str,
+    ) -> None:
+        self._source_root = source_repo_root.resolve()
+        self._source_repo_id = source_repo_id
+        self._tsconfig_paths = _read_tsconfig_paths(self._source_root / "tsconfig.json")
+
+    def resolve(
+        self,
+        import_stmt: str,
+        targets: list[TargetRepo],
+    ) -> str | None:
+        """Return ``<repo_id>:<file_path>::<symbol>`` on hit, else None."""
+        parsed = parse_import_statement(import_stmt)
+        if parsed is None or parsed.name is None:
+            # Side-effect imports don't link to a specific symbol, and
+            # garbage lines have nothing to look up.
+            return None
+        candidates = _expand_alias(parsed.module, self._tsconfig_paths)
+        for target in targets:
+            if target.repo_id == self._source_repo_id:
+                continue
+            hit = self._walk_target(target, candidates, parsed.name)
+            if hit is not None:
+                return hit
+        return None
+
+    def _walk_target(
+        self,
+        target: TargetRepo,
+        candidates: list[str],
+        symbol: str,
+    ) -> str | None:
+        """Look for any candidate path under target's workspace roots.
+
+        Each workspace glob (``packages/*``) is treated as a directory
+        prefix (``packages``) under which candidate paths are joined.
+        The repo root itself is also tried as a fallback so monorepos
+        without a ``workspaces`` declaration still resolve. For each
+        ``(root, candidate)`` pair, the ``.ts`` / ``.tsx`` / ``.d.ts``
+        extensions are tried plus an ``index.ts`` / ``index.tsx``
+        directory form. Returns the qualified name on the first hit.
+        """
+        target_root = target.root.resolve()
+        workspaces = _read_workspaces(target_root / "package.json")
+        # Build search roots: workspace dirs first, then bare repo root.
+        search_roots: list[Path] = []
+        for ws_glob in workspaces:
+            ws_dir = ws_glob.rstrip("/*").rstrip("/")
+            search_roots.append(target_root / ws_dir)
+        search_roots.append(target_root)
+
+        for candidate in candidates:
+            for root in search_roots:
+                for ext in (".ts", ".tsx", ".d.ts"):
+                    f = root / (candidate + ext)
+                    if f.is_file():
+                        rel = f.resolve().relative_to(target_root)
+                        return f"{target.repo_id}:{rel.as_posix()}::{symbol}"
+                for index_name in ("index.ts", "index.tsx"):
+                    f = root / candidate / index_name
+                    if f.is_file():
+                        rel = f.resolve().relative_to(target_root)
+                        return f"{target.repo_id}:{rel.as_posix()}::{symbol}"
+        return None

--- a/tests/test_resolver_typescript.py
+++ b/tests/test_resolver_typescript.py
@@ -1,0 +1,543 @@
+"""Tests for the TypeScript cross-repo resolver (Phase 2 Task 4).
+
+Covers :mod:`better_code_review_graph.resolver.typescript`:
+
+* ``parse_import_statement`` — turns ``import { x } from 'mod'`` /
+  ``import x from 'mod'`` / ``import * as ns from 'mod'`` /
+  ``import 'mod'`` source lines into a :class:`TypeScriptImport`.
+* ``_read_tsconfig_paths`` — extracts ``compilerOptions.paths`` mapping
+  from ``tsconfig.json`` (tolerates ``//`` line comments commonly used
+  in TypeScript config files).
+* ``_read_workspaces`` — extracts ``workspaces`` from ``package.json``
+  in either array form (``["packages/*"]``) or object form
+  (``{"packages": [...]}``).
+* ``_expand_alias`` — applies tsconfig path mapping to an import module
+  to produce candidate filesystem paths.
+* ``TypeScriptResolver.resolve`` — walks each target repo's workspace
+  roots applying tsconfig path mapping and returns
+  ``<repo_id>:<file_path>::<symbol>`` qualified names on a hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from better_code_review_graph.resolver.typescript import (
+    TargetRepo,
+    TypeScriptImport,
+    TypeScriptResolver,
+    _expand_alias,
+    _read_tsconfig_paths,
+    _read_workspaces,
+    parse_import_statement,
+)
+
+# ---------------------------------------------------------------------------
+# parse_import_statement
+# ---------------------------------------------------------------------------
+
+
+def test_parse_import_named_form() -> None:
+    """``import { foo } from 'mod'`` -> module='mod', name='foo'."""
+    parsed = parse_import_statement("import { foo } from 'mod'")
+    assert parsed == TypeScriptImport(module="mod", name="foo")
+
+
+def test_parse_import_named_form_multi_symbol() -> None:
+    """First named symbol wins for multi-symbol named imports."""
+    parsed = parse_import_statement("import { foo, bar, baz } from 'mod'")
+    assert parsed == TypeScriptImport(module="mod", name="foo")
+
+
+def test_parse_import_default_form() -> None:
+    """``import foo from 'mod'`` -> module='mod', name='foo'."""
+    parsed = parse_import_statement("import foo from 'mod'")
+    assert parsed == TypeScriptImport(module="mod", name="foo")
+
+
+def test_parse_import_namespace_form() -> None:
+    """``import * as ns from 'mod'`` -> module='mod', name='ns'."""
+    parsed = parse_import_statement("import * as ns from 'mod'")
+    assert parsed == TypeScriptImport(module="mod", name="ns")
+
+
+def test_parse_import_side_effect() -> None:
+    """``import 'mod'`` -> module='mod', name=None (no symbol)."""
+    parsed = parse_import_statement("import 'mod'")
+    assert parsed == TypeScriptImport(module="mod", name=None)
+
+
+def test_parse_import_double_quotes() -> None:
+    """Double-quoted module specifiers work the same as single-quoted ones."""
+    parsed = parse_import_statement('import { foo } from "mod"')
+    assert parsed == TypeScriptImport(module="mod", name="foo")
+
+
+def test_parse_import_with_trailing_semicolon() -> None:
+    """Trailing semicolons are tolerated."""
+    parsed = parse_import_statement("import { foo } from 'mod';")
+    assert parsed == TypeScriptImport(module="mod", name="foo")
+
+
+def test_parse_import_garbage() -> None:
+    """Non-import strings return None."""
+    assert parse_import_statement("function foo() {}") is None
+    assert parse_import_statement("") is None
+    assert parse_import_statement("    ") is None
+    assert parse_import_statement("// import { x } from 'mod'") is None
+    assert parse_import_statement("const x = 1") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_tsconfig_paths
+# ---------------------------------------------------------------------------
+
+
+def test_read_tsconfig_paths_handles_comments(tmp_path: Path) -> None:
+    """tsconfig with ``//`` line comments parses correctly."""
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text(
+        """{
+  // Project root tsconfig
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/foo/*": ["packages/foo/*"]  // workspace alias
+    }
+  }
+}
+""",
+        encoding="utf-8",
+    )
+    paths = _read_tsconfig_paths(tsconfig)
+    assert paths == {"@/foo/*": ["packages/foo/*"]}
+
+
+def test_read_tsconfig_paths_string_value_normalised_to_list(tmp_path: Path) -> None:
+    """Single-string path target normalises to a one-element list."""
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text(
+        '{"compilerOptions": {"paths": {"@/foo": "packages/foo"}}}',
+        encoding="utf-8",
+    )
+    paths = _read_tsconfig_paths(tsconfig)
+    assert paths == {"@/foo": ["packages/foo"]}
+
+
+def test_read_tsconfig_paths_missing_file(tmp_path: Path) -> None:
+    """Missing tsconfig -> empty dict, no exception."""
+    paths = _read_tsconfig_paths(tmp_path / "nope.json")
+    assert paths == {}
+
+
+def test_read_tsconfig_paths_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON -> empty dict (caller treats as 'no paths')."""
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text("this is not json {{{", encoding="utf-8")
+    paths = _read_tsconfig_paths(tsconfig)
+    assert paths == {}
+
+
+def test_read_tsconfig_paths_no_compiler_options(tmp_path: Path) -> None:
+    """tsconfig without ``compilerOptions`` -> empty dict."""
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text('{"include": ["src/**/*"]}', encoding="utf-8")
+    paths = _read_tsconfig_paths(tsconfig)
+    assert paths == {}
+
+
+# ---------------------------------------------------------------------------
+# _read_workspaces
+# ---------------------------------------------------------------------------
+
+
+def test_read_workspaces_array_form(tmp_path: Path) -> None:
+    """``"workspaces": ["packages/*"]`` -> ['packages/*']."""
+    pkg = tmp_path / "package.json"
+    pkg.write_text(
+        '{"name": "root", "workspaces": ["packages/*", "apps/*"]}',
+        encoding="utf-8",
+    )
+    assert _read_workspaces(pkg) == ["packages/*", "apps/*"]
+
+
+def test_read_workspaces_object_form(tmp_path: Path) -> None:
+    """``"workspaces": {"packages": [...]}`` -> the inner list."""
+    pkg = tmp_path / "package.json"
+    pkg.write_text(
+        '{"name": "root", "workspaces": {"packages": ["packages/*"]}}',
+        encoding="utf-8",
+    )
+    assert _read_workspaces(pkg) == ["packages/*"]
+
+
+def test_read_workspaces_missing_file(tmp_path: Path) -> None:
+    """Missing package.json -> empty list."""
+    assert _read_workspaces(tmp_path / "nope.json") == []
+
+
+def test_read_workspaces_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON -> empty list."""
+    pkg = tmp_path / "package.json"
+    pkg.write_text("not json {{{", encoding="utf-8")
+    assert _read_workspaces(pkg) == []
+
+
+def test_read_workspaces_absent_field(tmp_path: Path) -> None:
+    """package.json without ``workspaces`` -> empty list."""
+    pkg = tmp_path / "package.json"
+    pkg.write_text('{"name": "root", "version": "0.0.0"}', encoding="utf-8")
+    assert _read_workspaces(pkg) == []
+
+
+def test_read_workspaces_object_form_no_packages_key(tmp_path: Path) -> None:
+    """Object form without ``packages`` key -> empty list."""
+    pkg = tmp_path / "package.json"
+    pkg.write_text(
+        '{"name": "root", "workspaces": {"nohoist": ["**/react-native"]}}',
+        encoding="utf-8",
+    )
+    assert _read_workspaces(pkg) == []
+
+
+# ---------------------------------------------------------------------------
+# _expand_alias
+# ---------------------------------------------------------------------------
+
+
+def test_expand_alias_with_glob() -> None:
+    """``@/foo/*`` -> ``packages/foo/*`` rewrites the suffix."""
+    candidates = _expand_alias(
+        "@/foo/utils",
+        {"@/foo/*": ["packages/foo/*"]},
+    )
+    assert candidates == ["packages/foo/utils"]
+
+
+def test_expand_alias_exact_match() -> None:
+    """Exact (non-glob) alias maps to the literal target list."""
+    candidates = _expand_alias("~lib", {"~lib": ["lib"]})
+    assert candidates == ["lib"]
+
+
+def test_expand_alias_no_match_returns_module_as_is() -> None:
+    """Module without a matching alias is returned unchanged."""
+    candidates = _expand_alias(
+        "lodash",
+        {"@/foo/*": ["packages/foo/*"]},
+    )
+    assert candidates == ["lodash"]
+
+
+def test_expand_alias_empty_paths() -> None:
+    """Empty paths dict -> module returned as-is."""
+    assert _expand_alias("anything", {}) == ["anything"]
+
+
+def test_expand_alias_glob_target_without_star() -> None:
+    """Glob alias mapped to a non-glob target still works (joined with /)."""
+    candidates = _expand_alias(
+        "@/foo/utils",
+        {"@/foo/*": ["packages/foo"]},
+    )
+    assert candidates == ["packages/foo/utils"]
+
+
+def test_expand_alias_multi_target() -> None:
+    """Multiple target paths produce multiple candidates."""
+    candidates = _expand_alias(
+        "@/foo/utils",
+        {"@/foo/*": ["packages/foo/*", "vendor/foo/*"]},
+    )
+    assert candidates == ["packages/foo/utils", "vendor/foo/utils"]
+
+
+# ---------------------------------------------------------------------------
+# TypeScriptResolver.resolve — fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_repo_a_with_workspaces(tmp_path: Path) -> Path:
+    """Create ``repo_a`` with ``packages/foo/utils.ts`` and yarn workspaces."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "packages" / "foo"
+    pkg.mkdir(parents=True)
+    (pkg / "utils.ts").write_text(
+        "export function bar() { return 1 }\n",
+        encoding="utf-8",
+    )
+    (repo_a / "package.json").write_text(
+        '{"name": "repo_a", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+    return repo_a
+
+
+def _build_repo_b_with_alias(tmp_path: Path) -> Path:
+    """Create ``repo_b`` with tsconfig path alias to ``packages/foo/*``."""
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "tsconfig.json").write_text(
+        """{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/foo/*": ["packages/foo/*"]
+    }
+  }
+}
+""",
+        encoding="utf-8",
+    )
+    (repo_b / "package.json").write_text(
+        '{"name": "repo_b", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+    return repo_b
+
+
+# ---------------------------------------------------------------------------
+# TypeScriptResolver.resolve — behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_finds_workspace_target(tmp_path: Path) -> None:
+    """The plan-required 2-repo monorepo fixture (test 13).
+
+    repo_a has ``packages/foo/utils.ts::bar`` plus yarn workspaces.
+    repo_b has tsconfig ``"@/foo/*": ["packages/foo/*"]`` plus workspaces.
+    Parsing ``import { bar } from '@/foo/utils'`` against repo_a should
+    yield ``repo_a_id:packages/foo/utils.ts::bar``.
+    """
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { bar } from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/foo/utils.ts::bar"
+
+
+def test_resolver_finds_via_index_ts(tmp_path: Path) -> None:
+    """Module that resolves to a directory uses ``index.ts``."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "packages" / "foo" / "utils"
+    pkg.mkdir(parents=True)
+    (pkg / "index.ts").write_text(
+        "export function bar() {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "package.json").write_text(
+        '{"name": "repo_a", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { bar } from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/foo/utils/index.ts::bar"
+
+
+def test_resolver_finds_via_tsx_extension(tmp_path: Path) -> None:
+    """``.tsx`` files (React component) are also matched."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "packages" / "ui"
+    pkg.mkdir(parents=True)
+    (pkg / "Button.tsx").write_text(
+        "export function Button() {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "package.json").write_text(
+        '{"name": "repo_a", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "tsconfig.json").write_text(
+        '{"compilerOptions": {"paths": {"@/ui/*": ["packages/ui/*"]}}}',
+        encoding="utf-8",
+    )
+    (repo_b / "package.json").write_text(
+        '{"name": "repo_b", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { Button } from '@/ui/Button'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/ui/Button.tsx::Button"
+
+
+def test_resolver_skips_self_repo(tmp_path: Path) -> None:
+    """A target with the same repo_id as source is skipped."""
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_a_id",  # same as target -> skip
+    )
+    qualified = resolver.resolve(
+        "import { bar } from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_when_no_target_has_file(tmp_path: Path) -> None:
+    """No target contains the file -> None."""
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir()
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { bar } from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_for_side_effect_import(tmp_path: Path) -> None:
+    """``import 'reflect-metadata'`` has no symbol -> None."""
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import 'reflect-metadata'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_for_garbage_import(tmp_path: Path) -> None:
+    """Unparseable line -> None even with valid targets."""
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "this is not an import",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_finds_via_d_ts_declaration(tmp_path: Path) -> None:
+    """Declaration files (``.d.ts``) are also matched as a fallback."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "packages" / "types"
+    pkg.mkdir(parents=True)
+    (pkg / "index.d.ts").write_text(
+        "export type Foo = string\n",
+        encoding="utf-8",
+    )
+    (repo_a / "package.json").write_text(
+        '{"name": "repo_a", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "tsconfig.json").write_text(
+        '{"compilerOptions": {"paths": {"@/types/*": ["packages/types/*"]}}}',
+        encoding="utf-8",
+    )
+    (repo_b / "package.json").write_text(
+        '{"name": "repo_b", "workspaces": ["packages/*"]}',
+        encoding="utf-8",
+    )
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { Foo } from '@/types/index'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/types/index.d.ts::Foo"
+
+
+def test_resolver_falls_back_to_bare_root_when_no_workspaces(tmp_path: Path) -> None:
+    """Targets without ``workspaces`` declaration still search ``target_root``."""
+    repo_a = tmp_path / "repo_a"
+    (repo_a / "lib").mkdir(parents=True)
+    (repo_a / "lib" / "utils.ts").write_text(
+        "export function bar() {}\n",
+        encoding="utf-8",
+    )
+    # No package.json on repo_a -> bare-root fallback only.
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "tsconfig.json").write_text(
+        '{"compilerOptions": {"paths": {"@/lib/*": ["lib/*"]}}}',
+        encoding="utf-8",
+    )
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import { bar } from '@/lib/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:lib/utils.ts::bar"
+
+
+def test_resolver_default_import_resolves(tmp_path: Path) -> None:
+    """``import bar from '@/foo/utils'`` (default form) also resolves."""
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import bar from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/foo/utils.ts::bar"
+
+
+def test_resolver_namespace_import_resolves(tmp_path: Path) -> None:
+    """``import * as utils from '@/foo/utils'`` resolves with the namespace name."""
+    repo_a = _build_repo_a_with_workspaces(tmp_path)
+    repo_b = _build_repo_b_with_alias(tmp_path)
+
+    resolver = TypeScriptResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "import * as utils from '@/foo/utils'",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:packages/foo/utils.ts::utils"


### PR DESCRIPTION
## Summary
- New `resolver/typescript.py` — `TypeScriptResolver.resolve(import_stmt, targets)` returns `<repo_id>:<file>::<symbol>` for cross-repo TypeScript imports.
- Reads source repo `tsconfig.json compilerOptions.paths` (with `// line comment` tolerance) for path-mapping aliases (`@/foo/*` → `packages/foo/*`).
- Reads target repos' `package.json workspaces` (both array form `["packages/*"]` and object form `{packages: [...]}`).
- Walks workspace roots first, then bare repo root. Tries `.ts` → `.tsx` → `.d.ts` extensions, then `index.{ts,tsx}` fallback for directory-style modules.
- Parses 4 import forms: `import { x } from 'mod'` (named), `import x from 'mod'` (default), `import * as ns from 'mod'` (namespace), `import 'mod'` (side-effect; returns None — no symbol to link).

This is **Phase 2 Task 4 of 12** (epic #325). Module is importable but not yet wired (Task 8 dispatcher + Task 9 parser wiring).

## Test plan
- [x] `pytest tests/test_resolver_typescript.py -v`: 36 passed (4 parse forms + tsconfig comment tolerance + workspace array/object forms + alias glob/exact/no-match + 2-repo monorepo fixture from spec + index.ts fallback + self-skip + side-effect → None).
- [x] Coverage: `typescript.py` 99%, total 98.86%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green on this branch.

## Files
- New: `src/better_code_review_graph/resolver/typescript.py` (~155 lines), `tests/test_resolver_typescript.py` (~440 lines, 36 tests).
- Untouched: all existing source files.

## Out of scope (later tasks)
- Tasks 5-7: Go / Rust / Java per-language resolvers.
- Task 8: fallback resolver + dispatcher.
- Task 9: parser/incremental wiring.
- Task 10: cross-cutting `repo` query param.