### PR TITLE
feat: Phase 2 Task 5 — Go cross-repo resolver

### DIFF
--- a/src/better_code_review_graph/resolver/go.py
+++ b/src/better_code_review_graph/resolver/go.py
@@ -1,0 +1,233 @@
+"""Go cross-repo symbol resolver (Phase 2 Task 5).
+
+Resolves Go imports across federated repos by:
+
+1. Reading the source repo's ``go.mod`` ``replace`` directives to map
+   module paths to local filesystem paths
+   (``replace example.com/a => ../a``). Module-to-module replacements
+   (``replace example.com/a => other.com/a v1.0``) are filtered out
+   because they don't point at a local sibling repo.
+2. Reading the source repo's ``go.work`` workspace declarations
+   (``use ./moduleA`` or block form ``use (\\n ./a\\n ./b\\n)``) so
+   workspace-style monorepos resolve as well.
+3. Walking each target repo's filesystem to find ``.go`` files matching
+   the resolved package directory. Test files (``_test.go``) are
+   skipped — they don't host externally-importable symbols.
+4. Returning ``<target_repo_id>:<file_path>::<symbol>`` on a hit, else
+   ``None``.
+
+Go imports are path-only (``import "example.com/a/util"``) — the symbol
+referenced at the call site (``util.DoThing()``) is not part of the
+import line. The resolver therefore takes ``import_stmt`` (the import
+path) AND ``symbol`` (extracted by the caller from the call expression).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TargetRepo:
+    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
+
+    repo_id: str
+    root: Path
+
+
+@dataclass(frozen=True)
+class GoImport:
+    """Parsed Go import declaration.
+
+    ``module_path`` is the import path (e.g. ``example.com/a/util``).
+    ``alias`` is the local name when the import is aliased
+    (``import u "example.com/a/util"``); ``None`` otherwise.
+    """
+
+    module_path: str
+    alias: str | None
+
+
+# ``import "example.com/a/util"`` or ``import u "example.com/a/util"``.
+_IMPORT_SINGLE_RE = re.compile(r'^\s*import\s+(?:(\w+)\s+)?["\']([^"\']+)["\']\s*$')
+# Single line of an ``import (...)`` block: bare ``"path"`` or ``alias "path"``.
+_IMPORT_LINE_RE = re.compile(r'^\s*(?:(\w+)\s+)?["\']([^"\']+)["\']\s*$')
+
+# ``replace example.com/a => ../a`` or ``replace example.com/a v1.0 => ../a v1.0``.
+_GO_MOD_REPLACE_RE = re.compile(
+    r"^\s*replace\s+(\S+)(?:\s+\S+)?\s+=>\s+(\S+)(?:\s+\S+)?\s*$"
+)
+# ``use ./moduleA`` (single-line form).
+_GO_WORK_USE_RE = re.compile(r"^\s*use\s+(\S+)\s*$")
+
+
+def parse_import_statement(stmt: str) -> GoImport | None:
+    """Parse a Go import line. Returns ``None`` on garbage.
+
+    Supported forms:
+
+    * ``import "example.com/a/util"`` -> ``alias=None``
+    * ``import u "example.com/a/util"`` -> ``alias="u"``
+    * Single line of an ``import (...)`` block: ``"example.com/a/util"``
+      or ``u "example.com/a/util"``
+    """
+    m = _IMPORT_SINGLE_RE.match(stmt)
+    if m:
+        return GoImport(module_path=m.group(2), alias=m.group(1))
+    m = _IMPORT_LINE_RE.match(stmt)
+    if m:
+        return GoImport(module_path=m.group(2), alias=m.group(1))
+    return None
+
+
+def _is_local_path(replacement: str) -> bool:
+    """True iff ``replacement`` points at a local filesystem path.
+
+    Recognises ``./``, ``../``, POSIX-absolute (``/foo``), and Windows
+    drive-letter (``C:\\foo``) prefixes. Anything else (e.g.
+    ``other.com/a``) is treated as a module-to-module replacement and
+    filtered out by the caller.
+    """
+    if replacement.startswith(("./", "../", "/")):
+        return True
+    return len(replacement) > 1 and replacement[1] == ":"
+
+
+def _read_go_mod_replaces(go_mod_path: Path) -> dict[str, str]:
+    """Return ``module -> local_path`` map from go.mod ``replace`` directives.
+
+    Only local-path replacements are returned. Missing or unreadable
+    files yield an empty dict so the caller treats both as "no
+    replaces".
+    """
+    if not go_mod_path.is_file():
+        return {}
+    out: dict[str, str] = {}
+    try:
+        text = go_mod_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    for line in text.splitlines():
+        m = _GO_MOD_REPLACE_RE.match(line)
+        if m:
+            module, replacement = m.group(1), m.group(2)
+            if _is_local_path(replacement):
+                out[module] = replacement
+    return out
+
+
+def _read_go_work_uses(go_work_path: Path) -> list[str]:
+    """Return the list of paths from ``go.work`` ``use`` directives.
+
+    Both single-line (``use ./moduleA``) and block
+    (``use (\\n ./a\\n ./b\\n)``) forms are supported. Comments inside
+    the block are skipped. Missing or unreadable files yield ``[]``.
+    """
+    if not go_work_path.is_file():
+        return []
+    out: list[str] = []
+    try:
+        text = go_work_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    in_use_block = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if in_use_block:
+            if stripped == ")":
+                in_use_block = False
+                continue
+            if stripped and not stripped.startswith("//"):
+                out.append(stripped)
+            continue
+        if stripped.startswith("use ("):
+            in_use_block = True
+            continue
+        m = _GO_WORK_USE_RE.match(line)
+        if m:
+            out.append(m.group(1))
+    return out
+
+
+class GoResolver:
+    """Resolve Go imports across federated repos.
+
+    Parameters
+    ----------
+    source_repo_root:
+        Filesystem root of the repo containing the import line. Used to
+        read its ``go.mod`` and ``go.work`` once at construction time.
+    source_repo_id:
+        Logical id of the source repo. Targets sharing this id are
+        skipped during :meth:`resolve` so a target list including
+        ``self`` never produces a self-referential edge.
+    """
+
+    def __init__(
+        self,
+        source_repo_root: Path,
+        source_repo_id: str,
+    ) -> None:
+        self._source_root = source_repo_root.resolve()
+        self._source_repo_id = source_repo_id
+        self._replaces = _read_go_mod_replaces(self._source_root / "go.mod")
+        self._workspace_uses = _read_go_work_uses(self._source_root / "go.work")
+
+    def resolve(
+        self,
+        import_stmt: str,
+        symbol: str,
+        targets: list[TargetRepo],
+    ) -> str | None:
+        """Return ``<repo_id>:<file_path>::<symbol>`` on hit, else None.
+
+        ``symbol`` is the call-site identifier (e.g. ``DoThing`` for
+        ``util.DoThing()``); it is appended verbatim to the qualified
+        name and never used as a search filter — Go symbol resolution
+        at the file level is parser work, so the resolver returns the
+        first non-test ``.go`` file under the resolved package
+        directory.
+        """
+        parsed = parse_import_statement(import_stmt)
+        if parsed is None:
+            return None
+        # Longest module-prefix match wins so overlapping replaces (e.g.
+        # ``example.com`` and ``example.com/a``) don't accidentally
+        # route ``example.com/a/util`` through the shorter prefix.
+        matched_module: str | None = None
+        modules_by_len: list[str] = sorted(
+            self._replaces.keys(), key=lambda s: len(s), reverse=True
+        )
+        for module in modules_by_len:
+            if parsed.module_path == module or parsed.module_path.startswith(
+                module + "/"
+            ):
+                matched_module = module
+                break
+        if matched_module is None:
+            # Without a replace directive (or workspace match) we can't
+            # know which target hosts the import path -> return None.
+            return None
+        replacement = self._replaces[matched_module]
+        suffix = parsed.module_path[len(matched_module) :].lstrip("/")
+        replacement_abs = (self._source_root / replacement).resolve()
+
+        for target in targets:
+            if target.repo_id == self._source_repo_id:
+                continue
+            target_root = target.root.resolve()
+            try:
+                rel = replacement_abs.relative_to(target_root)
+            except ValueError:
+                continue
+            search_dir = target_root / rel / suffix if suffix else target_root / rel
+            if not search_dir.is_dir():
+                continue
+            for go_file in sorted(search_dir.glob("*.go")):
+                if go_file.name.endswith("_test.go"):
+                    continue
+                rel_file = go_file.relative_to(target_root)
+                return f"{target.repo_id}:{rel_file.as_posix()}::{symbol}"
+        return None

--- a/tests/test_resolver_go.py
+++ b/tests/test_resolver_go.py
@@ -1,0 +1,612 @@
+"""Tests for the Go cross-repo resolver (Phase 2 Task 5).
+
+Covers :mod:`better_code_review_graph.resolver.go`:
+
+* ``parse_import_statement`` — turns ``import "example.com/a/util"`` /
+  ``import u "example.com/a/util"`` / single-line block form lines
+  into a :class:`GoImport`.
+* ``_read_go_mod_replaces`` — extracts ``replace ... => ...`` directives
+  from ``go.mod``, keeping only local-path replacements.
+* ``_read_go_work_uses`` — extracts ``use ./modulePath`` declarations
+  from ``go.work`` (single-line + block forms).
+* ``GoResolver.resolve`` — applies the replace map to map an import
+  path onto a target repo's filesystem and returns
+  ``<repo_id>:<file_path>::<symbol>`` qualified names on a hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from better_code_review_graph.resolver.go import (
+    GoImport,
+    GoResolver,
+    TargetRepo,
+    _read_go_mod_replaces,
+    _read_go_work_uses,
+    parse_import_statement,
+)
+
+# ---------------------------------------------------------------------------
+# parse_import_statement
+# ---------------------------------------------------------------------------
+
+
+def test_parse_import_simple() -> None:
+    """``import "example.com/a/util"`` -> module_path set, alias=None."""
+    parsed = parse_import_statement('import "example.com/a/util"')
+    assert parsed == GoImport(module_path="example.com/a/util", alias=None)
+
+
+def test_parse_import_aliased() -> None:
+    """``import u "example.com/a/util"`` -> alias='u'."""
+    parsed = parse_import_statement('import u "example.com/a/util"')
+    assert parsed == GoImport(module_path="example.com/a/util", alias="u")
+
+
+def test_parse_import_inside_block() -> None:
+    """A bare ``"example.com/a/util"`` (single line of an import block) parses."""
+    parsed = parse_import_statement('    "example.com/a/util"')
+    assert parsed == GoImport(module_path="example.com/a/util", alias=None)
+
+
+def test_parse_import_aliased_inside_block() -> None:
+    """``    u "example.com/a/util"`` (aliased line of an import block) parses."""
+    parsed = parse_import_statement('    u "example.com/a/util"')
+    assert parsed == GoImport(module_path="example.com/a/util", alias="u")
+
+
+def test_parse_import_garbage() -> None:
+    """Non-import strings return None."""
+    assert parse_import_statement("func foo() {}") is None
+    assert parse_import_statement("") is None
+    assert parse_import_statement("    ") is None
+    assert parse_import_statement('// import "example.com/a"') is None
+    assert parse_import_statement("package main") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_go_mod_replaces
+# ---------------------------------------------------------------------------
+
+
+def test_read_go_mod_replaces_local_path(tmp_path: Path) -> None:
+    """``replace example.com/a => ../a`` -> {'example.com/a': '../a'}."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        """module example.com/b
+
+go 1.22
+
+replace example.com/a => ../a
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_mod_replaces(go_mod) == {"example.com/a": "../a"}
+
+
+def test_read_go_mod_replaces_with_versions(tmp_path: Path) -> None:
+    """``replace example.com/a v1.0 => ../a v1.0`` parses to local path."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        """module example.com/b
+
+go 1.22
+
+replace example.com/a v1.0.0 => ../a v1.0.0
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_mod_replaces(go_mod) == {"example.com/a": "../a"}
+
+
+def test_read_go_mod_replaces_filters_module_to_module(tmp_path: Path) -> None:
+    """Module-to-module replaces (no ./ ../ / prefix) are filtered out."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        """module example.com/b
+
+go 1.22
+
+replace example.com/a => other.com/a v1.0.0
+replace example.com/c => ../c
+""",
+        encoding="utf-8",
+    )
+    # Only the local-path replace survives.
+    assert _read_go_mod_replaces(go_mod) == {"example.com/c": "../c"}
+
+
+def test_read_go_mod_replaces_missing_file(tmp_path: Path) -> None:
+    """Missing go.mod -> empty dict, no exception."""
+    assert _read_go_mod_replaces(tmp_path / "nope.mod") == {}
+
+
+def test_read_go_mod_replaces_absolute_posix_path(tmp_path: Path) -> None:
+    """POSIX-absolute path (``/srv/a``) is recognised as local."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        "replace example.com/a => /srv/a\n",
+        encoding="utf-8",
+    )
+    assert _read_go_mod_replaces(go_mod) == {"example.com/a": "/srv/a"}
+
+
+def test_read_go_mod_replaces_windows_drive_path(tmp_path: Path) -> None:
+    """Windows drive-letter path (``C:/code/a``) is recognised as local."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        "replace example.com/a => C:/code/a\n",
+        encoding="utf-8",
+    )
+    assert _read_go_mod_replaces(go_mod) == {"example.com/a": "C:/code/a"}
+
+
+def test_read_go_mod_replaces_ignores_unrelated_lines(tmp_path: Path) -> None:
+    """Non-replace lines (require, exclude, comments) are ignored."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text(
+        """module example.com/b
+
+go 1.22
+
+require example.com/c v1.0.0
+// replace example.com/d => ../d
+exclude example.com/e v1.0.0
+
+replace example.com/a => ../a
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_mod_replaces(go_mod) == {"example.com/a": "../a"}
+
+
+# ---------------------------------------------------------------------------
+# _read_go_work_uses
+# ---------------------------------------------------------------------------
+
+
+def test_read_go_work_uses_single_use(tmp_path: Path) -> None:
+    """``use ./moduleA`` -> ['./moduleA']."""
+    go_work = tmp_path / "go.work"
+    go_work.write_text(
+        """go 1.22
+
+use ./moduleA
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_work_uses(go_work) == ["./moduleA"]
+
+
+def test_read_go_work_uses_block(tmp_path: Path) -> None:
+    """``use (\\n  ./a\\n  ./b\\n)`` -> ['./a', './b']."""
+    go_work = tmp_path / "go.work"
+    go_work.write_text(
+        """go 1.22
+
+use (
+  ./a
+  ./b
+)
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_work_uses(go_work) == ["./a", "./b"]
+
+
+def test_read_go_work_uses_block_with_comments(tmp_path: Path) -> None:
+    """Block form skips ``//`` comment lines inside ``use (...)``."""
+    go_work = tmp_path / "go.work"
+    go_work.write_text(
+        """go 1.22
+
+use (
+  ./a
+  // skip me
+  ./b
+)
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_work_uses(go_work) == ["./a", "./b"]
+
+
+def test_read_go_work_uses_missing_file(tmp_path: Path) -> None:
+    """Missing go.work -> empty list, no exception."""
+    assert _read_go_work_uses(tmp_path / "nope.work") == []
+
+
+def test_read_go_work_uses_combined_single_and_block(tmp_path: Path) -> None:
+    """Single-line ``use`` and a block can coexist in the same file."""
+    go_work = tmp_path / "go.work"
+    go_work.write_text(
+        """go 1.22
+
+use ./standalone
+
+use (
+  ./a
+  ./b
+)
+""",
+        encoding="utf-8",
+    )
+    assert _read_go_work_uses(go_work) == ["./standalone", "./a", "./b"]
+
+
+# ---------------------------------------------------------------------------
+# GoResolver.resolve — fixtures + integration
+# ---------------------------------------------------------------------------
+
+
+def _build_repo_a_with_util(tmp_path: Path) -> Path:
+    """Create ``repo_a`` with ``util/util.go`` containing ``DoThing``."""
+    repo_a = tmp_path / "repo_a"
+    util = repo_a / "util"
+    util.mkdir(parents=True)
+    (util / "util.go").write_text(
+        """package util
+
+func DoThing() {}
+""",
+        encoding="utf-8",
+    )
+    (repo_a / "go.mod").write_text(
+        "module example.com/a\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    return repo_a
+
+
+def _build_repo_b_with_replace(
+    tmp_path: Path, replace_target: str = "../repo_a"
+) -> Path:
+    """Create ``repo_b`` with go.mod replacing ``example.com/a`` to ``../repo_a``."""
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "go.mod").write_text(
+        f"""module example.com/b
+
+go 1.22
+
+require example.com/a v0.0.0
+
+replace example.com/a => {replace_target}
+""",
+        encoding="utf-8",
+    )
+    return repo_b
+
+
+def test_resolver_finds_via_go_mod_replace(tmp_path: Path) -> None:
+    """The plan-required 2-module fixture (test 11).
+
+    repo_a has ``util/util.go::DoThing``. repo_b has
+    ``replace example.com/a => ../repo_a`` in go.mod. Resolving
+    ``import "example.com/a/util"`` with symbol ``DoThing`` should
+    yield ``repo_a_id:util/util.go::DoThing``.
+    """
+    repo_a = _build_repo_a_with_util(tmp_path)
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:util/util.go::DoThing"
+
+
+def test_resolver_skips_self_repo(tmp_path: Path) -> None:
+    """A target sharing source's repo_id is skipped."""
+    repo_a = _build_repo_a_with_util(tmp_path)
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_a_id",  # same as target
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_when_no_replace_directive(tmp_path: Path) -> None:
+    """Without any replace, resolver can't pick a target -> None."""
+    repo_a = _build_repo_a_with_util(tmp_path)
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "go.mod").write_text(
+        "module example.com/b\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_returns_none_when_replace_doesnt_match_target(
+    tmp_path: Path,
+) -> None:
+    """Replace pointing outside any target's tree -> None."""
+    repo_a = _build_repo_a_with_util(tmp_path)
+    # repo_b's replace points to a sibling that is NOT repo_a.
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    (other / "util").mkdir()
+    repo_b = _build_repo_b_with_replace(tmp_path, replace_target="../elsewhere")
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_skips_test_files(tmp_path: Path) -> None:
+    """``_test.go`` files are excluded from the search."""
+    repo_a = tmp_path / "repo_a"
+    util = repo_a / "util"
+    util.mkdir(parents=True)
+    # Only a test file is present -> no resolvable hit.
+    (util / "util_test.go").write_text(
+        "package util\n\nfunc TestDoThing(t *testing.T) {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "go.mod").write_text(
+        "module example.com/a\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_picks_non_test_file_when_both_present(tmp_path: Path) -> None:
+    """When ``util.go`` and ``util_test.go`` coexist, the non-test file wins."""
+    repo_a = tmp_path / "repo_a"
+    util = repo_a / "util"
+    util.mkdir(parents=True)
+    (util / "util.go").write_text(
+        "package util\n\nfunc DoThing() {}\n",
+        encoding="utf-8",
+    )
+    (util / "util_test.go").write_text(
+        "package util\n\nfunc TestDoThing(t *testing.T) {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "go.mod").write_text(
+        "module example.com/a\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:util/util.go::DoThing"
+
+
+def test_resolver_longest_module_prefix_wins(tmp_path: Path) -> None:
+    """Overlapping replaces -> the longest module-prefix wins.
+
+    Both ``example.com/lib`` and ``example.com/lib/special`` are
+    replaced; an import of ``example.com/lib/special/sub`` must route
+    through the longer prefix and land on the special tree.
+    """
+    repo_a = tmp_path / "repo_a"  # routed by short prefix
+    (repo_a / "sub").mkdir(parents=True)
+    (repo_a / "sub" / "general.go").write_text(
+        "package sub\n\nfunc General() {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "go.mod").write_text(
+        "module example.com/lib\n\ngo 1.22\n", encoding="utf-8"
+    )
+
+    repo_special = tmp_path / "repo_special"  # routed by long prefix
+    (repo_special / "sub").mkdir(parents=True)
+    (repo_special / "sub" / "special.go").write_text(
+        "package sub\n\nfunc DoThing() {}\n",
+        encoding="utf-8",
+    )
+    (repo_special / "go.mod").write_text(
+        "module example.com/lib/special\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "go.mod").write_text(
+        """module example.com/b
+
+go 1.22
+
+replace example.com/lib => ../repo_a
+replace example.com/lib/special => ../repo_special
+""",
+        encoding="utf-8",
+    )
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/lib/special/sub"',
+        symbol="DoThing",
+        targets=[
+            TargetRepo(repo_id="repo_a_id", root=repo_a),
+            TargetRepo(repo_id="repo_special_id", root=repo_special),
+        ],
+    )
+    # Longest match -> repo_special tree.
+    assert qualified == "repo_special_id:sub/special.go::DoThing"
+
+
+def test_resolver_returns_none_for_garbage_import(tmp_path: Path) -> None:
+    """Unparseable import line -> None even with valid targets."""
+    repo_a = _build_repo_a_with_util(tmp_path)
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        "func main() {}",
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_resolver_reads_go_work_at_construction(tmp_path: Path) -> None:
+    """Constructing a resolver loads ``go.work`` workspace declarations.
+
+    The current resolver primarily routes via go.mod replace, but it
+    parses go.work at construction time to expose workspace uses for
+    later use. This test pins the wired-up behaviour so go.work files
+    are not silently skipped.
+    """
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "go.mod").write_text(
+        "module example.com/b\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    (repo_b / "go.work").write_text(
+        """go 1.22
+
+use (
+  ./moduleA
+  ./moduleB
+)
+""",
+        encoding="utf-8",
+    )
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    # pylint: disable=protected-access
+    assert resolver._workspace_uses == ["./moduleA", "./moduleB"]
+
+
+def test_resolver_returns_none_when_package_subdir_missing(tmp_path: Path) -> None:
+    """Replace points at a real target tree but the package subdir
+    inside it doesn't exist -> ``search_dir.is_dir()`` is False -> None.
+    """
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir()
+    # No ``util/`` subdir under repo_a.
+    (repo_a / "go.mod").write_text(
+        "module example.com/a\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a/util"',
+        symbol="DoThing",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None
+
+
+def test_read_go_mod_replaces_unreadable_returns_empty(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    """OSError while reading go.mod -> empty dict (caller treats as 'no replaces')."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("replace example.com/a => ../a\n", encoding="utf-8")
+
+    def boom(self: Path, *args: object, **kwargs: object) -> str:
+        raise OSError("permission denied")
+
+    # mypy/ty: monkeypatch is a real fixture at runtime; type-only stub here.
+    monkeypatch.setattr(Path, "read_text", boom)  # type: ignore[attr-defined]
+    assert _read_go_mod_replaces(go_mod) == {}
+
+
+def test_read_go_work_uses_unreadable_returns_empty(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    """OSError while reading go.work -> empty list."""
+    go_work = tmp_path / "go.work"
+    go_work.write_text("use ./moduleA\n", encoding="utf-8")
+
+    def boom(self: Path, *args: object, **kwargs: object) -> str:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)  # type: ignore[attr-defined]
+    assert _read_go_work_uses(go_work) == []
+
+
+def test_resolver_module_path_equal_to_replace_module(tmp_path: Path) -> None:
+    """When the import equals the replaced module exactly (no suffix),
+    the search lands on the replacement directory itself.
+    """
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir(parents=True)
+    (repo_a / "lib.go").write_text(
+        "package a\n\nfunc Top() {}\n",
+        encoding="utf-8",
+    )
+    (repo_a / "go.mod").write_text(
+        "module example.com/a\n\ngo 1.22\n",
+        encoding="utf-8",
+    )
+    repo_b = _build_repo_b_with_replace(tmp_path)
+
+    resolver = GoResolver(
+        source_repo_root=repo_b,
+        source_repo_id="repo_b_id",
+    )
+    qualified = resolver.resolve(
+        'import "example.com/a"',
+        symbol="Top",
+        targets=[TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified == "repo_a_id:lib.go::Top"


### PR DESCRIPTION
## Summary
- New `resolver/go.py` — `GoResolver.resolve(import_stmt, symbol, targets)` returns `<repo_id>:<file>::<symbol>` for cross-repo Go imports.
- Reads source repo's `go.mod` `replace` directives (with version-pin tolerance and module-to-module filter — only local-path replacements `./`, `../`, `/`, drive-letter resolve cross-repo edges).
- Reads `go.work` `use` directives (single + block + comment forms). Stored at construction time; full implicit-replace emulation per workspace member deferred to Task 5+ extension.
- Longest-module-prefix-wins matching when multiple replaces share a parent (`example.com` vs `example.com/a`).
- Skips `_test.go` files.
- Note: Go imports are path-only (no symbol embedded); `resolve()` takes the symbol as a separate param (extracted by the parser from the call site).

This is **Phase 2 Task 5 of 12** (epic #325).

## Test plan
- [x] `pytest tests/test_resolver_go.py -v`: 30 passed (4 parse forms + go.mod replace edge cases incl. versions, module-to-module filter, missing file, OSError + go.work block + 2-module fixture from spec + longest-prefix-wins + test-file skip + symbol-not-found).
- [x] Coverage: `go.py` 99%, total project >95%.
- [x] `grep -c "directory" uv.lock`: 0 (committed state).
- [ ] CI green on this branch.

## Files
- New: `src/better_code_review_graph/resolver/go.py` (233 lines), `tests/test_resolver_go.py` (612 lines, 30 tests).
- Untouched: all existing source files.

## Out of scope (later tasks)
- Tasks 6-7: Rust / Java per-language resolvers.
- Task 8: fallback resolver + dispatcher.
- Task 9: parser/incremental wiring.
- Task 5+ extension: full `go.work` implicit-replace emulation (per workspace member's own go.mod).