### PR TITLE
feat: Phase 3 Task 1 — pre-2.0 backup-before-migrate hook

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -6,6 +6,8 @@ Supports impact-radius queries and subgraph extraction.
 """
 
 import json
+import os
+import shutil
 import sqlite3
 import threading
 import time
@@ -16,6 +18,46 @@ from typing import Any
 import networkx as nx
 
 from .parser import EdgeInfo, NodeInfo
+
+# Phase 3 Task 1 — pre-flight backup hook constants.
+#
+# ``_BREAKING_REVISION`` is the alembic revision id at which the
+# v2.0.0 BREAKING migration ships (security-aware nodes + temporal
+# tracking).  Any upgrade chain that crosses *into* this revision
+# from below triggers a one-time copy of the SQLite file to
+# ``<db>.pre-2.0.bak`` before alembic runs.
+#
+# The hook is intentionally encoded as a string compare on revision
+# ids — the project pads alembic ids to 3 digits (``001`` … ``005``),
+# so lexical comparison matches numeric comparison.  When the day
+# comes that the project switches to alembic's default 12-char hex
+# ids (or a downstream fork inherits this hook), this constant +
+# the helper below are the only places that need to change.
+_BREAKING_REVISION: str = "005"
+_BACKUP_SUFFIX: str = ".pre-2.0.bak"
+_ARCHIVED_SUFFIX: str = ".post-2.0.archived"
+_DOWNGRADE_ENV_VAR: str = "CRG_DOWNGRADE_TO_1_X"
+
+
+def _crosses_breaking_boundary(current_rev: str | None, target_rev: str | None) -> bool:
+    """Return True iff the upgrade chain crosses the v2.0 BREAKING boundary.
+
+    The boundary is crossed when:
+      * ``target_rev`` is at or past ``_BREAKING_REVISION`` (so the
+        upgrade *will* run the BREAKING migration), AND
+      * ``current_rev`` is below ``_BREAKING_REVISION`` (or ``None``
+        for a fresh DB without ``alembic_version``).
+
+    A ``None`` ``target_rev`` is treated as "unknown / no migrations
+    available" → no backup needed (defensive: if alembic can't tell
+    us where it's going, we don't second-guess it).
+    """
+    if target_rev is None or target_rev < _BREAKING_REVISION:
+        return False
+    # target_rev >= _BREAKING_REVISION
+    if current_rev is None:
+        return True
+    return current_rev < _BREAKING_REVISION
 
 
 def _resolve_migrations_dir() -> Path:
@@ -247,6 +289,18 @@ class GraphStore:
         cfg.set_main_option("script_location", str(migrations_dir))
         cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
 
+        # Phase 3 Task 1 — early-exit downgrade path.
+        #
+        # When the operator sets ``CRG_DOWNGRADE_TO_1_X=1`` we restore
+        # the pre-2.0 backup BEFORE any alembic activity (including
+        # the auto-stamp branch below — stamping a v1.x DB to "002"
+        # is the same idempotent outcome as the restored DB already
+        # being at "002", but we still skip it to avoid touching the
+        # restored file at all).
+        if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
+            self._restore_pre_2_0_backup()
+            return
+
         # Detect "legacy DB": pre-existing structural tables but alembic
         # has not yet recorded a head revision. Two sub-cases:
         #   1. ``alembic_version`` table is missing entirely.
@@ -271,6 +325,20 @@ class GraphStore:
             if needs_stamp:
                 command.stamp(cfg, "002")
 
+        # Phase 3 Task 1 — backup before BREAKING migration crosses the
+        # 005 boundary.  Read the current recorded revision (post-stamp)
+        # and the script-directory head; if the chain crosses 005,
+        # snapshot the SQLite file via ``shutil.copy2`` so the operator
+        # can roll back via ``CRG_DOWNGRADE_TO_1_X=1`` if the BREAKING
+        # migration produces a worse outcome than expected.  Idempotent:
+        # an existing backup is preserved (could be from an earlier
+        # partial run that aborted mid-upgrade — that copy is closer to
+        # the true v1.x state than anything we'd produce now).
+        current_rev = self._read_alembic_version()
+        target_rev = ScriptDirectory.from_config(cfg).get_current_head()
+        if _crosses_breaking_boundary(current_rev, target_rev):
+            self._take_pre_2_0_backup()
+
         try:
             command.upgrade(cfg, "head")
         except CommandError as exc:
@@ -293,6 +361,113 @@ class GraphStore:
                 f"better-code-review-graph (head={head!r}). Either downgrade "
                 "the package or recreate the DB."
             ) from exc
+
+    # ------------------------------------------------------------------
+    # Phase 3 Task 1 — backup / restore helpers
+    # ------------------------------------------------------------------
+
+    def _read_alembic_version(self) -> str | None:
+        """Return the revision recorded in ``alembic_version`` (or ``None``).
+
+        ``None`` covers two cases the BREAKING-boundary check needs to
+        treat identically: the table is missing entirely (fresh DB) or
+        the table exists but has no row (interrupted prior run).
+        """
+        try:
+            row = self._conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None:
+            return None
+        return row[0]
+
+    def _take_pre_2_0_backup(self) -> None:
+        """Copy ``self.db_path`` to ``<db>.pre-2.0.bak`` if not already taken.
+
+        Uses ``shutil.copy2`` to preserve metadata so a forensic timestamp
+        comparison remains meaningful.  Idempotent: a pre-existing backup
+        file is left untouched (the original copy is closer to true v1.x
+        state than anything a re-run could produce).
+
+        :memory: databases — and any path that does not exist on disk —
+        are skipped silently.  alembic-managed in-memory DBs aren't a
+        target for forensic rollback, and the file-not-found case can
+        only come up on bizarre virtual filesystems where copy would
+        fail anyway.
+        """
+        backup_path = self.db_path.with_suffix(_BACKUP_SUFFIX)
+        if backup_path.exists():
+            return
+        if not self.db_path.is_file():
+            return
+        # ``shutil.copy2`` follows symlinks and preserves metadata.
+        # WAL files (``-wal`` / ``-shm``) are intentionally NOT copied:
+        # we close the sqlite connection's WAL state by issuing a
+        # checkpoint first so the .db file is self-contained.
+        try:
+            self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.Error:
+            # Some pragmas aren't available on every SQLite build /
+            # platform — falling back to a copy of the main file alone
+            # is still strictly better than no backup.
+            pass
+        shutil.copy2(self.db_path, backup_path)
+
+    def _restore_pre_2_0_backup(self) -> None:
+        """Restore ``<db>.pre-2.0.bak`` over ``self.db_path``.
+
+        Used when the operator opts into a v1.x downgrade via
+        ``CRG_DOWNGRADE_TO_1_X=1``.  The current (potentially v2)
+        DB is preserved at ``<db>.post-2.0.archived`` so a follow-up
+        forward-roll is still possible if the operator changes their
+        mind.
+
+        Closes the active sqlite connection before the restore so the
+        on-disk file can be replaced safely on Windows (which holds an
+        exclusive lock on open files).  A fresh connection is opened
+        against the restored file before returning so the rest of
+        ``GraphStore.__init__`` continues to work.
+
+        Raises :class:`RuntimeError` with a clear message when the env
+        var is set but no backup file exists — the operator's intent
+        was explicit and we have nothing to honour it with.
+        """
+        backup_path = self.db_path.with_suffix(_BACKUP_SUFFIX)
+        archived_path = self.db_path.with_suffix(_ARCHIVED_SUFFIX)
+
+        if not backup_path.is_file():
+            raise RuntimeError(
+                f"{_DOWNGRADE_ENV_VAR}=1 was set but no backup file was "
+                f"found at {backup_path}. A v1.x downgrade requires the "
+                "pre-migration snapshot taken on the previous startup. "
+                "Either restore the backup file from elsewhere or unset "
+                f"{_DOWNGRADE_ENV_VAR} to continue with the v2 schema."
+            )
+
+        # Close the live connection so Windows lets us swap the file.
+        # Re-opened below before this method returns.
+        self._conn.close()
+
+        # Move (not delete) the v2 state aside so the operator can still
+        # recover it.  ``os.replace`` is atomic on the same filesystem.
+        if self.db_path.is_file():
+            if archived_path.exists():
+                archived_path.unlink()
+            os.replace(self.db_path, archived_path)
+
+        shutil.copy2(backup_path, self.db_path)
+
+        # Reopen against the restored file with the same PRAGMAs as
+        # ``__init__``.  Keeping these in sync with ``__init__`` is a
+        # narrow contract; if either is changed, the other must follow.
+        self._conn = sqlite3.connect(
+            str(self.db_path), timeout=30, check_same_thread=False
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
 
     def _ensure_federation_columns(self) -> None:
         """Backfill Phase 2 Task 1 federation columns on legacy / in-memory DBs.

