### PR TITLE
feat: Phase 2 Task 10 — cross-cutting  query param + federated build

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -727,12 +727,20 @@ class GraphStore:
         return [r["file_path"] for r in rows]
 
     def search_nodes(
-        self, query: str, kind: str | None = None, limit: int = 20
+        self,
+        query: str,
+        kind: str | None = None,
+        limit: int = 20,
+        repo: str = "",
     ) -> list[GraphNode]:
         """Keyword search across node names and qualified names.
 
         Multi-word queries require ALL words to match (AND logic).  Each word
         must appear in either the node name or the qualified name.
+
+        Phase 2 Task 10: when ``repo`` is non-empty the result set is
+        scoped to nodes whose ``repo_id`` equals it. Empty ``repo``
+        (default) preserves the legacy unscoped behaviour.
         """
         words = query.lower().split()
         if not words:
@@ -751,16 +759,21 @@ class GraphStore:
                    OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
               AND (? IS NULL OR kind = ?)
+              AND (? = '' OR repo_id = ?)
             ORDER BY name LIMIT ?
             """,
-            [json.dumps(words), json.dumps(words), kind, kind, limit],
+            [json.dumps(words), json.dumps(words), kind, kind, repo, repo, limit],
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
     # --- Impact / Graph traversal ---
 
     def get_impact_radius(
-        self, changed_files: list[str], max_depth: int = 2, max_nodes: int = 500
+        self,
+        changed_files: list[str],
+        max_depth: int = 2,
+        max_nodes: int = 500,
+        repo: str = "",
     ) -> dict[str, Any]:
         """BFS from changed files to find all impacted nodes within depth N.
 
@@ -771,11 +784,31 @@ class GraphStore:
           - edges: connecting edges
           - truncated: True if BFS was stopped early due to max_nodes limit
           - total_impacted: total number of impacted nodes found before truncation
+
+        Phase 2 Task 10: when ``repo`` is non-empty the seed set, BFS
+        frontier, returned nodes, and connecting edges are filtered to
+        the matching ``repo_id``. Empty ``repo`` (default) preserves
+        legacy cross-repo behaviour.
         """
         nxg = self._build_networkx_graph()
 
-        # Seed: all qualified names in changed files (batched to avoid N+1)
-        seeds = {n.qualified_name for n in self.get_nodes_by_files(changed_files)}
+        # Seed: all qualified names in changed files (batched to avoid N+1).
+        # When ``repo`` is set, drop seed nodes that don't belong to it.
+        seed_nodes = self.get_nodes_by_files(changed_files)
+        if repo:
+            seed_nodes = [n for n in seed_nodes if self._node_repo_id(n) == repo]
+        seeds = {n.qualified_name for n in seed_nodes}
+
+        # Pre-compute the set of qualified_names belonging to ``repo`` so
+        # the BFS expansion can prune cross-repo neighbours. Skipped when
+        # ``repo == ""`` to keep the legacy hot path zero-overhead.
+        repo_qns: set[str] | None = None
+        if repo:
+            rows = self._conn.execute(
+                "SELECT qualified_name FROM nodes WHERE repo_id = ?",
+                (repo,),
+            ).fetchall()
+            repo_qns = {r["qualified_name"] for r in rows}
 
         # BFS outward through all edge types
         visited: set[str] = set()
@@ -791,15 +824,21 @@ class GraphStore:
                 # Forward edges (things this node affects)
                 if qn in nxg:
                     for neighbor in nxg.neighbors(qn):
-                        if neighbor not in visited:
-                            next_frontier.add(neighbor)
-                            impacted.add(neighbor)
+                        if neighbor in visited:
+                            continue
+                        if repo_qns is not None and neighbor not in repo_qns:
+                            continue
+                        next_frontier.add(neighbor)
+                        impacted.add(neighbor)
                 # Reverse edges (things that depend on this node)
                 if qn in nxg:
                     for pred in nxg.predecessors(qn):
-                        if pred not in visited:
-                            next_frontier.add(pred)
-                            impacted.add(pred)
+                        if pred in visited:
+                            continue
+                        if repo_qns is not None and pred not in repo_qns:
+                            continue
+                        next_frontier.add(pred)
+                        impacted.add(pred)
             # Cap total nodes to prevent resource exhaustion on dense graphs
             if len(visited) + len(next_frontier) > max_nodes:
                 truncated = True
@@ -813,6 +852,14 @@ class GraphStore:
         # Resolve to full node info using batch fetch to prevent N+1 queries
         changed_nodes = self.get_nodes_by_qualified_names(list(seeds))
         impacted_nodes = self.get_nodes_by_qualified_names(list(impacted - seeds))
+
+        # Defensive re-filter (qualified_name set above is already
+        # repo-scoped, but get_nodes_by_qualified_names is repo-blind).
+        if repo:
+            changed_nodes = [n for n in changed_nodes if self._node_repo_id(n) == repo]
+            impacted_nodes = [
+                n for n in impacted_nodes if self._node_repo_id(n) == repo
+            ]
 
         impacted_files = list({n.file_path for n in impacted_nodes})
 
@@ -830,6 +877,21 @@ class GraphStore:
             "truncated": truncated,
             "total_impacted": total_impacted,
         }
+
+    def _node_repo_id(self, node: GraphNode) -> str:
+        """Look up a GraphNode's persisted ``repo_id`` (column not on dataclass).
+
+        ``GraphNode`` is the public dataclass, frozen at the v1.6 shape;
+        the federation column lives on the SQL row only. This is a
+        cheap fallback used by the repo-filter helpers — single-row
+        lookup keyed by ``id`` so it stays O(1) even on large graphs.
+        """
+        row = self._conn.execute(
+            "SELECT repo_id FROM nodes WHERE id = ?", (node.id,)
+        ).fetchone()
+        if row is None:
+            return ""
+        return row["repo_id"] or ""
 
     def get_subgraph(self, qualified_names: list[str]) -> dict[str, Any]:
         """Extract a subgraph containing the specified nodes and their connecting edges."""
@@ -886,6 +948,7 @@ class GraphStore:
         kind: str | None = None,
         file_path_pattern: str | None = None,
         limit: int = 50,
+        repo: str = "",
     ) -> list[GraphNode]:
         """Find nodes within a line-count range, ordered largest first.
 
