### PR TITLE
feat: Phase 2 Task 8 — fallback resolver + cross-repo dispatcher

### DIFF
--- a/src/better_code_review_graph/resolver/__init__.py
+++ b/src/better_code_review_graph/resolver/__init__.py
@@ -1,8 +1,115 @@
-"""Cross-repo symbol resolvers (Phase 2).
+"""Cross-repo symbol resolver dispatcher (Phase 2 Task 8).
 
-Per-language modules live alongside this package marker. Task 8 will
-add a language dispatcher; for now callers should import the language
-resolver directly, e.g.::
+Routes :func:`resolve_cross_repo_imports` to the appropriate
+language-specific resolver, with a generic suffix-match fallback for
+tier-2 languages without dedicated support.
 
-    from better_code_review_graph.resolver.python import PythonResolver
+The canonical :class:`TargetRepo` dataclass lives in
+:mod:`better_code_review_graph.resolver._types` and is re-exported by
+this module and by every language resolver. Downstream callers should
+import from this module (``from better_code_review_graph.resolver
+import TargetRepo, resolve_cross_repo_imports``) to avoid coupling to a
+specific resolver.
 """
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ._types import TargetRepo
+from .fallback import FallbackResolver
+from .go import GoResolver
+from .java import JavaResolver
+from .python import PythonResolver
+from .rust import RustResolver
+from .typescript import TypeScriptResolver
+
+# Source language hint -> resolver class *attribute name on this module*.
+# We dereference the attribute at call time (rather than caching the
+# class object) so test patches on
+# ``better_code_review_graph.resolver.PythonResolver`` (etc.) are
+# honoured by the dispatcher.
+#
+# JavaScript reuses TypeScript because the import syntax and project
+# layout (tsconfig paths + workspaces) are identical. Kotlin reuses
+# Java because Maven/Gradle module structure is shared and the
+# JavaResolver already walks ``src/main/kotlin``.
+_RESOLVERS: dict[str, str] = {
+    "python": "PythonResolver",
+    "typescript": "TypeScriptResolver",
+    "javascript": "TypeScriptResolver",
+    "go": "GoResolver",
+    "rust": "RustResolver",
+    "java": "JavaResolver",
+    "kotlin": "JavaResolver",
+}
+
+
+def resolve_cross_repo_imports(
+    import_stmt: str,
+    source_lang: str,
+    source_repo_root: Path,
+    source_repo_id: str,
+    targets: list[TargetRepo],
+    *,
+    symbol: str | None = None,
+) -> str | None:
+    """Resolve a cross-repo import statement.
+
+    Dispatches based on ``source_lang`` (lower-cased and stripped).
+    Falls back to the suffix-match :class:`FallbackResolver` when no
+    language-specific resolver is registered.
+
+    Parameters
+    ----------
+    import_stmt:
+        The raw import line as captured by the parser
+        (``"from lib_a.utils import retry"``, ``"import \"foo/bar\""``,
+        ``"use foo::bar::Baz;"``, ...).
+    source_lang:
+        Language hint (case-insensitive). Maps to a tier-1 resolver
+        class via the dispatch table; unknown values route to
+        ``FallbackResolver``.
+    source_repo_root, source_repo_id:
+        Forwarded verbatim to the resolver constructor.
+    targets:
+        Federated repo targets. The resolver skips any target whose id
+        matches ``source_repo_id`` so self-references can't sneak in.
+    symbol:
+        Required by Go (whose imports are path-only — the symbol comes
+        from the call site) and by the fallback resolver when the
+        caller has stronger information than the trailing segment of
+        the qualified name. Ignored by the other tier-1 resolvers.
+    """
+    lang = source_lang.lower().strip()
+    cls_name = _RESOLVERS.get(lang)
+    module = sys.modules[__name__]
+    if cls_name is None:
+        fallback_cls = module.FallbackResolver
+        resolver = fallback_cls(source_repo_root, source_repo_id)
+        return resolver.resolve(import_stmt, targets, symbol=symbol)
+    resolver_cls = getattr(module, cls_name)
+    if cls_name == "GoResolver":
+        # Go uniquely requires the symbol param — without it we cannot
+        # build the qualified name, so short-circuit to None rather
+        # than hand a placeholder back to the caller.
+        if symbol is None:
+            return None
+        return resolver_cls(source_repo_root, source_repo_id).resolve(
+            import_stmt, symbol, targets
+        )
+    resolver = resolver_cls(source_repo_root, source_repo_id)
+    return resolver.resolve(import_stmt, targets)
+
+
+__all__ = [
+    "FallbackResolver",
+    "GoResolver",
+    "JavaResolver",
+    "PythonResolver",
+    "RustResolver",
+    "TargetRepo",
+    "TypeScriptResolver",
+    "resolve_cross_repo_imports",
+]

--- a/src/better_code_review_graph/resolver/_types.py
+++ b/src/better_code_review_graph/resolver/_types.py
@@ -1,0 +1,22 @@
+"""Shared types for cross-repo resolvers (Phase 2 Task 8).
+
+The :class:`TargetRepo` dataclass was originally duplicated across each
+language resolver module. Task 8 consolidates it here so the dispatcher
+in :mod:`better_code_review_graph.resolver` and every language module
+share the exact same type. Each language module re-exports the symbol
+to preserve backwards compatibility for callers importing
+``TargetRepo`` directly from a specific resolver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TargetRepo:
+    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
+
+    repo_id: str
+    root: Path

