### PR TITLE
feat: Phase 2 Task 9 — parser + incremental wiring (repo_id population + cross-repo edges + last_indexed_sha refresh)

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -214,6 +214,7 @@ class GraphStore:
         self._conn.executescript(_SCHEMA_SQL)
         self._conn.commit()
         self._ensure_summary_columns()
+        self._ensure_federation_columns()
 
     def _run_alembic_upgrade(self) -> None:
         """Bring ``self.db_path`` to alembic head before legacy bootstrap.
@@ -293,6 +294,61 @@ class GraphStore:
                 "the package or recreate the DB."
             ) from exc
 
+    def _ensure_federation_columns(self) -> None:
+        """Backfill Phase 2 Task 1 federation columns on legacy / in-memory DBs.
+
+        Mirrors ``_ensure_summary_columns`` for the
+        ``003_federation`` migration. Two cases land here:
+
+        * In-memory ``:memory:`` databases — alembic creates the schema
+          in a separate in-memory connection (per the
+          ``sqlite:///:memory:`` URL semantics), so the migration never
+          touches ``self._conn``. The legacy ``_SCHEMA_SQL`` is frozen
+          at v1.6 and intentionally does not include ``repo_id``, so
+          we add the column here to keep ``upsert_node`` /
+          ``upsert_edge`` working without forcing every test to use a
+          file-backed DB.
+        * File-backed databases created before alembic adoption —
+          ``_run_alembic_upgrade`` already brings them to head, so
+          this is a no-op for them. The ``IF NOT EXISTS`` guard on
+          the index plus the column-presence check make this safe to
+          call unconditionally on every connect.
+        """
+        node_cols = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(nodes)").fetchall()
+        }
+        if "repo_id" not in node_cols:
+            self._conn.execute(
+                "ALTER TABLE nodes ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
+            )
+        edge_cols = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(edges)").fetchall()
+        }
+        if "repo_id" not in edge_cols:
+            self._conn.execute(
+                "ALTER TABLE edges ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
+            )
+        # Repos registry table — created by migration 003 on disk-backed
+        # DBs. Mirror it here for in-memory connections so RepoRegistry
+        # works against ``:memory:`` GraphStores too.
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS repos (
+                repo_id TEXT PRIMARY KEY NOT NULL,
+                path TEXT NOT NULL,
+                remote_url TEXT,
+                last_indexed_sha TEXT,
+                first_indexed_at INTEGER NOT NULL,
+                last_indexed_at INTEGER NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_repo_kind ON nodes(repo_id, kind)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_edges_repo ON edges(repo_id)"
+        )
+        self._conn.commit()
+
     def _ensure_summary_columns(self) -> None:
         """Backfill Phase 1 v1.6.x summary columns on pre-existing DBs.
 
@@ -330,14 +386,20 @@ class GraphStore:
         """Insert or update a node. Returns the node ID."""
         now = time.time()
         qualified = self._make_qualified(node)
-        extra = json.dumps(node.extra) if node.extra else "{}"
+        # Tolerate dict / Mapping that don't survive ``if node.extra``
+        # (e.g. a stand-in object from a pre-Phase-2 caller).
+        extra_obj = getattr(node, "extra", None) or {}
+        extra = json.dumps(extra_obj) if extra_obj else "{}"
+        # Phase 2 Task 9 — fall back to "" for callers passing legacy
+        # NodeInfo objects without the federation field.
+        repo_id = getattr(node, "repo_id", "") or ""
 
         self._conn.execute(
             """INSERT INTO nodes
                (kind, name, qualified_name, file_path, line_start, line_end,
                 language, parent_name, params, return_type, modifiers, is_test,
-                file_hash, extra, updated_at, source_text)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                file_hash, extra, updated_at, source_text, repo_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(qualified_name) DO UPDATE SET
                  kind=excluded.kind, name=excluded.name,
                  file_path=excluded.file_path, line_start=excluded.line_start,
@@ -346,7 +408,7 @@ class GraphStore:
                  return_type=excluded.return_type, modifiers=excluded.modifiers,
                  is_test=excluded.is_test, file_hash=excluded.file_hash,
                  extra=excluded.extra, updated_at=excluded.updated_at,
-                 source_text=excluded.source_text
+                 source_text=excluded.source_text, repo_id=excluded.repo_id
             """,
             (
                 node.kind,
@@ -364,7 +426,8 @@ class GraphStore:
                 file_hash,
                 extra,
                 now,
-                node.source_text,
+                getattr(node, "source_text", None),
+                repo_id,
             ),
         )
         row = self._conn.execute(
@@ -375,7 +438,10 @@ class GraphStore:
     def upsert_edge(self, edge: EdgeInfo) -> int:
         """Insert or update an edge."""
         now = time.time()
-        extra = json.dumps(edge.extra) if edge.extra else "{}"
+        extra_obj = getattr(edge, "extra", None) or {}
+        extra = json.dumps(extra_obj) if extra_obj else "{}"
+        # Phase 2 Task 9 — same legacy fallback as ``upsert_node``.
+        repo_id = getattr(edge, "repo_id", "") or ""
 
         # Check for existing edge (include line so multiple call sites are preserved)
         existing = self._conn.execute(
@@ -387,15 +453,15 @@ class GraphStore:
 
         if existing:
             self._conn.execute(
-                "UPDATE edges SET line=?, extra=?, updated_at=? WHERE id=?",
-                (edge.line, extra, now, existing["id"]),
+                "UPDATE edges SET line=?, extra=?, updated_at=?, repo_id=? WHERE id=?",
+                (edge.line, extra, now, repo_id, existing["id"]),
             )
             return existing["id"]
 
         self._conn.execute(
             """INSERT INTO edges
-               (kind, source_qualified, target_qualified, file_path, line, extra, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (kind, source_qualified, target_qualified, file_path, line, extra, updated_at, repo_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 edge.kind,
                 edge.source,
@@ -404,6 +470,7 @@ class GraphStore:
                 edge.line,
                 extra,
                 now,
+                repo_id,
             ),
         )
         return self._conn.execute("SELECT last_insert_rowid()").fetchone()[0]
@@ -452,7 +519,8 @@ class GraphStore:
             node_data = []
             for node in nodes:
                 qualified = self._make_qualified(node)
-                extra = json.dumps(node.extra) if node.extra else "{}"
+                extra_obj = getattr(node, "extra", None) or {}
+                extra = json.dumps(extra_obj) if extra_obj else "{}"
                 node_data.append(
                     (
                         node.kind,
@@ -470,7 +538,8 @@ class GraphStore:
                         fhash,
                         extra,
                         now,
-                        node.source_text,
+                        getattr(node, "source_text", None),
+                        getattr(node, "repo_id", "") or "",
                     )
                 )
 
@@ -478,8 +547,8 @@ class GraphStore:
                 """INSERT INTO nodes
                    (kind, name, qualified_name, file_path, line_start, line_end,
                     language, parent_name, params, return_type, modifiers, is_test,
-                    file_hash, extra, updated_at, source_text)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    file_hash, extra, updated_at, source_text, repo_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(qualified_name) DO UPDATE SET
                      kind=excluded.kind, name=excluded.name,
                      file_path=excluded.file_path, line_start=excluded.line_start,
@@ -488,7 +557,7 @@ class GraphStore:
                      return_type=excluded.return_type, modifiers=excluded.modifiers,
                      is_test=excluded.is_test, file_hash=excluded.file_hash,
                      extra=excluded.extra, updated_at=excluded.updated_at,
-                     source_text=excluded.source_text
+                     source_text=excluded.source_text, repo_id=excluded.repo_id
                 """,
                 node_data,
             )
@@ -500,7 +569,8 @@ class GraphStore:
                 key = (edge.kind, edge.source, edge.target, edge.file_path, edge.line)
                 if key not in seen:
                     seen.add(key)
-                    extra = json.dumps(edge.extra) if edge.extra else "{}"
+                    extra_obj = getattr(edge, "extra", None) or {}
+                    extra = json.dumps(extra_obj) if extra_obj else "{}"
                     edge_data.append(
                         (
                             edge.kind,
@@ -510,13 +580,14 @@ class GraphStore:
                             edge.line,
                             extra,
                             now,
+                            getattr(edge, "repo_id", "") or "",
                         )
                     )
 
             self._conn.executemany(
                 """INSERT INTO edges
-                   (kind, source_qualified, target_qualified, file_path, line, extra, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                   (kind, source_qualified, target_qualified, file_path, line, extra, updated_at, repo_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 edge_data[::-1],
             )
 

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -14,13 +14,16 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from .graph import GraphStore
 from .parser import CodeParser
+
+if TYPE_CHECKING:
+    from .federation import RepoRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -477,13 +480,34 @@ def _update_files_in_store(
     return total_nodes, total_edges, actually_updated, errors
 
 
-def _finalize_incremental_metadata(repo_root: Path, store: GraphStore) -> None:
-    """Update store metadata and commit changes."""
+def _finalize_incremental_metadata(
+    repo_root: Path,
+    store: GraphStore,
+    repo_registry: RepoRegistry | None = None,
+) -> None:
+    """Update store metadata and commit changes.
+
+    When ``repo_registry`` is provided and ``repo_root`` is a git
+    repo, the registry's ``last_indexed_sha`` for the matching
+    ``repo_id`` is bumped to the current HEAD. Non-git directories and
+    callers who don't pass a registry skip the SHA refresh silently —
+    federation works without git.
+    """
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")
     current_head = get_head_sha(repo_root)
     if current_head:
         store.set_metadata("last_built_head", current_head)
+        if repo_registry is not None:
+            try:
+                repo_id = repo_registry.assign(repo_root)
+            except ValueError:
+                # Repo not registered — nothing to update. The caller
+                # is responsible for ``registry.add(repo_root)`` before
+                # incremental_update if they want SHA tracking.
+                repo_id = None
+            if repo_id is not None:
+                repo_registry.update_last_indexed_sha(repo_id, current_head)
     store.commit()
 
 
@@ -492,8 +516,22 @@ def incremental_update(
     store: GraphStore,
     base: str = "HEAD~1",
     changed_files: list[str] | None = None,
+    *,
+    repo_registry: RepoRegistry | None = None,
 ) -> dict:
-    """Incremental update: re-parse changed + dependent files only."""
+    """Incremental update: re-parse changed + dependent files only.
+
+    Parameters
+    ----------
+    repo_registry:
+        Phase 2 Task 9 — when provided, the registry's
+        ``last_indexed_sha`` for the repo matching ``repo_root`` is
+        bumped to the current ``HEAD`` once indexing completes. The
+        registry is currently only used for the SHA refresh; per-node
+        federation tagging on the parser path is handled by
+        ``CodeParser.parse_file`` callers (Task 10 wires this into the
+        full build).
+    """
     parser = CodeParser()
     ignore_patterns = _load_ignore_patterns(repo_root)
 
@@ -503,6 +541,18 @@ def incremental_update(
     )
 
     if not changed_files:
+        # Even on a no-op pass, refresh ``last_indexed_sha`` so a
+        # registry that's just been bootstrapped reflects HEAD instead
+        # of staying stuck on ``None``.
+        if repo_registry is not None:
+            head = get_head_sha(repo_root)
+            if head:
+                try:
+                    rid = repo_registry.assign(repo_root)
+                except ValueError:
+                    rid = None
+                if rid is not None:
+                    repo_registry.update_last_indexed_sha(rid, head)
         return {
             "files_updated": 0,
             "total_nodes": 0,
@@ -533,7 +583,7 @@ def incremental_update(
     )
 
     # 6. Finalize metadata and commit
-    _finalize_incremental_metadata(repo_root, store)
+    _finalize_incremental_metadata(repo_root, store, repo_registry=repo_registry)
 
     return {
         "files_updated": len(all_files),

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -18,6 +18,9 @@ import tree_sitter_language_pack as tslp
 if TYPE_CHECKING:
     from tree_sitter_language_pack import SupportedLanguage
 
+    from .federation import RepoRegistry
+    from .resolver import TargetRepo
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -47,6 +50,11 @@ class NodeInfo:
     # candidates without re-reading files. Class/Type/Test/File leave this None
     # to avoid bloating the DB with content that is irrelevant for LLM summaries.
     source_text: str | None = None
+    # Phase 2 Task 9: federation scoping. Empty string is the single-repo
+    # default and matches the SQLite ``DEFAULT ''`` on the ``nodes.repo_id``
+    # column added in alembic revision ``003_federation``. The federation
+    # driver populates this via ``RepoRegistry.assign(path)``.
+    repo_id: str = ""
 
 
 @dataclass
@@ -57,6 +65,10 @@ class EdgeInfo:
     file_path: str
     line: int = 0
     extra: dict = field(default_factory=dict)
+    # Phase 2 Task 9: federation scoping. Same shape and rationale as
+    # ``NodeInfo.repo_id``; for cross-repo edges this is the *source*
+    # repo's id (the edge originates in that repo).
+    repo_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -274,21 +286,58 @@ class CodeParser:
     def detect_language(self, path: Path) -> str | None:
         return EXTENSION_TO_LANGUAGE.get(path.suffix.lower())
 
-    def parse_file(self, path: Path) -> tuple[list[NodeInfo], list[EdgeInfo]]:
-        """Parse a single file and return extracted nodes and edges."""
+    def parse_file(
+        self,
+        path: Path,
+        *,
+        repo_registry: RepoRegistry | None = None,
+        target_repos: list[TargetRepo] | None = None,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a single file and return extracted nodes and edges.
+
+        Parameters
+        ----------
+        path:
+            Filesystem path to the file to parse.
+        repo_registry:
+            Phase 2 Task 9 — when provided, every emitted ``NodeInfo``
+            and ``EdgeInfo`` has its ``repo_id`` populated from
+            ``repo_registry.assign(path)``. Single-repo callers (the
+            default) get the legacy behaviour with empty ``repo_id``.
+        target_repos:
+            Phase 2 Task 9 — when both this and ``repo_registry`` are
+            provided, ``IMPORTS_FROM`` edges whose target can be
+            resolved across the federated targets are rewritten to
+            ``<other_repo_id>:<file>::<symbol>`` via
+            :func:`better_code_review_graph.resolver.resolve_cross_repo_imports`.
+            Unresolved imports keep their original within-repo target.
+        """
         try:
             source = path.read_bytes()
         except (OSError, PermissionError):
             return [], []
-        return self.parse_bytes(path, source)
+        return self.parse_bytes(
+            path,
+            source,
+            repo_registry=repo_registry,
+            target_repos=target_repos,
+        )
 
     def parse_bytes(
-        self, path: Path, source: bytes
+        self,
+        path: Path,
+        source: bytes,
+        *,
+        repo_registry: RepoRegistry | None = None,
+        target_repos: list[TargetRepo] | None = None,
     ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
         """Parse pre-read bytes and return extracted nodes and edges.
 
         This avoids re-reading the file from disk, eliminating TOCTOU gaps
         when the caller has already read the bytes (e.g. for hashing).
+
+        See :meth:`parse_file` for the ``repo_registry`` / ``target_repos``
+        federation kwargs.
         """
         language = self.detect_language(path)
         if not language:
@@ -344,7 +393,133 @@ class CodeParser:
         finally:
             self._current_source_lines = None
 
+        # Phase 2 Task 9: federation post-processing. Single-repo callers
+        # (no registry) skip this entirely so behaviour is unchanged.
+        if repo_registry is not None:
+            self._apply_federation(
+                path=path,
+                language=language,
+                nodes=nodes,
+                edges=edges,
+                repo_registry=repo_registry,
+                target_repos=target_repos,
+            )
+
         return nodes, edges
+
+    def _apply_federation(
+        self,
+        *,
+        path: Path,
+        language: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        repo_registry: RepoRegistry,
+        target_repos: list[TargetRepo] | None,
+    ) -> None:
+        """Stamp ``repo_id`` on nodes/edges and resolve cross-repo imports.
+
+        Tagging is unconditional once a registry is wired in (every node
+        belongs to *some* repo, even in single-repo federation mode);
+        cross-repo IMPORTS_FROM rewrites are best-effort and only run
+        when ``target_repos`` is non-empty.
+        """
+        # Resolve once, reuse for every node/edge in this file.
+        try:
+            source_repo_id = repo_registry.assign(path)
+        except ValueError:
+            # File lives outside every registered root — leave repo_id
+            # empty so the row is still writeable; the caller decides
+            # whether to register the path before retrying.
+            return
+
+        for node in nodes:
+            node.repo_id = source_repo_id
+        for edge in edges:
+            edge.repo_id = source_repo_id
+
+        if not target_repos:
+            return
+
+        # Cross-repo IMPORTS_FROM rewrite. Lazy import keeps the
+        # resolver's tomllib/regex cost off the hot path for callers
+        # that don't pass target_repos.
+        from .resolver import resolve_cross_repo_imports  # noqa: PLC0415
+
+        # Look up the source repo's filesystem root (registry knows it)
+        # so the resolver can read its ``pyproject.toml`` /
+        # ``Cargo.toml`` / ``go.mod`` etc. ``RepoRegistry.entries()``
+        # gives us the canonical mapping.
+        source_root: Path | None = None
+        for entry in repo_registry.entries():
+            if entry.repo_id == source_repo_id:
+                source_root = entry.path
+                break
+        if source_root is None:
+            return
+
+        for edge in edges:
+            if edge.kind != "IMPORTS_FROM":
+                continue
+            # Prefer the original import line (captured into
+            # ``extra["import_stmt"]`` by ``_handle_import_node``) so
+            # the resolvers see the imported symbol name. Fall back to
+            # a synthesised statement built from the bare target —
+            # this keeps the path working for legacy callers that
+            # construct EdgeInfo by hand without ``extra``.
+            stmt = (edge.extra or {}).get("import_stmt") or self._build_resolver_stmt(
+                language, edge.target
+            )
+            try:
+                resolved = resolve_cross_repo_imports(
+                    stmt,
+                    language,
+                    source_root,
+                    source_repo_id,
+                    target_repos,
+                )
+            except Exception:
+                # The resolver may touch the filesystem; treat any
+                # error as "no cross-repo match" rather than aborting
+                # the whole parse. Single-repo mode is preserved.
+                resolved = None
+            if resolved is not None:
+                edge.target = resolved
+
+    @staticmethod
+    def _build_resolver_stmt(language: str, target: str) -> str:
+        """Synthesise an import statement from the parser's bare target.
+
+        The parser stores per-language extracted forms (Python: dotted
+        module, JS/TS: module path string, Go: quoted path, Rust: full
+        ``use`` line, Java/Kotlin/C#: dotted name, Solidity/Ruby:
+        quoted path). The cross-repo resolvers re-parse these strings
+        with their own regexes so the round-trip is lossy in edge
+        cases (e.g. Python's imported symbol name is dropped because
+        we only keep the module). For Phase 2 Task 9 this is the
+        documented trade-off: cross-repo qualified names use the
+        module's basename when the imported symbol name is not
+        threaded through the parser-extracted target.
+        """
+        lang = language.lower()
+        if lang == "python":
+            return f"import {target}"
+        if lang in ("javascript", "typescript", "tsx"):
+            # TypeScript resolver matches the module string anywhere on the line.
+            return f'import "{target}"'
+        if lang == "go":
+            return f'import "{target}"'
+        if lang == "rust":
+            # Rust resolver expects ``use ...;`` shape; the target is
+            # already the full path-with-`::`.
+            stripped = target.strip().rstrip(";")
+            if stripped.startswith("use "):
+                return target
+            return f"use {stripped};"
+        if lang in ("java", "kotlin"):
+            return f"import {target};"
+        # Fallback / tier-2 languages: pass through verbatim.
+        return target
 
     def _extract_from_tree(
         self,
@@ -612,6 +787,11 @@ class CodeParser:
         edges: list[EdgeInfo],
     ) -> bool:
         imports = self._extract_import(node, language, source)
+        # Phase 2 Task 9: stash the raw import line on the edge so the
+        # federation post-processing can hand the full statement (with
+        # the imported symbol name intact) to the cross-repo resolvers.
+        # Single-repo callers ignore this field entirely.
+        raw_stmt = node.text.decode("utf-8", errors="replace").strip()
         for imp_target in imports:
             edges.append(
                 EdgeInfo(
@@ -620,6 +800,7 @@ class CodeParser:
                     target=imp_target,
                     file_path=file_path,
                     line=node.start_point[0] + 1,
+                    extra={"import_stmt": raw_stmt},
                 )
             )
         return True

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -290,3 +290,174 @@ class TestIncrementalUpdateFromHook:
         # Verify graph was created
         db_path = tmp_path / ".code-review-graph" / "graph.db"
         assert db_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Task 9: incremental_update refreshes repos.last_indexed_sha
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalUpdateRefreshesLastIndexedSha:
+    def _git_init_with_commit(self, repo_root):
+        """Init a git repo with one committed file and return the HEAD SHA."""
+        subprocess.run(["git", "init"], cwd=repo_root, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "t@t.com"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "T"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+        )
+        (repo_root / "sample.py").write_text("def foo():\n    pass\n")
+        subprocess.run(
+            ["git", "add", "."], cwd=repo_root, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return head.stdout.strip()
+
+    def test_refreshes_last_indexed_sha_in_git_repo(self, tmp_path):
+        """When repo_registry is provided + git is available, write HEAD SHA."""
+        from better_code_review_graph.federation import RepoRegistry
+
+        head_sha = self._git_init_with_commit(tmp_path)
+
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            registry = RepoRegistry(store)
+            rid = registry.add(tmp_path)
+
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["sample.py"],
+                repo_registry=registry,
+            )
+
+            row = store._conn.execute(
+                "SELECT last_indexed_sha FROM repos WHERE repo_id = ?", (rid,)
+            ).fetchone()
+            assert row is not None
+            assert row["last_indexed_sha"] == head_sha
+        finally:
+            store.close()
+
+    def test_skips_sha_refresh_when_no_registry(self, tmp_path):
+        """Without a repo_registry, last_indexed_sha is left unchanged."""
+        # Plain incremental_update (existing callers) is unaffected.
+        py_file = tmp_path / "mod.py"
+        py_file.write_text("def greet():\n    return 'hi'\n")
+
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            result = incremental_update(tmp_path, store, changed_files=["mod.py"])
+            assert result["files_updated"] >= 1
+        finally:
+            store.close()
+
+    def test_skips_sha_refresh_without_git(self, tmp_path):
+        """Non-git directory: no SHA available, last_indexed_sha stays None."""
+        from better_code_review_graph.federation import RepoRegistry
+
+        # NOTE: tmp_path has NO .git directory.
+        py_file = tmp_path / "mod.py"
+        py_file.write_text("def greet():\n    return 'hi'\n")
+
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            registry = RepoRegistry(store)
+            rid = registry.add(tmp_path)
+
+            # Should not raise even though git is unavailable.
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["mod.py"],
+                repo_registry=registry,
+            )
+
+            row = store._conn.execute(
+                "SELECT last_indexed_sha FROM repos WHERE repo_id = ?", (rid,)
+            ).fetchone()
+            assert row is not None
+            assert row["last_indexed_sha"] is None
+        finally:
+            store.close()
+
+    def test_no_changes_path_still_refreshes_sha_with_registry(self, tmp_path):
+        """Even on the early-return ``no changes`` path, SHA is refreshed."""
+        from better_code_review_graph.federation import RepoRegistry
+
+        head_sha = self._git_init_with_commit(tmp_path)
+
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            registry = RepoRegistry(store)
+            rid = registry.add(tmp_path)
+
+            # Pass an empty changed_files list -> the function returns
+            # early. With a registry wired in, last_indexed_sha should
+            # still be bumped to HEAD.
+            result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=[],
+                repo_registry=registry,
+            )
+            assert result["files_updated"] == 0
+
+            row = store._conn.execute(
+                "SELECT last_indexed_sha FROM repos WHERE repo_id = ?", (rid,)
+            ).fetchone()
+            assert row is not None
+            assert row["last_indexed_sha"] == head_sha
+        finally:
+            store.close()
+
+    def test_no_changes_path_skips_sha_refresh_when_repo_not_registered(self, tmp_path):
+        """Early-return path with registry but unregistered root: silent skip."""
+        from better_code_review_graph.federation import RepoRegistry
+
+        self._git_init_with_commit(tmp_path)
+
+        # Build a registry that is NOT pointed at tmp_path.
+        elsewhere = tmp_path.parent / (tmp_path.name + "-other")
+        elsewhere.mkdir(exist_ok=True)
+
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            registry = RepoRegistry(store)
+            registry.add(elsewhere)
+
+            # Should not raise — registry.assign(tmp_path) yields ValueError
+            # which the helper swallows.
+            result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=[],
+                repo_registry=registry,
+            )
+            assert result["files_updated"] == 0
+        finally:
+            store.close()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -227,3 +227,305 @@ def handler():
     assert loads_call is not None
     # External call -- stays bare (no local definition)
     assert "::" not in loads_call.target
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Task 9: parser + federation wiring
+# ---------------------------------------------------------------------------
+
+
+def test_parse_file_without_repo_registry_keeps_repo_id_empty(tmp_path):
+    """Backwards-compat: no repo_registry -> all nodes get repo_id == ''."""
+    parser = CodeParser()
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("def foo():\n    return 1\n")
+
+    nodes, edges = parser.parse_file(py_file)
+
+    # Every node defaults to empty repo_id when no registry is wired in.
+    assert nodes, "expected at least the File node"
+    for node in nodes:
+        assert node.repo_id == "", (
+            f"expected empty repo_id for {node.kind}/{node.name}, got {node.repo_id!r}"
+        )
+    for edge in edges:
+        assert edge.repo_id == "", (
+            f"expected empty repo_id for edge {edge.kind} {edge.source}->{edge.target}"
+        )
+
+
+def test_parse_file_with_repo_registry_populates_node_repo_id(tmp_path):
+    """When repo_registry is provided, every node's repo_id == registry.assign(path)."""
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    py_file = repo / "mod.py"
+    py_file.write_text("def hello():\n    return 'hi'\n")
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        rid = registry.add(repo)
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(py_file, repo_registry=registry)
+
+        assert nodes
+        for node in nodes:
+            assert node.repo_id == rid, (
+                f"expected repo_id={rid!r} for {node.kind}/{node.name}, "
+                f"got {node.repo_id!r}"
+            )
+        # IMPORTS_FROM edges (none here) plus CONTAINS edges should also
+        # carry the source repo's id.
+        for edge in edges:
+            assert edge.repo_id == rid
+    finally:
+        store.close()
+
+
+def test_parse_file_cross_repo_resolution_via_dispatcher(tmp_path):
+    """2-repo Python fixture: imports get cross-repo resolved when declared as dep.
+
+    repo_a exposes ``lib_a/utils.py`` with ``retry()``. repo_b's
+    ``pyproject.toml`` declares ``lib_a`` as a dependency and ``main.py``
+    imports ``from lib_a.utils import retry``. The parser, given
+    ``target_repos=[repo_a]``, should rewrite the IMPORTS_FROM edge
+    target to ``<repo_a_id>:lib_a/utils.py::retry`` (or ``::utils`` —
+    we accept either since the resolver may normalise to the module's
+    own basename when the imported symbol name is not threaded through).
+    """
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+    from better_code_review_graph.resolver import TargetRepo
+
+    # --- repo_a (target) ---
+    repo_a = tmp_path / "repo_a"
+    (repo_a / "lib_a").mkdir(parents=True)
+    (repo_a / "lib_a" / "__init__.py").write_text("")
+    (repo_a / "lib_a" / "utils.py").write_text("def retry():\n    pass\n")
+    (repo_a / "pyproject.toml").write_text(
+        '[project]\nname = "lib_a"\nversion = "0.1.0"\n'
+    )
+
+    # --- repo_b (source) ---
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "pyproject.toml").write_text(
+        '[project]\nname = "repo_b"\nversion = "0.1.0"\ndependencies = ["lib_a"]\n'
+    )
+    main_py = repo_b / "main.py"
+    main_py.write_text("from lib_a.utils import retry\n\ndef go():\n    retry()\n")
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        rid_a = registry.add(repo_a)
+        rid_b = registry.add(repo_b)
+
+        target_repos = [
+            TargetRepo(repo_id=rid_a, root=repo_a),
+            TargetRepo(repo_id=rid_b, root=repo_b),
+        ]
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(
+            main_py,
+            repo_registry=registry,
+            target_repos=target_repos,
+        )
+
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert imports, "expected at least one IMPORTS_FROM edge"
+        cross = [e for e in imports if e.target.startswith(f"{rid_a}:")]
+        assert len(cross) == 1, (
+            f"expected the lib_a import to be resolved cross-repo, "
+            f"got targets={[e.target for e in imports]}"
+        )
+        cross_edge = cross[0]
+        # Format: <repo_id>:<file_path>::<symbol>
+        assert "lib_a/utils.py" in cross_edge.target.replace("\\", "/")
+        assert "::" in cross_edge.target
+        # Edge originates in source repo, so its repo_id == source repo id.
+        assert cross_edge.repo_id == rid_b
+    finally:
+        store.close()
+
+
+def test_parse_file_cross_repo_unresolved_stays_within_repo(tmp_path):
+    """Imports that don't resolve to any target repo keep their bare target.
+
+    Stdlib imports (``import os``) aren't declared as deps in
+    pyproject.toml so the resolver returns ``None`` and the edge keeps
+    its single-repo bare target.
+    """
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+    from better_code_review_graph.resolver import TargetRepo
+
+    repo = tmp_path / "solo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "solo"\nversion = "0.1.0"\n'
+    )
+    py_file = repo / "app.py"
+    py_file.write_text("import os\n\ndef foo():\n    os.getcwd()\n")
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        rid = registry.add(repo)
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(
+            py_file,
+            repo_registry=registry,
+            target_repos=[TargetRepo(repo_id=rid, root=repo)],
+        )
+
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert imports
+        for edge in imports:
+            # Stays bare — not resolved cross-repo.
+            assert ":" not in edge.target.split("/")[-1] or edge.target == "os"
+            assert edge.target == "os"
+            assert edge.repo_id == rid
+    finally:
+        store.close()
+
+
+def test_build_resolver_stmt_per_language():
+    """Cover every language branch of ``_build_resolver_stmt``."""
+    fn = CodeParser._build_resolver_stmt
+
+    assert fn("python", "lib_a.utils") == "import lib_a.utils"
+    assert fn("javascript", "./foo") == 'import "./foo"'
+    assert fn("typescript", "./bar") == 'import "./bar"'
+    assert fn("tsx", "./baz") == 'import "./baz"'
+    assert fn("go", "github.com/x/y") == 'import "github.com/x/y"'
+    # Rust: bare path -> wrapped; already wrapped -> passed through.
+    assert fn("rust", "foo::bar::Baz") == "use foo::bar::Baz;"
+    assert fn("rust", "use foo::bar;") == "use foo::bar;"
+    # Java + Kotlin both use ``import ...;``.
+    assert fn("java", "com.example.Util") == "import com.example.Util;"
+    assert fn("kotlin", "com.example.Helper") == "import com.example.Helper;"
+    # Tier-2 fallback: any other language returns target verbatim.
+    assert fn("ruby", "foo/bar") == "foo/bar"
+
+
+def test_apply_federation_skips_when_path_outside_registry(tmp_path):
+    """File outside any registered repo: repo_id stays empty (no exception)."""
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+
+    # Register a repo at one location; parse a file under a sibling
+    # directory so registry.assign() raises ValueError, which the
+    # parser swallows and leaves repo_id empty.
+    registered = tmp_path / "registered"
+    registered.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    py_file = elsewhere / "stray.py"
+    py_file.write_text("def foo():\n    pass\n")
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        registry.add(registered)
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(py_file, repo_registry=registry)
+
+        # No assignment available -> repo_id stays at the dataclass default.
+        for node in nodes:
+            assert node.repo_id == ""
+    finally:
+        store.close()
+
+
+def test_apply_federation_resolver_exception_swallowed(tmp_path, monkeypatch):
+    """When the resolver raises, we leave the edge unchanged (single-repo)."""
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+    from better_code_review_graph.resolver import TargetRepo
+
+    repo = tmp_path / "src_repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "src_repo"\nversion = "0.1.0"\ndependencies = ["lib_a"]\n'
+    )
+    py_file = repo / "main.py"
+    py_file.write_text("import lib_a\n")
+
+    other = tmp_path / "other"
+    other.mkdir()
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        rid = registry.add(repo)
+        rid_other = registry.add(other)
+
+        # Force the resolver lookup (lazy import inside _apply_federation)
+        # to raise so the except branch runs.
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("synthetic resolver failure")
+
+        monkeypatch.setattr(
+            "better_code_review_graph.resolver.resolve_cross_repo_imports",
+            boom,
+        )
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(
+            py_file,
+            repo_registry=registry,
+            target_repos=[TargetRepo(repo_id=rid_other, root=other)],
+        )
+
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert imports
+        # Edge target unchanged because resolver raised.
+        assert imports[0].target == "lib_a"
+        assert imports[0].repo_id == rid
+    finally:
+        store.close()
+
+
+def test_apply_federation_target_repos_empty_skips_resolution(tmp_path):
+    """target_repos=[] short-circuits cross-repo resolution path."""
+    from better_code_review_graph.federation import RepoRegistry
+    from better_code_review_graph.graph import GraphStore
+
+    repo = tmp_path / "solo"
+    repo.mkdir()
+    py_file = repo / "x.py"
+    py_file.write_text("import os\n")
+
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    try:
+        registry = RepoRegistry(store)
+        rid = registry.add(repo)
+
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(
+            py_file,
+            repo_registry=registry,
+            target_repos=[],  # explicit empty list
+        )
+        for node in nodes:
+            assert node.repo_id == rid
+        # No edges rewritten.
+        for edge in edges:
+            if edge.kind == "IMPORTS_FROM":
+                assert edge.target == "os"
+    finally:
+        store.close()

--- a/tests/test_repo_id_persistence.py
+++ b/tests/test_repo_id_persistence.py
@@ -1,0 +1,194 @@
+"""Phase 2 Task 9: GraphStore persists repo_id on nodes and edges.
+
+Verifies that ``upsert_node`` / ``upsert_edge`` (and their batched
+counterpart ``store_file_nodes_edges``) write the new ``repo_id``
+column added in alembic revision ``003_federation``. Pre-Phase-2
+NodeInfo/EdgeInfo objects without the ``repo_id`` attribute also need
+to round-trip cleanly (``getattr(..., "repo_id", "")`` fallback).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+def _new_store() -> tuple[GraphStore, Path]:
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    return GraphStore(tmp.name), Path(tmp.name)
+
+
+def test_upsert_node_persists_repo_id() -> None:
+    """``upsert_node`` writes repo_id and round-trips through SQL."""
+    store, db_path = _new_store()
+    try:
+        node = NodeInfo(
+            kind="Function",
+            name="foo",
+            file_path="/x/y.py",
+            line_start=1,
+            line_end=5,
+            language="python",
+            repo_id="my-repo-12345678",
+        )
+        store.upsert_node(node)
+        store.commit()
+
+        row = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+            ("/x/y.py::foo",),
+        ).fetchone()
+        assert row is not None
+        assert row["repo_id"] == "my-repo-12345678"
+    finally:
+        store.close()
+        db_path.unlink(missing_ok=True)
+
+
+def test_upsert_edge_persists_repo_id() -> None:
+    """``upsert_edge`` writes repo_id and round-trips through SQL."""
+    store, db_path = _new_store()
+    try:
+        edge = EdgeInfo(
+            kind="CALLS",
+            source="/x/y.py::a",
+            target="/x/y.py::b",
+            file_path="/x/y.py",
+            line=10,
+            repo_id="my-repo-12345678",
+        )
+        store.upsert_edge(edge)
+        store.commit()
+
+        row = store._conn.execute(
+            "SELECT repo_id FROM edges WHERE source_qualified = ? AND target_qualified = ?",
+            ("/x/y.py::a", "/x/y.py::b"),
+        ).fetchone()
+        assert row is not None
+        assert row["repo_id"] == "my-repo-12345678"
+    finally:
+        store.close()
+        db_path.unlink(missing_ok=True)
+
+
+def test_upsert_node_default_repo_id_is_empty_string() -> None:
+    """Backwards-compat: NodeInfo without explicit repo_id stores ''."""
+    store, db_path = _new_store()
+    try:
+        node = NodeInfo(
+            kind="Function",
+            name="bar",
+            file_path="/p.py",
+            line_start=1,
+            line_end=2,
+            language="python",
+        )
+        store.upsert_node(node)
+        store.commit()
+
+        row = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+            ("/p.py::bar",),
+        ).fetchone()
+        assert row is not None
+        assert row["repo_id"] == ""
+    finally:
+        store.close()
+        db_path.unlink(missing_ok=True)
+
+
+def test_store_file_nodes_edges_persists_repo_id() -> None:
+    """Batched insertion path also writes repo_id for nodes and edges."""
+    store, db_path = _new_store()
+    try:
+        nodes = [
+            NodeInfo(
+                kind="File",
+                name="/x.py",
+                file_path="/x.py",
+                line_start=1,
+                line_end=10,
+                language="python",
+                repo_id="abc-12345678",
+            ),
+            NodeInfo(
+                kind="Function",
+                name="foo",
+                file_path="/x.py",
+                line_start=2,
+                line_end=4,
+                language="python",
+                repo_id="abc-12345678",
+            ),
+        ]
+        edges = [
+            EdgeInfo(
+                kind="CONTAINS",
+                source="/x.py",
+                target="/x.py::foo",
+                file_path="/x.py",
+                line=2,
+                repo_id="abc-12345678",
+            ),
+        ]
+        store.store_file_nodes_edges("/x.py", nodes, edges)
+
+        rows = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE file_path = ?", ("/x.py",)
+        ).fetchall()
+        assert rows
+        for r in rows:
+            assert r["repo_id"] == "abc-12345678"
+
+        edge_rows = store._conn.execute(
+            "SELECT repo_id FROM edges WHERE file_path = ?", ("/x.py",)
+        ).fetchall()
+        assert edge_rows
+        for r in edge_rows:
+            assert r["repo_id"] == "abc-12345678"
+    finally:
+        store.close()
+        db_path.unlink(missing_ok=True)
+
+
+def test_upsert_node_legacy_object_without_repo_id_attr() -> None:
+    """Legacy callers passing a NodeInfo-shaped object lacking ``repo_id`` work.
+
+    The graph layer uses ``getattr(node, "repo_id", "")`` so callers
+    that haven't been updated continue to work without a code change.
+    """
+    store, db_path = _new_store()
+    try:
+        # Build a stand-in object that mimics NodeInfo's surface but
+        # without the repo_id attribute (simulates a pre-Task-9 caller).
+        class LegacyNode:
+            kind = "Function"
+            name = "legacy"
+            file_path = "/legacy.py"
+            line_start = 1
+            line_end = 3
+            language = "python"
+            parent_name = None
+            params = None
+            return_type = None
+            modifiers = None
+            is_test = False
+            extra: dict = {}
+            source_text = None
+
+        store.upsert_node(LegacyNode())  # type: ignore[arg-type]
+        store.commit()
+
+        row = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+            ("/legacy.py::legacy",),
+        ).fetchone()
+        assert row is not None
+        assert row["repo_id"] == ""
+    finally:
+        store.close()
+        db_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- `parser.NodeInfo` and `EdgeInfo` add `repo_id: str = ""` field. Default keeps single-repo callers backwards-compat.
- `parser.parse_file` and `parse_bytes` accept optional `repo_registry` + `target_repos` keyword args. When provided: stamps every NodeInfo with `repo_registry.assign(path)`, then runs `_apply_federation` over IMPORTS_FROM edges → calls `resolve_cross_repo_imports` dispatcher → rewrites `target_qualified` to `<other_repo_id>:<file>::<sym>` on hit; otherwise edge stays single-repo.
- `parser._handle_import_node` now stashes the raw import statement in `extra["import_stmt"]` so resolvers see the imported symbol name (without this, the synthetic `import lib_a.utils` picked `__init__.py` instead of `utils.py`).
- `graph.GraphStore.upsert_node`, `upsert_edge`, `store_file_nodes_edges` persist `repo_id` to the columns added in 003_federation. `getattr(node, "repo_id", "")` fallback keeps pre-Phase-2 NodeInfo callers working.
- `graph._ensure_federation_columns` idempotent backfill mirrors the Phase 1 `_ensure_summary_columns` pattern — handles `:memory:` and pre-alembic DBs without touching frozen `_SCHEMA_SQL`.
- `incremental.incremental_update` accepts optional `repo_registry` kwarg. On success and on no-changes early-return, captures `git rev-parse HEAD` and calls `repo_registry.update_last_indexed_sha`. Non-git directories silently skip.

This is **Phase 2 Task 9 of 12** (epic #325). 9/12 done. Federation now reaches the running pipeline; Tasks 10-12 expose the `repo` query param + docs + smoke.

## Test plan
- [x] 17 new tests across `test_parser.py`, `test_incremental.py`, new `test_repo_id_persistence.py` — all pass.
- [x] Backwards compat: pre-Phase-2 callers untouched (verified by `test_parse_file_without_repo_registry_keeps_repo_id_empty` + `test_upsert_node_legacy_object_without_repo_id_attr`).
- [x] `pytest --cov-fail-under=95 -q` (excluding ONNX env): 870 passed, coverage 95.79%.
- [x] `grep -c "directory" uv.lock`: 0 (committed state — transient pollution reset before push).
- [ ] CI green on this branch.

## Files modified
- `src/better_code_review_graph/parser.py` — repo_id fields + repo_registry/target_repos params + `_apply_federation` helper.
- `src/better_code_review_graph/graph.py` — repo_id persistence in upsert_node/edge + `_ensure_federation_columns` backfill.
- `src/better_code_review_graph/incremental.py` — `repo_registry` kwarg + last_indexed_sha refresh.

## Files created
- `tests/test_repo_id_persistence.py` — 5 round-trip tests for repo_id on nodes/edges.

## Out of scope (later tasks)
- Task 10: `tools.py`/`server.py` cross-cutting `repo` query param.
- Task 11: docs/help update.
- Task 12: smoke against multi-repo fixture.