### PR TITLE
fix: Phase 2 Task 11 — document cross-repo federation in help topics

### DIFF
--- a/src/better_code_review_graph/docs/graph.md
+++ b/src/better_code_review_graph/docs/graph.md
@@ -11,11 +11,13 @@ Full or incremental graph build. Parses source files with Tree-sitter, extracts 
 - `full_rebuild`: Re-parse all files (default: false, incremental)
 - `base`: Git ref for incremental diff (default: HEAD~1)
 - `repo_root`: Repository root path (auto-detected)
+- `roots`: Optional list of additional repo roots for federated build (Phase 2). When provided, runs a full federated rebuild over `repo_root` plus every entry in `roots`. Each root is registered in the `repos` table with a stable `repo_id` derived from its path. Omit (default `null`) for a single-repo build that preserves the legacy behaviour. See "Federation: cross-repo graphs" below for the full recipe.
 
 **Example:**
 ```json
 {"action": "build", "full_rebuild": true}
 {"action": "build", "base": "main"}
+{"action": "build", "roots": ["../shared-lib", "../web-app"]}
 ```
 
 ---
@@ -127,6 +129,81 @@ graph(action="summarize", max_nodes=200)
 
 **When to re-run:** after `graph(action="update")` brings new functions in, or after large refactors where many `source_hash` values change. Edits to existing function bodies invalidate their cached summary automatically -- the next `summarize` call regenerates only the changed nodes.
 