@@ -895,6 +958,8 @@ class GraphStore:
             kind: Filter by node kind (Function, Class, File, etc.).
             file_path_pattern: SQL LIKE pattern to filter by file path.
             limit: Maximum results to return.
+            repo: Phase 2 Task 10 — when non-empty, scope to nodes whose
+                ``repo_id`` matches. Empty (default) = no filter.
 
         Returns:
             List of GraphNode objects, ordered by line count descending.
@@ -909,6 +974,7 @@ class GraphStore:
               AND (? IS NULL OR (line_end - line_start + 1) <= ?)
               AND (? IS NULL OR kind = ?)
               AND (? IS NULL OR file_path LIKE '%' || ? || '%')
+              AND (? = '' OR repo_id = ?)
             ORDER BY (line_end - line_start + 1) DESC LIMIT ?
             """,
             [
@@ -919,6 +985,8 @@ class GraphStore:
                 kind,
                 file_path_pattern,
                 file_path_pattern,
+                repo,
+                repo,
                 limit,
             ],
         ).fetchall()

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -98,11 +98,17 @@ def graph(
     format: str = "graphml",
     output_path: str | None = None,
     max_nodes: int = 500,
+    roots: list[str] | None = None,
 ) -> str:
     """Build, update, and manage the code knowledge graph.
 
     Actions (required params -> optional):
-    - build (-> full_rebuild=false, base="HEAD~1", repo_root): Parse source and build graph
+    - build (-> full_rebuild=false, base="HEAD~1", repo_root, roots): Parse source and build graph.
+        ``roots`` (Phase 2 Task 10) optionally federates additional repo
+        directories into the same graph DB; each is registered in the
+        :class:`RepoRegistry` and its files are tagged with the
+        corresponding ``repo_id``. Pair with ``query`` action's ``repo``
+        kwarg to scope subsequent queries.
     - update (-> base="HEAD~1", repo_root): Incremental update (alias for build)
     - stats (-> repo_root): Node/edge counts, languages, embedding status
     - embed (-> repo_root): Compute vector embeddings for semantic search