--- a/src/better_code_review_graph/resolver/fallback.py
+++ b/src/better_code_review_graph/resolver/fallback.py
@@ -1,0 +1,177 @@
+"""Tier-2 fallback resolver (Phase 2 Task 8).
+
+For languages without a dedicated resolver, attempt a best-effort match
+by suffix scanning each target repo's source tree. Heuristic only —
+intended for prototype federated graphs where one or two languages
+appear that we don't yet have a dedicated parser/resolver for (Ruby,
+PHP, C#, Swift, Scala, C/C++, ...).
+
+The strategy:
+
+1. Pull the longest qualified-name token (dotted, double-colon, or
+   slash-separated) out of the raw import line.
+2. Treat the last segment as the imported symbol name (unless the
+   caller passes ``symbol`` explicitly — required for Go-like languages
+   whose import line is path-only and the symbol comes from the call
+   site).
+3. Treat the leading segments as a relative file-path suffix and
+   suffix-match each target repo's source files (``.py``, ``.ts``,
+   ``.go``, ``.rs``, ``.java``, ``.rb``, ``.php``, ``.cs``, ``.swift``,
+   ``.scala``, ``.cpp`` family).
+4. Return the first hit per target, formatted as
+   ``<repo_id>:<file>::<symbol>``.
+
+The :func:`rglob` walk stops at the first matching file in each target
+to keep performance bounded for large monorepos.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._types import TargetRepo
+
+__all__ = [
+    "FallbackResolver",
+    "GenericImport",
+    "TargetRepo",
+    "parse_generic_qualified",
+]
+
+
+@dataclass(frozen=True)
+class GenericImport:
+    """Best-effort parse of a generic identifier-style import.
+
+    ``qualified`` holds the longest dotted / double-colon / slash token
+    pulled from the raw statement (e.g. ``"com.example.Util"``,
+    ``"foo::bar::baz"``, or ``"foo/bar/baz"``).
+    """
+
+    qualified: str
+
+
+# Match a single qualified token: word chars joined by `.`, `::`, or `/`.
+# At least one separator is required so single identifiers don't match.
+_GENERIC_QUALIFIED_RE = re.compile(r"(\w+(?:[.:/]+\w+)+)")
+
+
+def parse_generic_qualified(stmt: str) -> GenericImport | None:
+    """Pull the longest qualified token from ``stmt``.
+
+    Recognises three flavours of separator: ``.`` (Java/Kotlin/C# /
+    Scala / Swift), ``::`` (Rust/C++/Ruby constants/PHP namespaces),
+    and ``/`` (Ruby ``require`` / PHP ``use`` paths). Multiple
+    candidates in one line resolve to the longest by character count
+    so a ``require_relative 'foo/bar'`` keeps ``foo/bar`` instead of
+    a stray ``require_relative`` keyword fragment.
+
+    Returns ``None`` for unqualified strings (no separator).
+    """
+    matches: list[str] = _GENERIC_QUALIFIED_RE.findall(stmt)
+    if not matches:
+        return None
+    matches.sort(key=len, reverse=True)
+    return GenericImport(qualified=matches[0])
+
+
+# Common source-file extensions across mainstream languages we don't
+# yet have a dedicated resolver for. ``.py``/``.ts`` etc are included
+# for completeness — the dispatcher routes those to language-specific
+# resolvers, but a tier-2 caller passing ``source_lang="python"`` to
+# the fallback directly would still get a sensible suffix match.
+_SOURCE_EXTS = (
+    ".py",
+    ".pyi",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".kt",
+    ".kts",
+    ".rb",
+    ".php",
+    ".cs",
+    ".swift",
+    ".scala",
+    ".cpp",
+    ".cc",
+    ".cxx",
+    ".c",
+    ".h",
+    ".hpp",
+    ".hxx",
+)
+
+
+class FallbackResolver:
+    """Suffix-match resolver for tier-2 languages.
+
+    Parameters
+    ----------
+    source_repo_root:
+        Filesystem root of the repo containing the import line. Stored
+        only so the resolver behaves symmetrically with language
+        resolvers (it does not actually read the source repo — fallback
+        is parser-shape agnostic).
+    source_repo_id:
+        Logical id of the source repo. Targets sharing this id are
+        skipped during :meth:`resolve` so a target list including
+        ``self`` never produces a self-referential edge.
+    """
+
+    def __init__(self, source_repo_root: Path, source_repo_id: str) -> None:
+        self._source_root = source_repo_root.resolve()
+        self._source_repo_id = source_repo_id
+
+    def resolve(
+        self,
+        import_stmt: str,
+        targets: list[TargetRepo],
+        *,
+        symbol: str | None = None,
+    ) -> str | None:
+        """Return ``<repo_id>:<file>::<symbol>`` on hit, else ``None``.
+
+        ``symbol`` overrides the auto-derived last segment of the
+        qualified name. Required when the import line is path-only
+        (Go-like) and the actual symbol lives at the call site.
+        """
+        parsed = parse_generic_qualified(import_stmt)
+        if parsed is None:
+            return None
+        # Split on any of the supported separators; collapse runs of
+        # `::` or `..` so consecutive separators don't yield empty
+        # segments.
+        segments = [s for s in re.split(r"[.:/]+", parsed.qualified) if s]
+        if not segments:  # pragma: no cover -- defensive; regex guarantees ≥1 segment
+            return None
+        candidate_symbol = symbol or segments[-1]
+        # Suffix-match the full qualified token as a path. This works
+        # for slash-style (``foo/bar`` -> ``foo/bar.rb`` matches
+        # ``lib/foo/bar.rb``) and dotted/colon style alike
+        # (``com.example.Util`` -> ``com/example/Util.java`` matches
+        # ``src/main/java/com/example/Util.java``). The trailing
+        # segment is treated as both the file basename AND the default
+        # symbol; callers with stronger info pass ``symbol`` to
+        # override the symbol while keeping the file match.
+        path_parts = segments
+        for target in targets:
+            if target.repo_id == self._source_repo_id:
+                continue
+            target_root = target.root.resolve()
+            for ext in _SOURCE_EXTS:
+                expected_suffix = "/".join(path_parts) + ext
+                # rglob is the cheapest way to walk every source file
+                # of an extension; for prototype federated graphs the
+                # target trees stay small enough for this to be fine.
+                for candidate in target_root.rglob(f"*{ext}"):
+                    if candidate.as_posix().endswith(expected_suffix):
+                        rel = candidate.resolve().relative_to(target_root)
+                        return f"{target.repo_id}:{rel.as_posix()}::{candidate_symbol}"
+        return None

--- a/src/better_code_review_graph/resolver/go.py
+++ b/src/better_code_review_graph/resolver/go.py
@@ -28,13 +28,14 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._types import TargetRepo  # re-exported for backwards compatibility
 
-@dataclass(frozen=True)
-class TargetRepo:
-    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
-
-    repo_id: str
-    root: Path
+__all__ = [
+    "GoImport",
+    "GoResolver",
+    "TargetRepo",
+    "parse_import_statement",
+]
 
 
 @dataclass(frozen=True)

--- a/src/better_code_review_graph/resolver/java.py
+++ b/src/better_code_review_graph/resolver/java.py
@@ -31,13 +31,14 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._types import TargetRepo  # re-exported for backwards compatibility
 
-@dataclass(frozen=True)
-class TargetRepo:
-    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
-
-    repo_id: str
-    root: Path
+__all__ = [
+    "JavaImport",
+    "JavaResolver",
+    "TargetRepo",
+    "parse_import_statement",
+]
 
 
 @dataclass(frozen=True)

--- a/src/better_code_review_graph/resolver/python.py
+++ b/src/better_code_review_graph/resolver/python.py
@@ -27,13 +27,14 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._types import TargetRepo  # re-exported for backwards compatibility
 
-@dataclass(frozen=True)
-class TargetRepo:
-    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
-
-    repo_id: str
-    root: Path
+__all__ = [
+    "PythonImport",
+    "PythonResolver",
+    "TargetRepo",
+    "parse_import_statement",
+]
 
 
 @dataclass(frozen=True)

--- a/src/better_code_review_graph/resolver/rust.py
+++ b/src/better_code_review_graph/resolver/rust.py
@@ -30,13 +30,14 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._types import TargetRepo  # re-exported for backwards compatibility
 
-@dataclass(frozen=True)
-class TargetRepo:
-    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
-
-    repo_id: str
-    root: Path
+__all__ = [
+    "RustResolver",
+    "RustUse",
+    "TargetRepo",
+    "parse_use_statement",
+]
 
 
 @dataclass(frozen=True)

--- a/src/better_code_review_graph/resolver/typescript.py
+++ b/src/better_code_review_graph/resolver/typescript.py
@@ -26,13 +26,14 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._types import TargetRepo  # re-exported for backwards compatibility
 
-@dataclass(frozen=True)
-class TargetRepo:
-    """Per-target descriptor: ``repo_id`` plus its filesystem root."""
-
-    repo_id: str
-    root: Path
+__all__ = [
+    "TargetRepo",
+    "TypeScriptImport",
+    "TypeScriptResolver",
+    "parse_import_statement",
+]
 
 
 @dataclass(frozen=True)

--- a/tests/test_resolver_dispatcher.py
+++ b/tests/test_resolver_dispatcher.py
@@ -1,0 +1,239 @@
+"""Tests for the cross-repo resolver dispatcher (Phase 2 Task 8).
+
+Covers :func:`better_code_review_graph.resolver.resolve_cross_repo_imports`:
+
+* Dispatch table — Python / TypeScript / JavaScript / Go / Rust / Java
+  / Kotlin all route to the expected resolver class.
+* Case-insensitive ``source_lang`` handling.
+* Tier-2 fallback for unknown languages.
+* Go-specific ``symbol`` plumbing — without a symbol the dispatcher
+  returns ``None`` because the call-site identifier is required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from better_code_review_graph.resolver import (
+    FallbackResolver,
+    GoResolver,
+    JavaResolver,
+    PythonResolver,
+    RustResolver,
+    TargetRepo,
+    TypeScriptResolver,
+    resolve_cross_repo_imports,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal source repos so each resolver constructor succeeds.
+# ---------------------------------------------------------------------------
+
+
+def _make_source_repo(tmp_path: Path) -> Path:
+    """Create an empty repo dir; resolver constructors only need it to exist."""
+    src = tmp_path / "source_repo"
+    src.mkdir()
+    return src
+
+
+def _make_target(tmp_path: Path, name: str = "target_repo") -> TargetRepo:
+    root = tmp_path / name
+    root.mkdir()
+    return TargetRepo(repo_id=f"{name}_id", root=root)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table — verifies the correct resolver class is instantiated and
+# its ``resolve`` method is invoked. We patch the class on the dispatcher
+# module so we can both assert the call and short-circuit the actual walk.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_routes_python(tmp_path: Path) -> None:
+    """``source_lang='python'`` instantiates ``PythonResolver`` and forwards."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.PythonResolver",
+        wraps=PythonResolver,
+    ) as cls:
+        result = resolve_cross_repo_imports(
+            "from lib_a import x",
+            "python",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+    assert result is None  # no pyproject = no declared dep -> None
+
+
+def test_dispatcher_routes_typescript(tmp_path: Path) -> None:
+    """``source_lang='typescript'`` routes to ``TypeScriptResolver``."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.TypeScriptResolver",
+        wraps=TypeScriptResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "import { x } from '@/lib/util'",
+            "typescript",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_routes_javascript_to_typescript(tmp_path: Path) -> None:
+    """``source_lang='javascript'`` shares the TypeScript resolver."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.TypeScriptResolver",
+        wraps=TypeScriptResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "import { x } from 'lib/util'",
+            "javascript",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_routes_go(tmp_path: Path) -> None:
+    """``source_lang='go'`` routes to ``GoResolver`` and forwards ``symbol``."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.GoResolver",
+        wraps=GoResolver,
+    ) as cls:
+        result = resolve_cross_repo_imports(
+            'import "example.com/a/util"',
+            "go",
+            source,
+            "source_id",
+            [target],
+            symbol="DoThing",
+        )
+    cls.assert_called_once_with(source, "source_id")
+    # No go.mod replace -> resolver returns None even with symbol.
+    assert result is None
+
+
+def test_dispatcher_routes_rust(tmp_path: Path) -> None:
+    """``source_lang='rust'`` routes to ``RustResolver``."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.RustResolver",
+        wraps=RustResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "use foo::util::do_thing;",
+            "rust",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_routes_java(tmp_path: Path) -> None:
+    """``source_lang='java'`` routes to ``JavaResolver``."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.JavaResolver",
+        wraps=JavaResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "import com.example.a.Util;",
+            "java",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_routes_kotlin_to_java(tmp_path: Path) -> None:
+    """``source_lang='kotlin'`` shares the Java resolver."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.JavaResolver",
+        wraps=JavaResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "import com.example.a.Util",
+            "kotlin",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_falls_back_for_unknown_lang(tmp_path: Path) -> None:
+    """``source_lang='ruby'`` (not in the table) routes to ``FallbackResolver``."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.FallbackResolver",
+        wraps=FallbackResolver,
+    ) as cls:
+        resolve_cross_repo_imports(
+            "require 'foo/bar'",
+            "ruby",
+            source,
+            "source_id",
+            [target],
+        )
+    cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_lang_is_case_insensitive(tmp_path: Path) -> None:
+    """``'Python'`` and ``'PYTHON'`` both hit the python resolver."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    for variant in ("Python", "PYTHON", "  python  "):
+        with patch(
+            "better_code_review_graph.resolver.PythonResolver",
+            wraps=PythonResolver,
+        ) as cls:
+            resolve_cross_repo_imports(
+                "from lib import x",
+                variant,
+                source,
+                "source_id",
+                [target],
+            )
+        cls.assert_called_once_with(source, "source_id")
+
+
+def test_dispatcher_go_without_symbol_returns_none(tmp_path: Path) -> None:
+    """Go cannot resolve without a symbol — dispatcher short-circuits to None."""
+    source = _make_source_repo(tmp_path)
+    target = _make_target(tmp_path)
+    with patch(
+        "better_code_review_graph.resolver.GoResolver",
+        wraps=GoResolver,
+    ) as cls:
+        result = resolve_cross_repo_imports(
+            'import "example.com/a/util"',
+            "go",
+            source,
+            "source_id",
+            [target],
+            # symbol omitted on purpose.
+        )
+    assert result is None
+    # GoResolver should NOT have been instantiated when symbol is missing.
+    cls.assert_not_called()

--- a/tests/test_resolver_fallback.py
+++ b/tests/test_resolver_fallback.py
@@ -1,0 +1,168 @@
+"""Tests for the tier-2 fallback resolver (Phase 2 Task 8).
+
+Covers :mod:`better_code_review_graph.resolver.fallback`:
+
+* :func:`parse_generic_qualified` — extracts the longest qualified
+  token from a raw import line, recognising dotted, double-colon and
+  slash separators.
+* :class:`FallbackResolver.resolve` — suffix-matches the qualified
+  token against each target repo's source tree, skips the source repo,
+  and threads through an explicit ``symbol`` override when provided.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from better_code_review_graph.resolver import (
+    TargetRepo,
+    resolve_cross_repo_imports,
+)
+from better_code_review_graph.resolver.fallback import (
+    FallbackResolver,
+    GenericImport,
+    parse_generic_qualified,
+)
+
+# ---------------------------------------------------------------------------
+# parse_generic_qualified
+# ---------------------------------------------------------------------------
+
+
+def test_parse_generic_qualified_dot_notation() -> None:
+    """``import com.example.Util`` extracts ``com.example.Util``."""
+    parsed = parse_generic_qualified("import com.example.Util")
+    assert parsed == GenericImport(qualified="com.example.Util")
+
+
+def test_parse_generic_qualified_double_colon() -> None:
+    """``use foo::bar::baz`` extracts ``foo::bar::baz``."""
+    parsed = parse_generic_qualified("use foo::bar::baz")
+    assert parsed == GenericImport(qualified="foo::bar::baz")
+
+
+def test_parse_generic_qualified_slash() -> None:
+    """``require 'foo/bar/baz'`` extracts ``foo/bar/baz``."""
+    parsed = parse_generic_qualified("require 'foo/bar/baz'")
+    assert parsed == GenericImport(qualified="foo/bar/baz")
+
+
+def test_parse_generic_qualified_picks_longest() -> None:
+    """Multiple qualified tokens in one string -> longest wins."""
+    # ``a.b`` (3 chars) vs ``foo.bar.baz`` (11 chars) -> longest wins.
+    parsed = parse_generic_qualified("from a.b take foo.bar.baz")
+    assert parsed == GenericImport(qualified="foo.bar.baz")
+
+
+def test_parse_generic_qualified_garbage() -> None:
+    """Unqualified strings (no separator) return ``None``."""
+    assert parse_generic_qualified("not_a_qualified_name") is None
+    assert parse_generic_qualified("") is None
+    assert parse_generic_qualified("just words here") is None
+
+
+# ---------------------------------------------------------------------------
+# FallbackResolver.resolve — fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_ruby_target(tmp_path: Path) -> Path:
+    """Create ``repo_a/lib/foo/bar.rb`` with a ``Bar`` class."""
+    repo_a = tmp_path / "repo_a"
+    pkg = repo_a / "lib" / "foo"
+    pkg.mkdir(parents=True)
+    (pkg / "bar.rb").write_text("class Bar\nend\n", encoding="utf-8")
+    return repo_a
+
+
+def _build_source_repo(tmp_path: Path) -> Path:
+    """Create an empty source repo (fallback doesn't read source config)."""
+    repo = tmp_path / "source"
+    repo.mkdir()
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# FallbackResolver.resolve — behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_resolver_finds_via_suffix_match(tmp_path: Path) -> None:
+    """Plan-required spec: tier-2 fixture with Ruby file resolves via suffix.
+
+    Build ``repo_a/lib/foo/bar.rb``, source repo with no resolver
+    registered for ``"ruby"``. Calling ``resolve_cross_repo_imports``
+    routes to the fallback and returns the suffix-matched qualified
+    name with the explicit ``symbol`` override.
+    """
+    repo_a = _build_ruby_target(tmp_path)
+    source = _build_source_repo(tmp_path)
+    qualified = resolve_cross_repo_imports(
+        "require 'foo/bar'",
+        "ruby",
+        source,
+        "source_id",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+        symbol="Bar",
+    )
+    assert qualified == "repo_a_id:lib/foo/bar.rb::Bar"
+
+
+def test_fallback_resolver_skips_self_repo(tmp_path: Path) -> None:
+    """A target whose ``repo_id`` matches the source is skipped."""
+    repo_a = _build_ruby_target(tmp_path)
+    source = _build_source_repo(tmp_path)
+    resolver = FallbackResolver(source, "repo_a_id")
+    qualified = resolver.resolve(
+        "require 'foo/bar'",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+        symbol="Bar",
+    )
+    assert qualified is None
+
+
+def test_fallback_resolver_returns_none_when_no_match(tmp_path: Path) -> None:
+    """No matching file in any target -> ``None``."""
+    repo_a = _build_ruby_target(tmp_path)
+    source = _build_source_repo(tmp_path)
+    resolver = FallbackResolver(source, "source_id")
+    qualified = resolver.resolve(
+        "require 'nonexistent/path'",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+        symbol="Whatever",
+    )
+    assert qualified is None
+
+
+def test_fallback_resolver_uses_symbol_kwarg_when_provided(tmp_path: Path) -> None:
+    """Explicit ``symbol`` override beats the auto-derived last segment."""
+    repo_a = _build_ruby_target(tmp_path)
+    source = _build_source_repo(tmp_path)
+    resolver = FallbackResolver(source, "source_id")
+    # Without ``symbol`` the parser would treat ``bar`` as the symbol;
+    # passing ``"Bar"`` overrides that to use the actual class name.
+    qualified = resolver.resolve(
+        "require 'foo/bar'",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+        symbol="Bar",
+    )
+    assert qualified == "repo_a_id:lib/foo/bar.rb::Bar"
+
+    # Without the kwarg the symbol falls back to the last segment.
+    qualified_default = resolver.resolve(
+        "require 'foo/bar'",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified_default == "repo_a_id:lib/foo/bar.rb::bar"
+
+
+def test_fallback_resolver_returns_none_for_unparseable_stmt(tmp_path: Path) -> None:
+    """Statement with no qualified token at all -> ``None``."""
+    repo_a = _build_ruby_target(tmp_path)
+    source = _build_source_repo(tmp_path)
+    resolver = FallbackResolver(source, "source_id")
+    qualified = resolver.resolve(
+        "no qualified token here",
+        [TargetRepo(repo_id="repo_a_id", root=repo_a)],
+    )
+    assert qualified is None


### PR DESCRIPTION
## Summary
- New `resolver/_types.py` — shared `TargetRepo` dataclass (consolidated from 5 language modules; each now re-exports via `from ._types import TargetRepo` + `__all__`).
- New `resolver/fallback.py` — `FallbackResolver` for tier-2 languages: extracts longest qualified-name token (`a.b.c` / `a::b::c` / `a/b/c`) and rglob suffix-matches against 30+ source extensions across all target repos.
- Replaced placeholder `resolver/__init__.py` with `resolve_cross_repo_imports(import_stmt, source_lang, ...)` dispatcher.
- Language routing table: python, typescript, javascript→TypeScriptResolver, go, rust, java, kotlin→JavaResolver. Unknown lang → FallbackResolver.
- Go's `symbol` kwarg quirk handled at dispatcher level (returns None when source_lang="go" + symbol=None).
- Source language is case-insensitive + whitespace-trimmed.

This is **Phase 2 Task 8 of 12** (epic #325). 8/12 done. All 5 language resolvers + fallback now reachable through one entry point — ready for Task 9 parser wiring.

## Test plan
- [x] `pytest tests/test_resolver_*.py -v`: 165 passed (5 language resolvers untouched: 17+36+30+35+27 = 145; new dispatcher: 10; new fallback: 10).
- [x] Coverage on resolver package: 99% overall (resolver/__init__.py 100%, _types.py 100%, fallback.py 100%, language modules unchanged).
- [x] `pytest --cov-fail-under=95 -q`: 930 passed, total 95.82%.
- [x] `grep -c "directory" uv.lock`: 0 (committed state).
- [ ] CI green on this branch.

## Files
- New: `resolver/_types.py` (21), `resolver/fallback.py` (177), `tests/test_resolver_dispatcher.py` (10 tests), `tests/test_resolver_fallback.py` (10 tests).
- Modified: `resolver/__init__.py` (placeholder → dispatcher), `resolver/{python,typescript,go,rust,java}.py` (mechanical TargetRepo refactor — re-export from `_types`).
- Untouched: `parser.py`, `incremental.py`, `embeddings.py`, `tools.py`, `server.py`, `summarizer.py`, `exporter.py`, `graph.py`, `federation.py`, migrations.

## Out of scope (later tasks)
- Task 9: parser/incremental wiring — `parse_file()` will call `resolve_cross_repo_imports()` for IMPORTS_FROM edges with unresolved targets.
- Task 10: cross-cutting `repo` query param.
- Tasks 11-12: docs + smoke.