+## Federation: cross-repo graphs (Phase 2 v1.7+)
+
+A single graph DB can index multiple repository roots and resolve imports between them. Pass a `roots` list to `graph(action="build")` and each root is registered in the `repos` registry table with a stable `repo_id`. Subsequent `query` and `review` actions accept a `repo='<repo_id>'` filter to scope results to one federated repo (see `query.md` / `review.md`).
+
+**`repo_id` derivation:** `<basename>-<sha256-prefix-8>` of the absolute, resolved path. Filesystem-root basenames (`/`, `C:\`) normalise to `root-<hash>`. The id is deterministic across machines for the same absolute path -- pass the same `roots` list and you get the same ids. Empty / `.` / `..` basenames also normalise to `root`.
+
+**Single-repo backwards compat:** Omitting `roots` (or passing `roots=[]` / `null`) runs the existing single-root build path. Existing graphs created before Phase 2 keep working; the migration adds a `repo_id` column with a NULL default and a `repos` table without forcing a re-build. Federation is purely opt-in.
+
+**Cross-repo edges:** When the parser resolves an `IMPORTS_FROM` edge whose target lives in a different registered repo, the edge's `target_qualified` is written as `<other_repo_id>:<file>::<symbol>` (note the leading `<repo_id>:` prefix -- single-repo edges keep the legacy `<file>::<symbol>` shape). Per-language resolvers cover Python, TypeScript, Go, Rust, and Java; remaining tier-2 languages fall back to a generic dispatcher that performs basename matching against registered roots.
+
+**`last_indexed_sha`:** `graph(action="update")` records the current git HEAD per repo into `repos.last_indexed_sha` when git is available, so federated incremental updates can later diff per-root against the last indexed commit.
+
+### Recipe 1 -- Federated multi-repo Python build
+
+Two Python repos that import each other; build them into one graph and query a single repo.
+
+```json
+{"tool": "graph", "action": "build",
+ "repo_root": "./repo_a",
+ "roots": ["./repo_b"]}
+```
+
+Response (abridged):
+```json
+{
+  "status": "ok",
+  "build_type": "full_federated",
+  "summary": "Federated build over 2 root(s): parsed 87 files, created 612 nodes and 941 edges.",
+  "files_parsed": 87,
+  "total_nodes": 612,
+  "total_edges": 941,
+  "roots": ["/abs/path/repo_a", "/abs/path/repo_b"]
+}
+```
+
+The derived `repo_id`s for these roots will look like `repo_a-3f2a91bc` / `repo_b-1d4e87aa`. Inspect `repos` in the SQLite DB (or capture them from `RepoRegistry.entries()` if you embed the library) to copy-paste them into a scoped query:
+
+```json
+{"tool": "query", "action": "query",
+ "pattern": "callers_of",
+ "target": "src/auth.py::authenticate",
+ "repo": "repo_a-3f2a91bc"}
+```
+
+Only callers whose nodes belong to `repo_a` are returned -- callers in `repo_b` are filtered out, even if `repo_b` imports `authenticate`.
+
+### Recipe 2 -- Cross-language federation (Python lib + TypeScript app)
+
+A Python library + a TypeScript app that consumes its compiled artefacts. Each language's per-language resolver runs first; the dispatcher falls back to basename matching for any tier-2 file under either root.
+
+```json
+{"tool": "graph", "action": "build",
+ "repo_root": "./py-core",
+ "roots": ["./ts-app"]}
+```
+
+After build, an import in `ts-app/src/api.ts` that resolves to a Python symbol in `py-core/src/core/auth.py::authenticate` materialises an `IMPORTS_FROM` edge whose `target_qualified` reads:
+
+```
+py_core-9a8b7c6d:src/core/auth.py::authenticate
+```
+
+Use the cross-repo qualified name to walk back across the boundary:
+
+```json
+{"tool": "query", "action": "query",
+ "pattern": "importers_of",
+ "target": "src/core/auth.py::authenticate",
+ "repo": "py_core-9a8b7c6d"}
+```
+
+Importers in both repos appear, and each result row carries its own `repo_id` so you can tell which side the call lives on. Drop the `repo` filter to see every importer regardless of repo, including the TypeScript ones.
+
+---
+
 ## Supported Languages
 
 Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
@@ -136,4 +213,4 @@ Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/
 **Node types:** File, Class, Function, Type, Test
 **Edge types:** CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON
 
-Qualified names use `file_path::name` format (e.g. `src/auth.py::authenticate`).
+Qualified names use `file_path::name` format (e.g. `src/auth.py::authenticate`). Cross-repo edges produced by federation prefix the target with the owning `repo_id`: `<repo_id>:<file_path>::<symbol>` (see "Federation: cross-repo graphs" above).

--- a/src/better_code_review_graph/docs/query.md
+++ b/src/better_code_review_graph/docs/query.md
@@ -19,12 +19,14 @@ Run predefined graph queries to explore code relationships.
   - `file_summary`: Get all nodes in a file
 - `target` (required): Node name, qualified name, or file path
 - `repo_root`: Repository root path (auto-detected)
+- `repo`: Federated repo filter (Phase 2). When non-empty, restricts results to nodes whose `repo_id` matches. Default `""` queries every registered repo (legacy behaviour). Useful to disambiguate same-named symbols across federated repos. Discover available `repo_id`s by inspecting the `repos` table in the graph DB after a federated `graph(action="build", roots=[...])`; see `graph.md` "Federation: cross-repo graphs" for the derivation rule.
 
 **Example:**
 ```json
 {"action": "query", "pattern": "callers_of", "target": "authenticate"}
 {"action": "query", "pattern": "file_summary", "target": "src/auth.py"}
 {"action": "query", "pattern": "tests_for", "target": "UserService"}
+{"action": "query", "pattern": "callers_of", "target": "authenticate", "repo": "repo_a-3f2a91bc"}
 ```
 
 Multi-word search uses AND-logic: `"firebase auth"` matches nodes containing both words.
@@ -40,6 +42,7 @@ Search for code entities by name, keyword, or semantic similarity.
 - `kind`: Filter by node type: File, Class, Function, Type, or Test
 - `limit`: Maximum results (default: 20)
 - `repo_root`: Repository root path (auto-detected)
+- `repo`: Federated repo filter (Phase 2). When non-empty, restricts results to nodes whose `repo_id` matches. Default `""` searches across every registered repo. Vector hits are cross-checked against the SQL `repo_id` column so semantic-mode results are filtered consistently with keyword-mode. See `graph.md` "Federation: cross-repo graphs" for `repo_id` discovery.
 
 Uses vector embeddings for semantic search when available (run `graph action=embed` first). Falls back to keyword matching otherwise.
 
@@ -60,11 +63,13 @@ Analyze the blast radius of changed files. Shows which functions, classes, and f
 - `max_results`: Maximum impacted nodes to return (default: 500)
 - `base`: Git ref for auto-detecting changes (default: HEAD~1)
 - `repo_root`: Repository root path (auto-detected)
+- `repo`: Federated repo filter (Phase 2). When non-empty, scopes the BFS to nodes whose `repo_id` matches. Default `""` traverses across every federated repo, so cross-repo `IMPORTS_FROM` edges count toward the blast radius. See `graph.md` "Federation: cross-repo graphs" for `repo_id` discovery.
 
 **Example:**
 ```json
 {"action": "impact", "changed_files": ["src/auth.py", "src/models.py"]}
 {"action": "impact", "max_depth": 3, "base": "main"}
+{"action": "impact", "changed_files": ["src/auth.py"], "repo": "repo_a-3f2a91bc"}
 ```
 
 ---
@@ -78,9 +83,11 @@ Find functions, classes, or files exceeding a line-count threshold. Useful for d
 - `file_path_pattern`: Filter by file path substring (e.g. "components/")
 - `limit`: Maximum results (default: 50)
 - `repo_root`: Repository root path (auto-detected)
+- `repo`: Federated repo filter (Phase 2). When non-empty, restricts oversized-node results to nodes whose `repo_id` matches. Default `""` returns large nodes across every federated repo. See `graph.md` "Federation: cross-repo graphs" for `repo_id` discovery.
 
 **Example:**
 ```json
 {"action": "large_functions", "min_lines": 100, "kind": "Function"}
 {"action": "large_functions", "file_path_pattern": "src/", "limit": 20}
+{"action": "large_functions", "min_lines": 100, "repo": "repo_a-3f2a91bc"}
 ```

--- a/src/better_code_review_graph/docs/recipes.md
+++ b/src/better_code_review_graph/docs/recipes.md
@@ -99,6 +99,25 @@ Returns: blast radius, untested-function list, wide-blast flags, and
 
 ---
 
+## Cross-repo federation
+
+Index multiple repos into a single graph and scope queries to one of them
+via the `repo='<repo_id>'` filter on `query` / `review`:
+
+```json
+{"tool": "graph", "action": "build", "repo_root": "./repo_a", "roots": ["./repo_b"]}
+{"tool": "query", "action": "query", "pattern": "callers_of",
+ "target": "src/auth.py::authenticate", "repo": "repo_a-3f2a91bc"}
+```
+
+`repo_id`s are derived as `<basename>-<sha256[:8]>` of the absolute path,
+so they're stable across runs. See `graph.md` section
+"Federation: cross-repo graphs" for full recipes (including cross-language
+Python + TypeScript federation) and the cross-repo `IMPORTS_FROM`
+qualified-name format.
+
+---
+
 ## Tips
 
 - `query.action="callers_of"` auto-resolves the bare-name File+Function

--- a/src/better_code_review_graph/docs/review.md
+++ b/src/better_code_review_graph/docs/review.md
@@ -10,12 +10,14 @@ Generate focused, token-efficient review context for code changes. Combines impa
 - `max_lines_per_file`: Max source lines per file (default: 200)
 - `base`: Git ref for change detection (default: HEAD~1)
 - `repo_root`: Repository root path (auto-detected)
+- `repo`: Federated repo filter (Phase 2). When non-empty, scopes the impact subgraph and untested-function audit to nodes whose `repo_id` matches. Default `""` includes every federated repo, so cross-repo callers/importers contribute to the review context. Useful when a PR touches one repo in a federated graph but you only want review guidance about that repo. See `graph.md` "Federation: cross-repo graphs" for `repo_id` discovery.
 
 ## Example
 
 ```json
 {"changed_files": ["src/auth.py"]}
 {"include_source": false, "base": "main"}
+{"changed_files": ["src/auth.py"], "repo": "repo_a-3f2a91bc"}
 ```
 
 ## What It Returns


### PR DESCRIPTION
## Summary
- New section in `graph.md` documenting `roots=[...]` for federated build, repo_id derivation rule (`<basename>-<sha256[:8]>`), single-repo backwards compat, cross-repo `<repo_id>:<file>::<symbol>` format, and `last_indexed_sha` per-repo recording.
- Two example recipes added to `graph.md`:
  - Recipe 1: federated multi-repo Python build with scoped `callers_of` query.
  - Recipe 2: cross-language federation (Python lib + TypeScript app) walking IMPORTS_FROM edges across repos.
- `query.md` documents `repo` param under each of `query`, `search`, `impact`, `large_functions`.
- `review.md` documents `repo` param.
- `recipes.md` adds short `## Cross-repo federation` pointer to `graph.md`.

This is **Phase 2 Task 11 of 12** (epic #325). 11/12 done. Only Task 12 (multi-repo smoke fixture) remaining before Phase 2 BETA → Test B → STABLE.

## Test plan
- [x] All parameter signatures verified against `tools.py` `build_or_update_graph`/`query_graph`/etc. + `server.py` MCP exposure + `federation.derive_repo_id`.
- [x] No emojis. Only non-ASCII chars are pre-existing em-dashes (U+2014); new prose uses ASCII.
- [x] `uv run python` smoke-loads all 4 modified files via `importlib.resources` + asserts new sections present.
- [x] Existing help test suite (41 tests in `tests/test_*help*` and `tests/test_*docs*`) still passes.
- [ ] CI green.

## Files modified
- `src/better_code_review_graph/docs/graph.md` (+78 / -1)
- `src/better_code_review_graph/docs/query.md` (+7)
- `src/better_code_review_graph/docs/review.md` (+2)
- `src/better_code_review_graph/docs/recipes.md` (+19)

## Out of scope (Task 12)
- Multi-repo smoke fixture (Python lib + TS app + Go service) verifying cross-repo edges actually emerge.