--- a/tests/test_pre_2_0_backup.py
+++ b/tests/test_pre_2_0_backup.py
@@ -1,0 +1,491 @@
+"""Tests for Phase 3 Task 1 — pre-flight backup-before-migrate hook.
+
+The Phase 3 (v2.0.0) BREAKING migration ``005_temporal_columns`` will
+restructure ``nodes``/``edges`` for security-aware nodes + temporal
+tracking.  Before that migration ships, we add a safety net:
+
+1. **Backup**: when ``GraphStore.__init__`` opens a DB whose alembic
+   target head is ``005`` or later AND the DB itself is at a pre-005
+   revision (None / 001 / 002 / 003 / 004), a ``shutil.copy2`` of the
+   DB file is taken to ``<db>.pre-2.0.bak`` BEFORE
+   ``command.upgrade(cfg, "head")`` runs.  Idempotent — if the backup
+   already exists (prior partial run), it is not overwritten.
+
+2. **Downgrade**: when ``CRG_DOWNGRADE_TO_1_X=1`` is set in the
+   environment and a ``<db>.pre-2.0.bak`` exists, the current DB is
+   archived to ``<db>.post-2.0.archived`` and the backup is restored
+   in place; the alembic upgrade is then skipped (the restored DB is
+   at v1.x revision and that's the user's intent).  If the env var is
+   set but no backup exists, a clear :class:`RuntimeError` is raised.
+
+These tests must work BEFORE migration 005 ships: we monkeypatch
+``ScriptDirectory.get_current_head`` to return ``"005"`` to simulate
+the post-005 world.  Today's real head is still ``003``, so the hook
+is a no-op on the production code path until the BREAKING migration
+lands.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+import better_code_review_graph.graph as graph_mod
+from better_code_review_graph.graph import GraphStore
+
+
+def _alembic_config_for(db_path: Path) -> Config:
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _stamp(db_path: Path, revision: str) -> None:
+    """Bring a fresh DB up through alembic to ``revision``."""
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, revision)
+
+
+def _current_revision(db_path: Path) -> str | None:
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='alembic_version'"
+        ).fetchone()
+        if row is None:
+            return None
+        rev = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+        return rev[0] if rev else None
+
+
+def _force_target_head(monkeypatch: pytest.MonkeyPatch, head: str) -> None:
+    """Make ``ScriptDirectory.get_current_head`` report ``head`` everywhere
+    ``graph._run_alembic_upgrade`` resolves it.
+
+    The hook reads the target head via ``ScriptDirectory.from_config(cfg).get_current_head()``;
+    we patch the unbound method so every fresh ``ScriptDirectory`` instance
+    that ``_run_alembic_upgrade`` builds reports the simulated head.
+    """
+    monkeypatch.setattr(
+        ScriptDirectory, "get_current_head", lambda self: head, raising=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# (1) Backup created when crossing rev 005
+# ---------------------------------------------------------------------------
+
+
+def test_backup_created_when_crossing_rev_005(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DB at rev 002, simulated head at 005 → backup file produced.
+
+    We bring a real DB to revision ``002`` via alembic so it has the
+    Phase 1/2 schema rows alembic records, then monkeypatch
+    ``get_current_head`` to ``"005"`` so the hook believes a BREAKING
+    migration is about to run.  The hook must copy the DB to
+    ``<db>.pre-2.0.bak`` BEFORE the upgrade is attempted.
+
+    Because the simulated head ``005`` is not a revision alembic can
+    resolve, the upgrade itself will fail — that's fine for this test:
+    we assert the backup was created (timing: BEFORE upgrade) and let
+    the failure propagate.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "002")
+    assert _current_revision(db_path) == "002"
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    assert not backup_path.exists()
+
+    _force_target_head(monkeypatch, "005")
+
+    # The hook reads ``ScriptDirectory.get_current_head()`` and sees
+    # ``"005"``, so it takes a backup before invoking
+    # ``command.upgrade(cfg, "head")``.  alembic itself resolves
+    # "head" via its own internal walk of the script directory and
+    # will land at the real shipped head ("003"), which is fine for
+    # this assertion: the backup file must exist regardless of where
+    # the upgrade ended up.
+    store = GraphStore(db_path)
+    try:
+        assert backup_path.exists(), (
+            f"backup {backup_path} should be created when target head crosses 005"
+        )
+        # Backup contents match the rev-002 DB (the source of the copy).
+        with closing(sqlite3.connect(str(backup_path))) as conn:
+            row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+        assert row[0] == "002", f"backup should preserve rev 002; got {row[0]!r}"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# (2) Backup skipped when DB already at 005 or above
+# ---------------------------------------------------------------------------
+
+
+def test_backup_skipped_when_already_at_005_or_above(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DB already at rev 005 — no backup needed (we're past the boundary).
+
+    We synthesize a DB that alembic considers at revision ``005`` by
+    stamping (without running a real migration) and then patch
+    ``get_current_head`` to ``"005"`` so target == current.  The hook
+    must NOT create a backup file.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "head")  # bring schema up
+    # Forge alembic_version to "005" so the hook sees current_rev=="005"
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.execute("UPDATE alembic_version SET version_num = '005'")
+        conn.commit()
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    assert not backup_path.exists()
+
+    _force_target_head(monkeypatch, "005")
+
+    # GraphStore will fail at command.upgrade("head") because alembic
+    # can't resolve revision 005; the relevant assertion is whether the
+    # backup was attempted before the failure.  Either path (success or
+    # raise) must NOT produce a backup.
+    try:
+        store = GraphStore(db_path)
+        store.close()
+    except Exception:
+        pass
+
+    assert not backup_path.exists(), (
+        "backup must not be created when DB is already at/past rev 005"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) Backup skipped when target below 005
+# ---------------------------------------------------------------------------
+
+
+def test_backup_skipped_when_target_below_005(tmp_path: Path) -> None:
+    """DB at rev 001, real head at "003" — no backup (boundary not crossed).
+
+    No monkeypatch — the real shipped head is currently ``003`` (Phase 2
+    federation), well below the BREAKING boundary of ``005``.  The hook
+    must be a no-op so existing flows remain unaffected.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "001")
+    assert _current_revision(db_path) == "001"
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    assert not backup_path.exists()
+
+    store = GraphStore(db_path)
+    try:
+        # GraphStore brings the DB to head normally; backup never created.
+        assert _current_revision(db_path) is not None
+    finally:
+        store.close()
+
+    assert not backup_path.exists(), (
+        "backup must not be created when target head is below rev 005"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (4) Backup is idempotent (existing file not overwritten)
+# ---------------------------------------------------------------------------
+
+
+def test_backup_idempotent_if_file_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-existing backup file is preserved, not overwritten.
+
+    Simulates a re-run after a partial / failed migration: a backup is
+    already on disk from the first attempt.  Opening the DB again must
+    NOT replace the old backup with a copy of the (potentially partially
+    migrated) current DB.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "002")
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    sentinel = b"OLD-BACKUP-MARKER"
+    backup_path.write_bytes(sentinel)
+    assert backup_path.read_bytes() == sentinel
+
+    _force_target_head(monkeypatch, "005")
+
+    store = GraphStore(db_path)
+    try:
+        # Old backup preserved verbatim — idempotent.
+        assert backup_path.read_bytes() == sentinel, (
+            "existing backup must not be overwritten on subsequent runs"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# (5) Downgrade env var restores backup
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_env_var_restores_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CRG_DOWNGRADE_TO_1_X=1`` + backup exists → restore + archive current.
+
+    Setup:
+      * DB at simulated post-005 state (real head, but contents
+        immaterial — we're going to overwrite the file anyway).
+      * Backup file marker = "BACKUP".
+      * Env var set.
+
+    Expected outcome:
+      * ``<db>.post-2.0.archived`` contains the v2 (current) DB.
+      * ``<db>`` itself contains the backup marker.
+      * The alembic upgrade is skipped (backup is at v1.x).
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "002")  # creates a real v1.x-shaped DB
+
+    # Take a real backup of the current rev-002 state (so the "restore"
+    # produces a usable DB), then bump current to head to simulate v2 state.
+    import shutil
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    shutil.copy2(db_path, backup_path)
+
+    # Bump current DB to head ("003") — pretend we're at v2.
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+    v2_rev = _current_revision(db_path)
+    assert v2_rev == "003"
+
+    # Sanity: backup is still at 002.
+    with closing(sqlite3.connect(str(backup_path))) as conn:
+        bkp_rev = conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+    assert bkp_rev == "002"
+
+    archived_path = db_path.with_suffix(".post-2.0.archived")
+    assert not archived_path.exists()
+
+    monkeypatch.setenv("CRG_DOWNGRADE_TO_1_X", "1")
+
+    store = GraphStore(db_path)
+    try:
+        # Restored DB is at the backup revision (002), not head.
+        assert _current_revision(db_path) == "002", (
+            "DB should now contain the v1.x backup state"
+        )
+        # The v2 state was preserved on disk for recovery.
+        assert archived_path.exists()
+        with closing(sqlite3.connect(str(archived_path))) as conn:
+            arch_rev = conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()[0]
+        assert arch_rev == v2_rev, (
+            f"archived file should contain the v2 state ({v2_rev}); got {arch_rev!r}"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# (6) Downgrade env var without backup raises
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_env_var_without_backup_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env var set but no backup exists → :class:`RuntimeError`.
+
+    Cannot silently fall through to a forward-upgrade — the user
+    explicitly asked for a downgrade and we have nothing to restore.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "head")
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    assert not backup_path.exists()
+
+    monkeypatch.setenv("CRG_DOWNGRADE_TO_1_X", "1")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        GraphStore(db_path)
+
+    msg = str(excinfo.value)
+    assert "backup" in msg.lower(), (
+        f"error message should mention the missing backup: {msg!r}"
+    )
+    assert str(backup_path) in msg, (
+        f"error message should name the expected backup path: {msg!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (7) Downgrade env var unset → no restore (default flow)
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_env_var_unset_does_not_restore(tmp_path: Path) -> None:
+    """Backup file present but env var unset → default forward-flow runs.
+
+    The mere presence of a backup file from a prior aborted run must
+    not trigger a restore on its own; the user has to explicitly opt
+    in via ``CRG_DOWNGRADE_TO_1_X=1``.
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "002")
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    sentinel = b"BACKUP-SHOULD-BE-IGNORED"
+    backup_path.write_bytes(sentinel)
+
+    archived_path = db_path.with_suffix(".post-2.0.archived")
+    assert not archived_path.exists()
+
+    # Env var deliberately unset (covered by sandboxed test env).
+    store = GraphStore(db_path)
+    try:
+        # DB advanced normally to head.
+        assert _current_revision(db_path) is not None
+        # Archive file never created — no restore happened.
+        assert not archived_path.exists(), (
+            "archive must not be created when env var is unset"
+        )
+        # Backup file untouched.
+        assert backup_path.read_bytes() == sentinel
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Module reference smoke (keeps the import marked used by linters and
+# pins the symbol the implementation must export — moves with the code).
+# ---------------------------------------------------------------------------
+
+
+def test_graph_module_exposes_graphstore() -> None:
+    assert hasattr(graph_mod, "GraphStore")
+
+
+# ---------------------------------------------------------------------------
+# Edge-case coverage: defensive branches in the helpers
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_replaces_existing_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An archive file from a prior aborted downgrade gets replaced.
+
+    Covers the ``archived_path.unlink()`` branch in
+    ``_restore_pre_2_0_backup``: if the user is running a second
+    downgrade attempt (e.g. after an interrupted shutdown), the
+    stale archive on disk must be removed before
+    ``os.replace(db, archived)`` runs (Windows ``os.replace`` errors
+    if the destination already exists across some filesystems).
+    """
+    db_path = tmp_path / "graph.db"
+    _stamp(db_path, "002")
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    import shutil as _shutil
+
+    _shutil.copy2(db_path, backup_path)
+
+    # Pre-existing archive from a prior aborted attempt.
+    archived_path = db_path.with_suffix(".post-2.0.archived")
+    archived_path.write_bytes(b"STALE-ARCHIVE")
+    assert archived_path.exists()
+
+    monkeypatch.setenv("CRG_DOWNGRADE_TO_1_X", "1")
+
+    store = GraphStore(db_path)
+    try:
+        # Restore succeeded despite the pre-existing archive: the stale
+        # archive was unlinked, the v2 (current) state moved into its
+        # place, and the backup restored over the live db.
+        assert _current_revision(db_path) == "002"
+        assert archived_path.exists()
+        # The new archive is NOT the stale marker — the old one was
+        # unlinked and replaced with the v2 state.
+        assert archived_path.read_bytes() != b"STALE-ARCHIVE"
+    finally:
+        store.close()
+
+
+def test_take_backup_silent_no_op_when_db_path_missing(tmp_path: Path) -> None:
+    """``_take_pre_2_0_backup`` is a no-op when the main DB file is missing.
+
+    Scenario: a memory-only test path or a virtual filesystem where the
+    on-disk file simply does not exist.  We synthesize this by opening
+    a ``GraphStore`` against a fresh tmp file and then deleting the file
+    out from under it before invoking the helper directly.
+
+    The helper must NOT raise — defensive guard for code paths that
+    re-enter ``_run_alembic_upgrade`` from atypical bootstraps.
+    """
+    db_path = tmp_path / "graph.db"
+    store = GraphStore(db_path)
+    try:
+        backup_path = db_path.with_suffix(".pre-2.0.bak")
+        # Delete the live file (closing the sqlite connection first so
+        # Windows lets us drop the inode).
+        store._conn.close()
+        db_path.unlink()
+        assert not db_path.exists()
+
+        # Direct call — no exception, no backup file.
+        store._take_pre_2_0_backup()
+        assert not backup_path.exists()
+    finally:
+        # Reopen the connection so the closing context manager doesn't
+        # double-close on a now-invalid handle.
+        store._conn = sqlite3.connect(":memory:")
+        store.close()
+
+
+def test_crosses_breaking_boundary_helper() -> None:
+    """Exercise the pure boundary-detection helper directly.
+
+    The helper drives a load-bearing branch in production code so we
+    pin its exact contract here: only the (current_rev < 005, target_rev >= 005)
+    quadrant returns True.  ``None`` for current means fresh DB →
+    crosses (when target is at/past 005).  ``None`` for target is
+    treated as "alembic doesn't know" and never crosses.
+    """
+    from better_code_review_graph.graph import _crosses_breaking_boundary
+
+    # Pre-005 DB about to upgrade to 005+: triggers backup.
+    assert _crosses_breaking_boundary(None, "005") is True
+    assert _crosses_breaking_boundary("001", "005") is True
+    assert _crosses_breaking_boundary("002", "005") is True
+    assert _crosses_breaking_boundary("003", "005") is True
+    assert _crosses_breaking_boundary("004", "005") is True
+    assert _crosses_breaking_boundary("002", "006") is True
+    # Already at/past 005: no backup needed.
+    assert _crosses_breaking_boundary("005", "005") is False
+    assert _crosses_breaking_boundary("005", "006") is False
+    assert _crosses_breaking_boundary("006", "006") is False
+    # Target below 005: no backup needed (current head today).
+    assert _crosses_breaking_boundary(None, "003") is False
+    assert _crosses_breaking_boundary("001", "002") is False
+    assert _crosses_breaking_boundary("002", "003") is False
+    # Target unknown: defensive False.
+    assert _crosses_breaking_boundary(None, None) is False
+    assert _crosses_breaking_boundary("002", None) is False


### PR DESCRIPTION
## Summary
- `GraphStore._run_alembic_upgrade` now takes a backup of `graph.db` to `graph.db.pre-2.0.bak` BEFORE the upgrade chain crosses revision 005 (the BREAKING boundary that lands in Phase 3 Task 6).
- New env var `CRG_DOWNGRADE_TO_1_X=1` triggers the reverse path: archives current db to `.post-2.0.archived` and restores the backup, skipping the upgrade.
- Production no-op today: real head is `"003"` (post-Phase 2), so `_crosses_breaking_boundary("003", "005")` returns False on every existing call.
- WAL-safe (PRAGMA wal_checkpoint TRUNCATE before copy), Windows-safe (`_conn.close()` before `os.replace`), atomic (`os.replace` not `shutil.move`).

This is **Phase 3 Task 1 of 12** (epic #326).

## Test plan
- [x] `pytest tests/test_pre_2_0_backup.py -v`: 11 passed (7 spec scenarios + 4 edge cases).
- [x] `pytest --cov-fail-under=95 -q`: 975 passed, coverage 95.16%, `graph.py` 97%.
- [x] Backwards compat: hook is no-op at current head ("003"); zero regression in 964 prior tests.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## Files
- Modified: `src/better_code_review_graph/graph.py` — added imports, constants (`_BREAKING_REVISION`, `_BACKUP_SUFFIX`, `_ARCHIVED_SUFFIX`, `_DOWNGRADE_ENV_VAR`), pure helper `_crosses_breaking_boundary`, and 3 GraphStore methods (`_read_alembic_version`, `_take_pre_2_0_backup`, `_restore_pre_2_0_backup`).
- Created: `tests/test_pre_2_0_backup.py` (11 tests).

## Out of scope (later tasks)
- Task 2: 004_security_tags migration.
- Tasks 3-5: heuristic + Semgrep + security MCP tool.
- Task 6: 005_temporal_columns BREAKING migration (this is when the hook actually fires).
- Tasks 7-12: commits table + TemporalIndex + as_of/diff + line shifts + docs + release dry-run.