@@ -118,7 +124,10 @@ def graph(
         case "build":
             return _json(
                 build_or_update_graph(
-                    full_rebuild=full_rebuild, repo_root=repo_root, base=base
+                    full_rebuild=full_rebuild,
+                    repo_root=repo_root,
+                    base=base,
+                    roots=roots,
                 )
             )
         case "update":
@@ -211,16 +220,21 @@ def query(
     context_lines: int = 2,
     # common
     repo_root: str | None = None,
+    # Phase 2 Task 10 — cross-cutting repo filter
+    repo: str = "",
 ) -> str:
     """Query the code knowledge graph for relationships, search, and impact analysis.
 
     Actions (required params -> optional):
-    - query (pattern, target -> repo_root, languages): Predefined graph queries
+    - query (pattern, target -> repo_root, languages, repo): Predefined graph queries
       pattern: callers_of | callees_of | imports_of | importers_of | children_of | tests_for | inheritors_of | file_summary
       languages: filter `tests_for` results to listed languages (D16, fixes #340)
-    - search (search_query -> kind, limit=20, repo_root): Search nodes by name/keyword/vector
-    - impact (-> changed_files, max_depth=2, max_results=500, base="HEAD~1", repo_root): Blast radius analysis
-    - large_functions (-> min_lines=50, kind, file_path_pattern, limit=20, repo_root): Find oversized functions
+      repo: Phase 2 Task 10 — when non-empty, scope to that ``repo_id``
+        (e.g. ``repo='repo_a-aaaaaaaa'``). Default ``""`` queries every
+        federated repo.
+    - search (search_query -> kind, limit=20, repo_root, repo): Search nodes by name/keyword/vector
+    - impact (-> changed_files, max_depth=2, max_results=500, base="HEAD~1", repo_root, repo): Blast radius analysis
+    - large_functions (-> min_lines=50, kind, file_path_pattern, limit=20, repo_root, repo): Find oversized functions
 
     For `query` action with `callers_of`/`callees_of`, the `not_found` response
     includes a `reason` field (`no_such_symbol` | `symbol_not_indexed` |
@@ -253,13 +267,18 @@ def query(
                     target=target,
                     repo_root=repo_root,
                     languages=languages,
+                    repo=repo,
                 )
             )
         case "search":
             if not search_query:
                 return _json({"error": "search_query is required for search action"})
             result = semantic_search_nodes(
-                query=search_query, kind=kind, limit=limit, repo_root=repo_root
+                query=search_query,
+                kind=kind,
+                limit=limit,
+                repo_root=repo_root,
+                repo=repo,
             )
             result = _maybe_include_setup_hint(result)
             return _json(result)
@@ -272,6 +291,7 @@ def query(
                     repo_root=repo_root,
                     base=base,
                     max_payload_bytes=max_payload_bytes,
+                    repo=repo,
                 )
             )
         case "large_functions":
@@ -282,6 +302,7 @@ def query(
                     file_path_pattern=file_path_pattern,
                     limit=limit,
                     repo_root=repo_root,
+                    repo=repo,
                 )
             )
         case "spot_check":
@@ -350,6 +371,7 @@ def review(
     base: str = "HEAD~1",
     repo_root: str | None = None,
     languages: list[str] | None = None,
+    repo: str = "",
 ) -> str:
     """Generate focused review context for code changes.
 
@@ -367,6 +389,10 @@ def review(
             scope the ``untested_functions`` list. Excludes functions whose
             language doesn't match. Fixes false positives on cross-language
             repos (D16, fixes #340).
+        repo: Phase 2 Task 10 — when non-empty, scope the impact subgraph
+            to nodes whose ``repo_id`` matches (e.g.
+            ``repo='repo_a-aaaaaaaa'``). Default ``""`` includes every
+            federated repo.
     """
     return _json(
         get_review_context(
@@ -377,6 +403,7 @@ def review(
             repo_root=repo_root,
             base=base,
             languages=languages,
+            repo=repo,
         )
     )
 

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -12,6 +12,8 @@ Exposes 9 tools:
 9. find_large_functions   - find oversized functions/classes by line count
 """
 
+import hashlib
+import time
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +26,7 @@ from .embeddings import (
 )
 from .graph import GraphStore, edge_to_dict, node_to_dict
 from .incremental import (
+    collect_all_files,
     find_project_root,
     full_build,
     get_changed_files,
@@ -295,6 +298,7 @@ def build_or_update_graph(
     full_rebuild: bool = False,
     repo_root: str | None = None,
     base: str = "HEAD~1",
+    roots: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build or incrementally update the code knowledge graph.
 
@@ -303,12 +307,20 @@ def build_or_update_graph(
                       only re-parse files changed since `base`.
         repo_root: Path to the repository root. Auto-detected if omitted.
         base: Git ref for incremental diff (default: HEAD~1).
+        roots: Phase 2 Task 10 — optional list of additional repo roots
+            to register and parse alongside ``repo_root``. Each entry is
+            registered with :class:`RepoRegistry` and contributes nodes
+            tagged with that repo's ``repo_id``. ``None`` (default) =
+            single-root build using only ``repo_root``.
 
     Returns:
         Summary with files_parsed/updated, node/edge counts, and errors.
     """
     store, root = _get_store(repo_root)
     try:
+        if roots:
+            return _full_build_federated(store, root, [Path(r) for r in roots])
+
         if full_rebuild:
             result = full_build(root, store)
             return {
@@ -362,6 +374,87 @@ def build_or_update_graph(
         store.close()
 
 
+def _full_build_federated(
+    store: GraphStore, primary_root: Path, roots: list[Path]
+) -> dict[str, Any]:
+    """Federated full build over multiple registered roots (Task 10).
+
+    Each entry in ``roots`` is registered with :class:`RepoRegistry` so
+    nodes/edges parsed under it inherit the matching ``repo_id``. The
+    primary ``repo_root`` (the one whose ``.code-review-graph`` dir backs
+    the DB) is registered too so its files don't fall outside every
+    root and lose their ``repo_id``.
+    """
+    from .federation import RepoRegistry
+    from .parser import CodeParser
+
+    registry = RepoRegistry(store)
+    # Register primary first so it's always present, then each extra
+    # root supplied by the caller. ``add`` is idempotent on re-add.
+    registry.add(primary_root)
+    for r in roots:
+        registry.add(r)
+
+    parser = CodeParser()
+    total_files = 0
+    total_nodes = 0
+    total_edges = 0
+    errors: list[dict[str, Any]] = []
+
+    visited_files: set[Path] = set()
+    for r in [primary_root, *roots]:
+        r_resolved = r.resolve()
+        try:
+            files = collect_all_files(r)
+        except Exception as e:
+            errors.append({"root": str(r), "error": str(e)})
+            continue
+        for rel_path in files:
+            full_path = (r / rel_path).resolve()
+            if not full_path.is_relative_to(r_resolved):
+                continue
+            if full_path in visited_files:
+                # A child root inside the primary would otherwise be
+                # parsed twice; the registry's longest-match-wins means
+                # the child wins for assign(), so we skip on the second
+                # encounter.
+                continue
+            visited_files.add(full_path)
+            try:
+                source = full_path.read_bytes()
+                fhash = hashlib.sha256(source).hexdigest()
+                nodes, edges = parser.parse_bytes(
+                    full_path, source, repo_registry=registry
+                )
+                store.store_file_nodes_edges(str(full_path), nodes, edges, fhash)
+                total_nodes += len(nodes)
+                total_edges += len(edges)
+                total_files += 1
+            except (OSError, PermissionError) as e:
+                errors.append({"file": str(full_path), "error": str(e)})
+            except Exception as e:
+                errors.append({"file": str(full_path), "error": str(e)})
+
+    store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
+    store.set_metadata("last_build_type", "full_federated")
+    store.commit()
+
+    return {
+        "status": "ok",
+        "build_type": "full_federated",
+        "summary": (
+            f"Federated build over {len(roots) + 1} root(s): parsed "
+            f"{total_files} files, created {total_nodes} nodes and "
+            f"{total_edges} edges."
+        ),
+        "files_parsed": total_files,
+        "total_nodes": total_nodes,
+        "total_edges": total_edges,
+        "roots": [str(r) for r in [primary_root, *roots]],
+        "errors": errors,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tool 2: get_impact_radius
 # ---------------------------------------------------------------------------
@@ -387,6 +480,7 @@ def get_impact_radius(
     repo_root: str | None = None,
     base: str = "HEAD~1",
     max_payload_bytes: int = _DEFAULT_IMPACT_PAYLOAD_BYTES,
+    repo: str = "",
 ) -> dict[str, Any]:
     """Analyze the blast radius of changed files.
 
@@ -403,6 +497,9 @@ def get_impact_radius(
             arrays are truncated and ``results_truncated=True`` is set on
             the response with a hint suggesting ``max_depth=1`` or a
             narrower file scope. (#315.)
+        repo: Phase 2 Task 10 — when non-empty, scope the BFS to nodes
+            belonging to the given ``repo_id``. Empty (default) =
+            traverse across every federated repo.
 
     Returns:
         Changed nodes, impacted nodes, impacted files, connecting edges,
@@ -439,7 +536,7 @@ def get_impact_radius(
             abs_files.append(str(full_path))
 
         result = store.get_impact_radius(
-            abs_files, max_depth=max_depth, max_nodes=max_results
+            abs_files, max_depth=max_depth, max_nodes=max_results, repo=repo
         )
 
         changed_dicts = [node_to_dict(n) for n in result["changed_nodes"]]
@@ -574,9 +671,10 @@ def _resolve_search_candidates(
     target: str,
     pattern: str,
     original_target: str,
+    repo: str = "",
 ) -> tuple[Any | None, str, dict[str, Any] | None, list[str]]:
     """Search for nodes by name and handle ambiguity/promotion."""
-    candidates = store.search_nodes(target, limit=5)
+    candidates = store.search_nodes(target, limit=5, repo=repo)
     promoted_indexed_under: list[str] = []
 
     # #316: when the pattern is call-graph oriented and the only ambiguity
@@ -688,6 +786,7 @@ def _resolve_query_target(
     root: Any,
     target: str,
     pattern: str,
+    repo: str = "",
 ) -> tuple[Any | None, str, dict[str, Any] | None]:
     """Resolve the query target to a node or path.
 
@@ -698,12 +797,22 @@ def _resolve_query_target(
 
     # 1. Direct lookup (qualified name or absolute path)
     node = _lookup_node_directly(store, root, target)
+    # Phase 2 Task 10: drop direct hits that don't belong to the
+    # requested repo so the search-by-name fallback below can pick a
+    # repo-scoped candidate instead of returning the cross-repo match.
+    if node is not None and repo:
+        row = store._conn.execute(
+            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+            (node.qualified_name,),
+        ).fetchone()
+        if row is None or (row["repo_id"] or "") != repo:
+            node = None
 
     # 2. Search by name if not found directly
     promoted_indexed_under: list[str] = []
     if not node:
         node, target, error_resp, promoted_indexed_under = _resolve_search_candidates(
-            store, target, pattern, original_target
+            store, target, pattern, original_target, repo=repo
         )
         if error_resp:
             return None, target, error_resp
@@ -968,6 +1077,7 @@ def query_graph(
     target: str,
     repo_root: str | None = None,
     languages: list[str] | None = None,
+    repo: str = "",
 ) -> dict[str, Any]:
     """Run a predefined graph query.
 
@@ -980,6 +1090,10 @@ def query_graph(
             applies to ``tests_for`` (filters returned test nodes by language).
             Allowed values: python, typescript, javascript, go, rust, java,
             csharp, ruby, kotlin, swift, php, c, cpp, solidity.
+        repo: Phase 2 Task 10 — when non-empty, restrict the result set
+            to nodes whose ``repo_id`` matches. Default ``""`` searches
+            across every registered repo (legacy behaviour). Used to
+            disambiguate same-named symbols across federated repos.
 
     Returns:
         Matching nodes and edges for the query.
@@ -1022,7 +1136,7 @@ def query_graph(
             }
 
         node, resolved_qn_or_path, error_resp = _resolve_query_target(
-            store, root, target, pattern
+            store, root, target, pattern, repo=repo
         )
         if error_resp:
             return error_resp
@@ -1047,6 +1161,39 @@ def query_graph(
         # D16: filter tests_for results by language if requested.
         if pattern == "tests_for" and languages is not None:
             results = [r for r in results if r.get("language") in languages]
+
+        # Phase 2 Task 10: post-filter results + edges to the requested
+        # repo. The handlers (callers_of/callees_of/etc.) ride on
+        # qualified-name lookups that don't carry repo_id, so the
+        # narrowing happens here against the ``repo_id`` column on the
+        # nodes table. Edges are scoped indirectly: only edges whose
+        # source AND target survive the node filter remain.
+        if repo:
+            kept_qns: set[str] = set()
+            filtered_results = []
+            for r in results:
+                qn = r.get("qualified_name")
+                if qn is None:
+                    # importers_of / imports_of dicts use ``importer`` /
+                    # ``import_target`` keys instead of ``qualified_name``.
+                    # Fall back to the most likely qualified field.
+                    qn = r.get("importer") or r.get("import_target")
+                if qn is None:
+                    filtered_results.append(r)
+                    continue
+                row = store._conn.execute(
+                    "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+                    (qn,),
+                ).fetchone()
+                if row is not None and (row["repo_id"] or "") == repo:
+                    kept_qns.add(qn)
+                    filtered_results.append(r)
+            results = filtered_results
+            edges_out = [
+                e
+                for e in edges_out
+                if e.get("source") in kept_qns or e.get("target") in kept_qns
+            ]
 
         response: dict[str, Any] = {
             "status": "ok",
@@ -1469,6 +1616,7 @@ def get_review_context(
     repo_root: str | None = None,
     base: str = "HEAD~1",
     languages: list[str] | None = None,
+    repo: str = "",
 ) -> dict[str, Any]:
     """Generate a focused review context from changed files.
 
@@ -1487,6 +1635,9 @@ def get_review_context(
             re-derived from the filtered list. Allowed values: python,
             typescript, javascript, go, rust, java, csharp, ruby, kotlin,
             swift, php, c, cpp, solidity. (D16, fixes #340.)
+        repo: Phase 2 Task 10 — when non-empty, scope the impact subgraph
+            to nodes whose ``repo_id`` matches. Empty (default) leaves
+            the cross-repo behaviour unchanged.
 
     Returns:
         Structured review context with subgraph, source snippets, and review guidance.
@@ -1510,7 +1661,7 @@ def get_review_context(
             }
 
         abs_files = _filter_valid_paths(root, changed_files)
-        impact = store.get_impact_radius(abs_files, max_depth=max_depth)
+        impact = store.get_impact_radius(abs_files, max_depth=max_depth, repo=repo)
 
         untested_functions = _compute_untested_functions(impact, languages=languages)
 
@@ -1681,6 +1832,7 @@ def semantic_search_nodes(
     kind: str | None = None,
     limit: int = 20,
     repo_root: str | None = None,
+    repo: str = "",
 ) -> dict[str, Any]:
     """Search for nodes by name, keyword, or semantic similarity.
 
@@ -1693,6 +1845,9 @@ def semantic_search_nodes(
         kind: Optional filter by node kind (File, Class, Function, Type, Test).
         limit: Maximum results to return (default: 20).
         repo_root: Repository root path. Auto-detected if omitted.
+        repo: Phase 2 Task 10 — when non-empty, scope to nodes whose
+            ``repo_id`` matches. Default ``""`` searches across every
+            registered repo.
 
     Returns:
         Ranked list of matching nodes.
@@ -1717,6 +1872,21 @@ def semantic_search_nodes(
                 raw = semantic_search(query, store, emb_store, limit=limit * 2)
                 if kind:
                     raw = [r for r in raw if r.get("kind") == kind]
+                if repo:
+                    # The vector store has no repo_id column; cross-check
+                    # each hit against the SQL row and drop misses.
+                    filtered = []
+                    for r in raw:
+                        qn = r.get("qualified_name")
+                        if qn is None:
+                            continue
+                        row = store._conn.execute(
+                            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
+                            (qn,),
+                        ).fetchone()
+                        if row is not None and (row["repo_id"] or "") == repo:
+                            filtered.append(r)
+                    raw = filtered
                 raw = raw[:limit]
                 return {
                     "status": "ok",
@@ -1733,7 +1903,7 @@ def semantic_search_nodes(
             emb_store.close()
 
         # Keyword fallback
-        results = store.search_nodes(query, limit=limit * 2)
+        results = store.search_nodes(query, limit=limit * 2, repo=repo)
 
         if kind:
             results = [r for r in results if r.kind == kind]
@@ -2066,6 +2236,7 @@ def find_large_functions(
     file_path_pattern: str | None = None,
     limit: int = 50,
     repo_root: str | None = None,
+    repo: str = "",
 ) -> dict[str, Any]:
     """Find functions, classes, or files exceeding a line-count threshold.
 
@@ -2078,6 +2249,9 @@ def find_large_functions(
         file_path_pattern: Filter by file path substring (e.g. "components/").
         limit: Maximum results (default: 50).
         repo_root: Repository root path. Auto-detected if omitted.
+        repo: Phase 2 Task 10 — when non-empty, scope to nodes whose
+            ``repo_id`` matches. Default ``""`` returns large nodes
+            across every federated repo.
 
     Returns:
         Oversized nodes with line counts, ordered largest first.
@@ -2089,6 +2263,7 @@ def find_large_functions(
             kind=kind,
             file_path_pattern=file_path_pattern,
             limit=limit,
+            repo=repo,
         )
 
         results = []

--- a/tests/test_repo_filter.py
+++ b/tests/test_repo_filter.py
@@ -1,0 +1,417 @@
+"""Phase 2 Task 10: cross-cutting ``repo`` query parameter.
+
+Verifies that query/review tools accept a ``repo: str = ""`` kwarg that
+filters results to the matching ``repo_id``. Default ``""`` returns
+results across all repos (backwards-compatible).
+
+Also covers the federated ``build_or_update_graph(roots=[...])`` path
+that registers each root in the :class:`RepoRegistry` and parses files
+under each, plus the legacy single-root path that must continue to work
+unchanged when ``roots`` is omitted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from better_code_review_graph.federation import RepoRegistry
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+from better_code_review_graph.tools import (
+    build_or_update_graph,
+    get_impact_radius,
+    get_review_context,
+    query_graph,
+    semantic_search_nodes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_two_repo_graph(store: GraphStore, repo_a_dir: Path, repo_b_dir: Path) -> None:
+    """Seed a graph with two repos: repo_a and repo_b.
+
+    Each has one File + one Function with the bare name ``retry`` (so a
+    keyword search for "retry" hits both, and the ``repo`` filter is what
+    discriminates).
+    """
+    repo_a_id = "repo_a-aaaaaaaa"
+    repo_b_id = "repo_b-bbbbbbbb"
+
+    file_a = str(repo_a_dir / "a.py")
+    file_b = str(repo_b_dir / "b.py")
+
+    store.upsert_node(
+        NodeInfo(
+            kind="File",
+            name=file_a,
+            file_path=file_a,
+            line_start=1,
+            line_end=5,
+            language="python",
+            repo_id=repo_a_id,
+        )
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="retry",
+            file_path=file_a,
+            line_start=1,
+            line_end=3,
+            language="python",
+            repo_id=repo_a_id,
+        )
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="File",
+            name=file_b,
+            file_path=file_b,
+            line_start=1,
+            line_end=5,
+            language="python",
+            repo_id=repo_b_id,
+        )
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="retry",
+            file_path=file_b,
+            line_start=1,
+            line_end=3,
+            language="python",
+            repo_id=repo_b_id,
+        )
+    )
+    # CALLS edge inside repo_a so impact radius has something to traverse.
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="caller_a",
+            file_path=file_a,
+            line_start=4,
+            line_end=5,
+            language="python",
+            repo_id=repo_a_id,
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS",
+            source=f"{file_a}::caller_a",
+            target=f"{file_a}::retry",
+            file_path=file_a,
+            line=4,
+            repo_id=repo_a_id,
+        )
+    )
+    # CALLS edge inside repo_b.
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="caller_b",
+            file_path=file_b,
+            line_start=4,
+            line_end=5,
+            language="python",
+            repo_id=repo_b_id,
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS",
+            source=f"{file_b}::caller_b",
+            target=f"{file_b}::retry",
+            file_path=file_b,
+            line=4,
+            repo_id=repo_b_id,
+        )
+    )
+    store.commit()
+
+
+@pytest.fixture
+def two_repo_setup(tmp_path: Path) -> Iterator[dict[str, Any]]:
+    """Build a workspace with two fake repo dirs + seeded graph DB.
+
+    Returns a dict of ``{workspace, repo_a_dir, repo_b_dir, store, db_path,
+    repo_a_id, repo_b_id}`` for tests to consume. Each repo dir gets a
+    fake ``.git`` so ``_validate_repo_root`` accepts it as a project
+    root.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+    crg_dir = workspace / ".code-review-graph"
+    crg_dir.mkdir()
+    (crg_dir / ".gitignore").write_text("*\n")
+
+    repo_a_dir = workspace / "repo_a"
+    repo_a_dir.mkdir()
+    repo_b_dir = workspace / "repo_b"
+    repo_b_dir.mkdir()
+
+    db_path = crg_dir / "graph.db"
+    store = GraphStore(str(db_path))
+    _seed_two_repo_graph(store, repo_a_dir, repo_b_dir)
+
+    yield {
+        "workspace": workspace,
+        "repo_a_dir": repo_a_dir,
+        "repo_b_dir": repo_b_dir,
+        "store": store,
+        "db_path": db_path,
+        "repo_a_id": "repo_a-aaaaaaaa",
+        "repo_b_id": "repo_b-bbbbbbbb",
+    }
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# 1+2: query_graph repo filter on/off
+# ---------------------------------------------------------------------------
+
+
+def test_query_graph_repo_filter_returns_only_matching(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """``query_graph(... repo='repo_a-...')`` returns only repo_a callers."""
+    workspace = two_repo_setup["workspace"]
+    repo_a_id = two_repo_setup["repo_a_id"]
+
+    result = query_graph(
+        pattern="callers_of",
+        target="retry",
+        repo_root=str(workspace),
+        repo=repo_a_id,
+    )
+
+    assert result["status"] == "ok", result
+    assert result["results"], "expected at least one caller in repo_a"
+    for n in result["results"]:
+        # caller_a is in repo_a/a.py; caller_b is in repo_b/b.py.
+        assert "/repo_a/" in n["file_path"] or "\\repo_a\\" in n["file_path"], n
+
+
+def test_query_graph_default_returns_all_repos(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """No ``repo`` kwarg -> nodes from both repos visible via search.
+
+    Uses semantic_search_nodes (no kind/repo filter) since ``callers_of``
+    on a name shared across repos triggers the ambiguity heuristic
+    instead of returning a flat list. Validates that the default
+    behaviour ``repo == ""`` does not silently scope to a single repo.
+    """
+    workspace = two_repo_setup["workspace"]
+
+    result = semantic_search_nodes(
+        query="retry",
+        repo_root=str(workspace),
+    )
+
+    assert result["status"] == "ok", result
+    file_paths = {n["file_path"] for n in result["results"]}
+    has_a = any("repo_a" in fp for fp in file_paths)
+    has_b = any("repo_b" in fp for fp in file_paths)
+    assert has_a and has_b, (
+        f"expected matches from both repos; got file_paths={file_paths}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3: get_impact_radius repo filter
+# ---------------------------------------------------------------------------
+
+
+def test_get_impact_radius_repo_filter(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """``get_impact_radius(... repo='repo_a-...')`` only returns repo_a nodes."""
+    workspace = two_repo_setup["workspace"]
+    repo_a_id = two_repo_setup["repo_a_id"]
+    repo_a_dir = two_repo_setup["repo_a_dir"]
+
+    # Pass changed_files explicitly so we don't need a real git diff.
+    result = get_impact_radius(
+        changed_files=[str(repo_a_dir / "a.py")],
+        repo_root=str(workspace),
+        repo=repo_a_id,
+    )
+
+    assert result["status"] == "ok", result
+    # Every node in changed_nodes + impacted_nodes must live under repo_a.
+    for node in result["changed_nodes"] + result["impacted_nodes"]:
+        fp = node.get("file_path", "")
+        assert "repo_a" in fp, f"unexpected repo in impact result: {fp!r}"
+        assert "repo_b" not in fp, f"repo_b leaked into repo_a-filter: {fp!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4: semantic_search_nodes repo filter (keyword fallback path)
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_search_nodes_repo_filter(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """``semantic_search_nodes`` filtered to repo_a returns repo_a only.
+
+    The fixture has no embeddings so this exercises the keyword-fallback
+    code path; both paths must honour the ``repo`` filter.
+    """
+    workspace = two_repo_setup["workspace"]
+    repo_a_id = two_repo_setup["repo_a_id"]
+
+    result = semantic_search_nodes(
+        query="retry",
+        repo_root=str(workspace),
+        repo=repo_a_id,
+    )
+
+    assert result["status"] == "ok", result
+    assert result["results"], "expected at least one match"
+    for n in result["results"]:
+        assert "repo_a" in n["file_path"], n
+
+
+# ---------------------------------------------------------------------------
+# 5: get_review_context repo filter
+# ---------------------------------------------------------------------------
+
+
+def test_get_review_context_repo_filter(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """``get_review_context(... repo='repo_a-...')`` scopes subgraph to repo_a."""
+    workspace = two_repo_setup["workspace"]
+    repo_a_id = two_repo_setup["repo_a_id"]
+    repo_a_dir = two_repo_setup["repo_a_dir"]
+
+    # Simulate a changed file in repo_a.
+    (repo_a_dir / "a.py").write_text("def retry():\n    pass\n")
+    result = get_review_context(
+        changed_files=[str(repo_a_dir / "a.py")],
+        include_source=False,
+        repo_root=str(workspace),
+        repo=repo_a_id,
+    )
+
+    assert result["status"] == "ok", result
+    ctx = result["context"]
+    # Subgraph nodes must all be in repo_a.
+    for node in ctx["graph"]["changed_nodes"] + ctx["graph"]["impacted_nodes"]:
+        fp = node.get("file_path", "")
+        assert "repo_b" not in fp, f"repo_b leaked into review context: {fp!r}"
+
+
+# ---------------------------------------------------------------------------
+# 6+7: build_or_update_graph(roots=...) and single-root backwards compat
+# ---------------------------------------------------------------------------
+
+
+def _make_real_repo(parent: Path, name: str) -> Path:
+    """Create a real-looking repo dir with .git and a small Python file."""
+    repo = parent / name
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    py = repo / "main.py"
+    py.write_text("def retry():\n    return 1\n")
+    return repo
+
+
+def test_build_or_update_graph_with_multiple_roots(tmp_path: Path) -> None:
+    """``roots=[a, b]`` registers both in RepoRegistry and parses both."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+    (workspace / ".code-review-graph").mkdir()
+
+    repo_a = _make_real_repo(workspace, "repo_a")
+    repo_b = _make_real_repo(workspace, "repo_b")
+
+    result = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(workspace),
+        roots=[str(repo_a), str(repo_b)],
+    )
+
+    assert result["status"] == "ok", result
+
+    # Verify the registry has both repos.
+    db_path = workspace / ".code-review-graph" / "graph.db"
+    store = GraphStore(str(db_path))
+    try:
+        registry = RepoRegistry(store)
+        repo_paths = {entry.path.resolve() for entry in registry.entries()}
+        assert repo_a.resolve() in repo_paths, repo_paths
+        assert repo_b.resolve() in repo_paths, repo_paths
+        assert len(repo_paths) >= 2, f"expected >=2 repos, got {repo_paths}"
+
+        # Verify nodes from both repos exist with non-empty repo_id.
+        rows = store._conn.execute(
+            "SELECT DISTINCT repo_id FROM nodes WHERE repo_id != ''"
+        ).fetchall()
+        repo_ids = {r["repo_id"] for r in rows}
+        assert len(repo_ids) >= 2, (
+            f"expected nodes tagged with >=2 distinct repo_ids, got {repo_ids}"
+        )
+    finally:
+        store.close()
+
+
+def test_query_graph_repo_filter_drops_cross_repo_direct_hit(
+    two_repo_setup: dict[str, Any],
+) -> None:
+    """Direct qualified-name lookup that hits a cross-repo node falls back.
+
+    Pass the qualified name of repo_b's ``retry`` while filtering to
+    repo_a. The direct-lookup branch in ``_resolve_query_target`` must
+    discard the cross-repo match and let the search-by-name fallback
+    pick repo_a's ``retry`` instead — exercising the repo guard at
+    L803-809 in tools.py.
+    """
+    workspace = two_repo_setup["workspace"]
+    repo_a_id = two_repo_setup["repo_a_id"]
+    repo_b_dir = two_repo_setup["repo_b_dir"]
+
+    cross_repo_qn = f"{repo_b_dir / 'b.py'}::retry"
+    result = query_graph(
+        pattern="callers_of",
+        target=cross_repo_qn,
+        repo_root=str(workspace),
+        repo=repo_a_id,
+    )
+
+    # Either the resolver finds repo_a's retry via name fallback, or
+    # returns not_found. Either way, no repo_b node may surface in the
+    # result — that's the invariant the guard protects.
+    if result["status"] == "ok":
+        for n in result["results"]:
+            assert "repo_b" not in n.get("file_path", ""), n
+
+
+def test_build_or_update_graph_single_root_backwards_compat(tmp_path: Path) -> None:
+    """Legacy single-root call (no ``roots`` kwarg) works unchanged."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+    (workspace / ".code-review-graph").mkdir()
+    (workspace / "main.py").write_text("def retry():\n    return 1\n")
+
+    result = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(workspace),
+    )
+
+    assert result["status"] == "ok", result
+    assert result.get("build_type") == "full"
+    assert result.get("files_parsed", 0) >= 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,7 +57,7 @@ class TestGraphTool:
         mock_fn.return_value = {"status": "ok", "build_type": "full"}
         result = json.loads(graph(action="build", full_rebuild=True, repo_root="/test"))
         mock_fn.assert_called_once_with(
-            full_rebuild=True, repo_root="/test", base="HEAD~1"
+            full_rebuild=True, repo_root="/test", base="HEAD~1", roots=None
         )
         assert result["status"] == "ok"
 
@@ -103,7 +103,11 @@ class TestQueryTool:
             query(action="query", pattern="callers_of", target="foo", repo_root="/test")
         )
         mock_fn.assert_called_once_with(
-            pattern="callers_of", target="foo", repo_root="/test", languages=None
+            pattern="callers_of",
+            target="foo",
+            repo_root="/test",
+            languages=None,
+            repo="",
         )
         assert result["status"] == "ok"
 
@@ -130,7 +134,7 @@ class TestQueryTool:
             )
         )
         mock_fn.assert_called_once_with(
-            query="auth", kind="Class", limit=5, repo_root="/test"
+            query="auth", kind="Class", limit=5, repo_root="/test", repo=""
         )
         assert result["status"] == "ok"
 
@@ -159,6 +163,7 @@ class TestQueryTool:
             repo_root="/test",
             base="HEAD~3",
             max_payload_bytes=500_000,
+            repo="",
         )
         assert result["status"] == "ok"
 
@@ -181,6 +186,7 @@ class TestQueryTool:
             file_path_pattern="src/",
             limit=10,
             repo_root="/test",
+            repo="",
         )
         assert result["status"] == "ok"
 
@@ -217,6 +223,7 @@ class TestReviewTool:
             repo_root="/test",
             base="main",
             languages=None,
+            repo="",
         )
         assert result["status"] == "ok"
 
@@ -232,6 +239,7 @@ class TestReviewTool:
             repo_root=None,
             base="HEAD~1",
             languages=None,
+            repo="",
         )
         assert result["status"] == "ok"
 


### PR DESCRIPTION
## Summary
- `query_graph`, `get_impact_radius`, `semantic_search_nodes`, `get_review_context`, `find_large_functions` accept `repo: str = ""` kwarg. Default `""` = no filter (all repos).
- Underlying `GraphStore.search_nodes`, `get_impact_radius`, `get_nodes_by_size` gain `repo` kwarg with WHERE-clause filter.
- New `tools.build_or_update_graph(roots: list[str] | None = None, ...)` for federated multi-repo build. Single-root callers unchanged (default `roots=None`).
- New `_full_build_federated` walks all registered roots in one pass with shared visited-files guard — handles nested repos gracefully.
- `server.py` MCP tool signatures expose `repo` (query/review) + `roots` (graph build action).
- New private `_node_repo_id(node_id)` helper — keeps `GraphNode` dataclass shape stable, federation column lookup on demand.

This is **Phase 2 Task 10 of 12** (epic #325). 10/12 done. Federation now reaches the public MCP API surface.

## Test plan
- [x] New `tests/test_repo_filter.py`: 8/8 pass (7 spec behaviors + 1 extra cross-repo direct-hit guard).
- [x] `pytest --cov-fail-under=95 -q`: 1024 passed, 1 skipped, coverage 95.19%.
- [x] Existing `tests/test_server.py` updated for new kwargs (`repo=""`, `roots=None`).
- [x] `grep -c "directory" uv.lock`: 0 (committed state).
- [ ] CI green.

## Files modified
- `src/better_code_review_graph/graph.py` — repo kwarg on search/impact/large_functions + `_node_repo_id` helper.
- `src/better_code_review_graph/tools.py` — repo kwarg on 5 query/review tools + roots kwarg on build_or_update_graph + `_full_build_federated` helper.
- `src/better_code_review_graph/server.py` — MCP signature updates.
- `tests/test_server.py` — updated 7 strict-match assertions for new kwargs.

## Files created
- `tests/test_repo_filter.py` — 8 tests covering single/multi-repo build + repo filter on each query tool.

## Out of scope (later tasks)
- Task 11: docs/help update.
- Task 12: smoke against multi-repo fixture.