### PR TITLE
feat: Phase 3 Task 5 — security MCP tool (scan/report/suppress/rule_list)

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -27,6 +27,10 @@ from .tools import (
     list_graph_stats,
     query_graph,
     renamed_in_diff,
+    security_report,
+    security_rule_list,
+    security_scan,
+    security_suppress,
     semantic_search_nodes,
     spot_check_last_callers,
     summarize_graph_dispatch,
@@ -766,6 +770,75 @@ def help(topic: str = "graph") -> str:
                 "valid_topics": sorted(valid_topics),
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: security (Phase 3 Task 5) -- scan / report / suppress / rule_list
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Security scanning over the code knowledge graph. "
+        "Actions: scan (engine='heuristic'|'semgrep', repo_root), "
+        "report (format='json'|'sarif', repo_root), "
+        "suppress (rule_id, remove=false, repo_root), "
+        "rule_list (engine='heuristic'|'semgrep'). "
+        "Use `help` tool for full docs."
+    ),
+    annotations=ToolAnnotations(
+        title="Security",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+)
+def security(
+    action: str = "scan",
+    repo_root: str | None = None,
+    engine: str = "heuristic",
+    format: str = "json",
+    rule_id: str | None = None,
+    remove: bool = False,
+) -> str:
+    """Security scanning tool: scan / report / suppress / rule_list.
+
+    Actions (required params -> optional):
+
+    - scan (-> engine='heuristic'|'semgrep', repo_root): Run a security scan
+      over Function/Class/Method nodes; results are cached on disk and
+      persisted to ``nodes.security_tags``.
+    - report (-> format='json'|'sarif', repo_root): Re-emit the cached scan
+      payload as JSON (default) or SARIF v2.1.0.
+    - suppress (rule_id -> remove=false, repo_root): Add or remove a rule_id
+      from the persistent suppression list at
+      ``.code-review-graph/security-suppressions.json``.
+    - rule_list (-> engine='heuristic'|'semgrep'): Enumerate active rules.
+    """
+    match action:
+        case "scan":
+            return _json(security_scan(repo_root=repo_root, engine=engine))
+        case "report":
+            return _json(security_report(repo_root=repo_root, format=format))
+        case "suppress":
+            return _json(
+                security_suppress(repo_root=repo_root, rule_id=rule_id, remove=remove)
+            )
+        case "rule_list":
+            return _json(security_rule_list(engine=engine))
+        case _:
+            import difflib
+
+            valid_actions = ["report", "rule_list", "scan", "suppress"]
+            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
+            return _json(
+                {
+                    "error": f"Unknown action '{action}'.{suggestion}",
+                    "valid_actions": valid_actions,
+                }
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -13,6 +13,7 @@ Exposes 9 tools:
 """
 
 import hashlib
+import json
 import time
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,12 @@ from .incremental import (
     get_db_path,
     get_staged_and_unstaged,
     incremental_update,
+)
+from .security import HeuristicScanner, Tag
+from .security.semgrep_engine import (
+    SemgrepNotAvailable,
+    SemgrepScanner,
+    _resolve_overlay_rules_dir,
 )
 
 # Common JS/TS builtin method names filtered from callers_of results.
@@ -2317,3 +2324,334 @@ def find_large_functions(
         }
     finally:
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# Tool 10: security (Phase 3 Task 5) -- scan / report / suppress / rule_list
+# ---------------------------------------------------------------------------
+
+_SUPPRESS_PATH_DEFAULT = ".code-review-graph/security-suppressions.json"
+_LAST_SCAN_CACHE_FILENAME = "security-last-scan.json"
+
+
+class _NodeView:
+    """Duck-typed adapter exposing the four attributes ``HeuristicScanner``
+    expects (``source_text``, ``language``, ``line_start``, ``qualified_name``).
+
+    Used to feed plain ``GraphStore`` rows into the scanner without forcing
+    a full ``NodeInfo`` re-construction.
+    """
+
+    __slots__ = ("qualified_name", "language", "line_start", "source_text")
+
+    def __init__(
+        self,
+        qualified_name: str,
+        language: str,
+        line_start: int | None,
+        source_text: str | None,
+    ) -> None:
+        self.qualified_name = qualified_name
+        self.language = language or ""
+        self.line_start = line_start
+        self.source_text = source_text
+
+
+def security_scan(
+    repo_root: str | None = None,
+    *,
+    engine: str = "heuristic",
+) -> dict[str, Any]:
+    """Run a security scan over Function/Class/Method nodes in the graph.
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        engine: ``"heuristic"`` (default, regex tier-1) or ``"semgrep"``
+            (tier-2; requires the ``[security]`` extra).
+
+    Returns:
+        ``{"engine": str, "total": int, "by_severity": dict, "by_rule": dict,
+        "tags_by_node": dict[node_id -> list[tag dict]],
+        "suppressed_count": int}``.
+
+        When ``engine="semgrep"`` is requested but the CLI is unavailable,
+        returns ``{"error": <reason>, "engine": "semgrep"}``.
+    """
+    store, root = _get_store(repo_root)
+    try:
+        suppressions = _load_suppressions(root)
+        tags_by_node: dict[str, list[Tag]] = {}
+
+        if engine == "semgrep":
+            try:
+                scanner = SemgrepScanner()
+            except SemgrepNotAvailable as exc:
+                return {"error": str(exc), "engine": "semgrep"}
+            result = scanner.scan_path(root)
+            for tag in result.tags:
+                if tag.rule_id in suppressions:
+                    continue
+                tags_by_node.setdefault("(repo-wide)", []).append(tag)
+        else:
+            scanner = HeuristicScanner()
+            rows = store._conn.execute(
+                "SELECT qualified_name, language, line_start, source_text "
+                "FROM nodes WHERE source_text IS NOT NULL "
+                "AND kind IN ('Function','Class','Method')"
+            ).fetchall()
+            for row in rows:
+                view = _NodeView(
+                    qualified_name=row["qualified_name"],
+                    language=row["language"] or "",
+                    line_start=row["line_start"],
+                    source_text=row["source_text"],
+                )
+                tags = [
+                    t for t in scanner.scan_node(view) if t.rule_id not in suppressions
+                ]
+                if tags:
+                    tags_by_node[row["qualified_name"]] = tags
+
+        total = 0
+        by_severity: dict[str, int] = {}
+        by_rule: dict[str, int] = {}
+        for tags in tags_by_node.values():
+            total += len(tags)
+            for tag in tags:
+                by_severity[tag.severity] = by_severity.get(tag.severity, 0) + 1
+                by_rule[tag.rule_id] = by_rule.get(tag.rule_id, 0) + 1
+
+        serialized = {
+            nid: [
+                {
+                    "rule_id": t.rule_id,
+                    "severity": t.severity,
+                    "message": t.message,
+                    "line": t.line,
+                }
+                for t in tags
+            ]
+            for nid, tags in tags_by_node.items()
+        }
+        payload = {
+            "engine": engine,
+            "total": total,
+            "by_severity": by_severity,
+            "by_rule": by_rule,
+            "tags_by_node": serialized,
+            "suppressed_count": len(suppressions),
+        }
+        _cache_last_scan(root, payload)
+        _persist_security_tags(store, tags_by_node)
+        return payload
+    finally:
+        store.close()
+
+
+def security_report(
+    repo_root: str | None = None,
+    *,
+    format: str = "json",
+) -> dict[str, Any]:
+    """Re-emit the cached last scan as JSON or SARIF v2.1.0.
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        format: ``"json"`` (default, returns the cached payload directly) or
+            ``"sarif"`` (wraps the payload in a SARIF v2.1.0 envelope).
+
+    Returns:
+        The cached payload, a SARIF envelope, or
+        ``{"error": "No prior scan found..."}`` when no scan has run yet.
+    """
+    _, root = _get_store(repo_root)
+    cached = _load_last_scan(root)
+    if cached is None:
+        return {"error": "No prior scan found. Run security_scan first."}
+    if format == "sarif":
+        return _to_sarif(cached)
+    return cached
+
+
+def security_suppress(
+    repo_root: str | None = None,
+    *,
+    rule_id: str | None = None,
+    remove: bool = False,
+) -> dict[str, Any]:
+    """Add or remove ``rule_id`` from the persistent suppression list.
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        rule_id: The rule identifier (e.g. ``"cwe-89-sql-string-format"``).
+        remove: When ``True``, removes the rule instead of adding it.
+
+    Returns:
+        ``{"rule_id": str, "suppressed": bool, "total_suppressed": int}`` or
+        ``{"error": "rule_id is required"}`` when ``rule_id`` is missing.
+    """
+    if not rule_id:
+        return {"error": "rule_id is required"}
+    _, root = _get_store(repo_root)
+    suppressions = set(_load_suppressions(root))
+    if remove:
+        suppressions.discard(rule_id)
+    else:
+        suppressions.add(rule_id)
+    _save_suppressions(root, sorted(suppressions))
+    return {
+        "rule_id": rule_id,
+        "suppressed": not remove,
+        "total_suppressed": len(suppressions),
+    }
+
+
+def security_rule_list(
+    *,
+    engine: str = "heuristic",
+) -> dict[str, Any]:
+    """Enumerate active rules for the given engine.
+
+    Args:
+        engine: ``"heuristic"`` (default) or ``"semgrep"``.
+
+    Returns:
+        ``{"engine": str, "rules": [...]}`` -- entries are dicts with
+        ``id``/``severity``/``languages``/``message`` for the heuristic engine,
+        or filenames (``"name.yaml"``) for the semgrep overlay.
+    """
+    if engine == "semgrep":
+        rules_dir = _resolve_overlay_rules_dir()
+        if rules_dir is None:
+            return {
+                "engine": "semgrep",
+                "rules": [],
+                "note": "no curated overlay found",
+            }
+        rule_files = sorted(p.name for p in rules_dir.glob("*.yaml"))
+        return {"engine": "semgrep", "rules": rule_files}
+    scanner = HeuristicScanner()
+    rules = [
+        {
+            "id": r.id,
+            "severity": r.severity,
+            "languages": sorted(r.languages),
+            "message": r.message,
+        }
+        for r in scanner._rules
+    ]
+    return {"engine": "heuristic", "rules": rules}
+
+
+# ---------------------------------------------------------------------------
+# Persistence + serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_suppressions(root: Path) -> set[str]:
+    """Load the JSON-array suppression list. Returns ``set()`` if absent or
+    unreadable -- callers treat suppressions as best-effort."""
+    sup_path = root / _SUPPRESS_PATH_DEFAULT
+    if not sup_path.is_file():
+        return set()
+    try:
+        data = json.loads(sup_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    if not isinstance(data, list):
+        return set()
+    return {str(item) for item in data}
+
+
+def _save_suppressions(root: Path, suppressions: list[str]) -> None:
+    """Persist the suppression list as a sorted JSON array."""
+    sup_path = root / _SUPPRESS_PATH_DEFAULT
+    sup_path.parent.mkdir(parents=True, exist_ok=True)
+    sup_path.write_text(json.dumps(suppressions, indent=2), encoding="utf-8")
+
+
+def _cache_last_scan(root: Path, payload: dict[str, Any]) -> None:
+    """Cache the most recent scan payload so ``security_report`` can re-emit it."""
+    cache_path = root / ".code-review-graph" / _LAST_SCAN_CACHE_FILENAME
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _load_last_scan(root: Path) -> dict[str, Any] | None:
+    """Return the cached scan payload, or ``None`` if absent/corrupt."""
+    cache_path = root / ".code-review-graph" / _LAST_SCAN_CACHE_FILENAME
+    if not cache_path.is_file():
+        return None
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _to_sarif(payload: dict[str, Any]) -> dict[str, Any]:
+    """Convert a cached scan payload to a SARIF v2.1.0 envelope."""
+    results: list[dict[str, Any]] = []
+    for node_id, tags in payload.get("tags_by_node", {}).items():
+        for tag in tags:
+            line = tag.get("line") or 1
+            results.append(
+                {
+                    "ruleId": tag["rule_id"],
+                    "level": _sarif_level(tag["severity"]),
+                    "message": {"text": tag["message"]},
+                    "locations": [
+                        {
+                            "logicalLocations": [{"name": node_id}],
+                            "physicalLocation": {"region": {"startLine": line}},
+                        }
+                    ],
+                }
+            )
+    return {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "better-code-review-graph",
+                        "informationUri": (
+                            "https://github.com/n24q02m/better-code-review-graph"
+                        ),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+
+def _sarif_level(severity: str) -> str:
+    """Map CRG severity to SARIF level."""
+    return {
+        "CRITICAL": "error",
+        "HIGH": "error",
+        "MEDIUM": "warning",
+        "LOW": "note",
+    }.get(severity, "warning")
+
+
+def _persist_security_tags(
+    store: GraphStore, tags_by_node: dict[str, list[Tag]]
+) -> None:
+    """Write JSON-serialized tag summaries into ``nodes.security_tags``.
+
+    Skips the ``(repo-wide)`` semgrep bucket since it has no node anchor.
+    Each entry is a compact ``"<rule_id>:<severity>"`` string -- callers
+    that need the full tag detail re-run ``security_report``.
+    """
+    for node_id, tags in tags_by_node.items():
+        if node_id == "(repo-wide)":
+            continue
+        serialized = json.dumps([f"{t.rule_id}:{t.severity}" for t in tags])
+        store._conn.execute(
+            "UPDATE nodes SET security_tags = ? WHERE qualified_name = ?",
+            (serialized, node_id),
+        )
+    store._conn.commit()

--- a/tests/test_security_tool.py
+++ b/tests/test_security_tool.py
@@ -1,0 +1,415 @@
+"""Tests for the Phase 3 Task 5 ``security`` MCP tool.
+
+Covers:
+
+* ``security_scan`` (heuristic + semgrep dispatch)
+* ``security_report`` (json + sarif format)
+* ``security_suppress`` (add + remove + missing rule_id)
+* ``security_rule_list`` (heuristic + semgrep with/without overlay)
+* server-level ``security`` action dispatcher
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import NodeInfo
+from better_code_review_graph.security import Tag
+from better_code_review_graph.security.semgrep_engine import (
+    SemgrepNotAvailable,
+    SemgrepResult,
+)
+from better_code_review_graph.tools import (
+    _load_last_scan,
+    _load_suppressions,
+    _save_suppressions,
+    security_report,
+    security_rule_list,
+    security_scan,
+    security_suppress,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixture: a repo root with a populated GraphStore.
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_with_node(
+    tmp_path: Path,
+    *,
+    name: str = "vulnerable_query",
+    file_path: str = "src/db.py",
+    source_text: str | None = None,
+    language: str = "python",
+    kind: str = "Function",
+) -> tuple[Path, str]:
+    """Materialise a repo root + a single Function node + return (root, qname)."""
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    crg_dir = tmp_path / ".code-review-graph"
+    crg_dir.mkdir(exist_ok=True)
+    db_path = crg_dir / "graph.db"
+
+    # Default to an obvious SQL-injection sink so the heuristic scanner fires.
+    if source_text is None:
+        source_text = (
+            "def vulnerable_query(user_id):\n"
+            '    cursor.execute(f"SELECT * FROM users WHERE id={user_id}")\n'
+        )
+
+    store = GraphStore(db_path)
+    try:
+        store.upsert_node(
+            NodeInfo(
+                kind=kind,
+                name=name,
+                file_path=file_path,
+                line_start=1,
+                line_end=10,
+                language=language,
+                source_text=source_text,
+            )
+        )
+        store._conn.commit()
+    finally:
+        store.close()
+    qualified = f"{file_path}::{name}"
+    return tmp_path, qualified
+
+
+# ---------------------------------------------------------------------------
+# security_scan
+# ---------------------------------------------------------------------------
+
+
+def test_security_scan_heuristic_default(tmp_path: Path) -> None:
+    """A SQL-injection f-string in a Function node produces ``HIGH`` finding."""
+    root, qname = _make_repo_with_node(tmp_path)
+    payload = security_scan(repo_root=str(root))
+    assert payload["engine"] == "heuristic"
+    assert payload["total"] >= 1
+    assert payload["by_severity"].get("HIGH", 0) >= 1
+    assert qname in payload["tags_by_node"]
+    tag_entries = payload["tags_by_node"][qname]
+    assert any(entry["rule_id"] == "cwe-89-sql-string-format" for entry in tag_entries)
+
+
+def test_security_scan_semgrep_returns_error_when_cli_missing(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+
+    def _raise(self, *args, **kwargs):
+        raise SemgrepNotAvailable("semgrep not installed for test")
+
+    with patch(
+        "better_code_review_graph.tools.SemgrepScanner.__init__",
+        new=_raise,
+    ):
+        payload = security_scan(repo_root=str(root), engine="semgrep")
+    assert payload["engine"] == "semgrep"
+    assert "error" in payload
+    assert "not installed" in payload["error"]
+
+
+def test_security_scan_semgrep_uses_scanner_when_available(tmp_path: Path) -> None:
+    """When the CLI is available, results are aggregated under ``(repo-wide)``."""
+    root, _ = _make_repo_with_node(tmp_path)
+    fake_tag = Tag(
+        rule_id="semgrep-rule-x",
+        severity="MEDIUM",
+        message="hardcoded literal",
+        line=2,
+    )
+
+    class _FakeScanner:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def scan_path(self, target):
+            return SemgrepResult(tags=[fake_tag], raw_output="{}")
+
+    with patch("better_code_review_graph.tools.SemgrepScanner", new=_FakeScanner):
+        payload = security_scan(repo_root=str(root), engine="semgrep")
+    assert payload["engine"] == "semgrep"
+    assert payload["total"] == 1
+    assert payload["by_severity"].get("MEDIUM") == 1
+    assert "(repo-wide)" in payload["tags_by_node"]
+
+
+def test_security_scan_caches_last_scan_to_disk(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    payload = security_scan(repo_root=str(root))
+    cache_path = root / ".code-review-graph" / "security-last-scan.json"
+    assert cache_path.is_file(), "cache file should be written"
+    cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert cached == payload
+
+
+def test_security_scan_persists_security_tags_to_nodes(tmp_path: Path) -> None:
+    root, qname = _make_repo_with_node(tmp_path)
+    security_scan(repo_root=str(root))
+    db_path = root / ".code-review-graph" / "graph.db"
+    store = GraphStore(db_path)
+    try:
+        row = store._conn.execute(
+            "SELECT security_tags FROM nodes WHERE qualified_name = ?",
+            (qname,),
+        ).fetchone()
+        assert row is not None
+        assert row["security_tags"] is not None
+        decoded = json.loads(row["security_tags"])
+        assert isinstance(decoded, list)
+        assert any("cwe-89" in entry for entry in decoded)
+    finally:
+        store.close()
+
+
+def test_security_scan_skips_suppressed_rules(tmp_path: Path) -> None:
+    root, qname = _make_repo_with_node(tmp_path)
+    _save_suppressions(root, ["cwe-89-sql-string-format"])
+    payload = security_scan(repo_root=str(root))
+    assert qname not in payload["tags_by_node"]
+    assert payload["suppressed_count"] == 1
+
+
+def test_security_scan_no_findings_yields_empty_payload(tmp_path: Path) -> None:
+    """A node whose source text does not match any rule produces no tags."""
+    root, qname = _make_repo_with_node(
+        tmp_path,
+        source_text="def safe(): return 1\n",
+    )
+    payload = security_scan(repo_root=str(root))
+    assert payload["total"] == 0
+    assert qname not in payload["tags_by_node"]
+
+
+# ---------------------------------------------------------------------------
+# security_report
+# ---------------------------------------------------------------------------
+
+
+def test_security_report_returns_json_by_default(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    scan_payload = security_scan(repo_root=str(root))
+    report = security_report(repo_root=str(root))
+    assert report == scan_payload
+
+
+def test_security_report_returns_sarif_when_format_sarif(tmp_path: Path) -> None:
+    root, qname = _make_repo_with_node(tmp_path)
+    security_scan(repo_root=str(root))
+    sarif = security_report(repo_root=str(root), format="sarif")
+    assert sarif["version"] == "2.1.0"
+    assert "runs" in sarif and len(sarif["runs"]) == 1
+    run = sarif["runs"][0]
+    assert run["tool"]["driver"]["name"] == "better-code-review-graph"
+    assert run["results"], "SARIF run should carry at least one result"
+    first = run["results"][0]
+    assert first["ruleId"] == "cwe-89-sql-string-format"
+    assert first["level"] == "error"  # HIGH -> error
+    assert first["locations"][0]["logicalLocations"][0]["name"] == qname
+
+
+def test_security_report_returns_error_when_no_prior_scan(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    # Do NOT call security_scan first.
+    report = security_report(repo_root=str(root))
+    assert "error" in report
+    assert "No prior scan" in report["error"]
+
+
+# ---------------------------------------------------------------------------
+# security_suppress
+# ---------------------------------------------------------------------------
+
+
+def test_security_suppress_adds_rule_id(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    payload = security_suppress(repo_root=str(root), rule_id="cwe-89")
+    assert payload["rule_id"] == "cwe-89"
+    assert payload["suppressed"] is True
+    assert payload["total_suppressed"] == 1
+    assert "cwe-89" in _load_suppressions(root)
+
+
+def test_security_suppress_remove_clears_rule_id(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    _save_suppressions(root, ["cwe-89", "cwe-78"])
+    payload = security_suppress(repo_root=str(root), rule_id="cwe-89", remove=True)
+    assert payload["suppressed"] is False
+    assert payload["total_suppressed"] == 1
+    sup = _load_suppressions(root)
+    assert "cwe-89" not in sup
+    assert "cwe-78" in sup
+
+
+def test_security_suppress_returns_error_without_rule_id(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    payload = security_suppress(repo_root=str(root), rule_id=None)
+    assert "error" in payload
+    assert "rule_id" in payload["error"]
+
+
+def test_security_suppress_persists_across_calls(tmp_path: Path) -> None:
+    root, _ = _make_repo_with_node(tmp_path)
+    security_suppress(repo_root=str(root), rule_id="cwe-22")
+    security_suppress(repo_root=str(root), rule_id="cwe-95")
+    sup = _load_suppressions(root)
+    assert sup == {"cwe-22", "cwe-95"}
+
+
+# ---------------------------------------------------------------------------
+# security_rule_list
+# ---------------------------------------------------------------------------
+
+
+def test_security_rule_list_heuristic() -> None:
+    payload = security_rule_list(engine="heuristic")
+    assert payload["engine"] == "heuristic"
+    assert isinstance(payload["rules"], list)
+    assert len(payload["rules"]) >= 1
+    sample = payload["rules"][0]
+    assert {"id", "severity", "languages", "message"} <= set(sample.keys())
+
+
+def test_security_rule_list_semgrep_with_overlay() -> None:
+    payload = security_rule_list(engine="semgrep")
+    assert payload["engine"] == "semgrep"
+    if payload["rules"]:
+        # At least the curated.yaml exists in the repo checkout.
+        assert any(name.endswith(".yaml") for name in payload["rules"])
+    else:
+        assert "note" in payload
+
+
+def test_security_rule_list_semgrep_no_overlay(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "better_code_review_graph.tools._resolve_overlay_rules_dir",
+        lambda: None,
+    )
+    payload = security_rule_list(engine="semgrep")
+    assert payload["engine"] == "semgrep"
+    assert payload["rules"] == []
+    assert "note" in payload
+
+
+# ---------------------------------------------------------------------------
+# Suppression persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def test_load_suppressions_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    assert _load_suppressions(tmp_path) == set()
+
+
+def test_load_suppressions_handles_corrupt_file(tmp_path: Path) -> None:
+    sup_path = tmp_path / ".code-review-graph" / "security-suppressions.json"
+    sup_path.parent.mkdir(parents=True, exist_ok=True)
+    sup_path.write_text("not-json", encoding="utf-8")
+    assert _load_suppressions(tmp_path) == set()
+
+
+def test_load_suppressions_rejects_non_list_payload(tmp_path: Path) -> None:
+    sup_path = tmp_path / ".code-review-graph" / "security-suppressions.json"
+    sup_path.parent.mkdir(parents=True, exist_ok=True)
+    sup_path.write_text('{"not": "a list"}', encoding="utf-8")
+    assert _load_suppressions(tmp_path) == set()
+
+
+def test_security_scan_semgrep_filters_suppressed_tag(tmp_path: Path) -> None:
+    """Suppressed rule_id is dropped from semgrep tags_by_node bucket."""
+    root, _ = _make_repo_with_node(tmp_path)
+    _save_suppressions(root, ["semgrep-rule-x"])
+    suppressed_tag = Tag(
+        rule_id="semgrep-rule-x",
+        severity="MEDIUM",
+        message="suppressed",
+        line=1,
+    )
+    surviving_tag = Tag(
+        rule_id="semgrep-rule-y",
+        severity="HIGH",
+        message="not suppressed",
+        line=2,
+    )
+
+    class _FakeScanner:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def scan_path(self, target):
+            return SemgrepResult(
+                tags=[suppressed_tag, surviving_tag],
+                raw_output="{}",
+            )
+
+    with patch("better_code_review_graph.tools.SemgrepScanner", new=_FakeScanner):
+        payload = security_scan(repo_root=str(root), engine="semgrep")
+    assert payload["total"] == 1
+    assert "semgrep-rule-y" in payload["by_rule"]
+    assert "semgrep-rule-x" not in payload["by_rule"]
+
+
+def test_load_last_scan_returns_none_when_missing(tmp_path: Path) -> None:
+    assert _load_last_scan(tmp_path) is None
+
+
+def test_load_last_scan_handles_corrupt_file(tmp_path: Path) -> None:
+    cache_path = tmp_path / ".code-review-graph" / "security-last-scan.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text("{not json", encoding="utf-8")
+    assert _load_last_scan(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Server-level ``security`` action dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_server_security_tool_dispatches_scan(tmp_path: Path) -> None:
+    from better_code_review_graph.server import security as security_tool
+
+    root, _ = _make_repo_with_node(tmp_path)
+    raw = security_tool(action="scan", repo_root=str(root))
+    payload = json.loads(raw)
+    assert payload["engine"] == "heuristic"
+    assert payload["total"] >= 1
+
+
+def test_server_security_tool_dispatches_report(tmp_path: Path) -> None:
+    from better_code_review_graph.server import security as security_tool
+
+    root, _ = _make_repo_with_node(tmp_path)
+    security_scan(repo_root=str(root))
+    sarif_raw = security_tool(action="report", repo_root=str(root), format="sarif")
+    sarif = json.loads(sarif_raw)
+    assert sarif["version"] == "2.1.0"
+
+
+def test_server_security_tool_dispatches_suppress(tmp_path: Path) -> None:
+    from better_code_review_graph.server import security as security_tool
+
+    root, _ = _make_repo_with_node(tmp_path)
+    raw = security_tool(action="suppress", repo_root=str(root), rule_id="cwe-89")
+    payload = json.loads(raw)
+    assert payload["rule_id"] == "cwe-89"
+    assert payload["suppressed"] is True
+
+
+def test_server_security_tool_dispatches_rule_list(tmp_path: Path) -> None:
+    from better_code_review_graph.server import security as security_tool
+
+    raw = security_tool(action="rule_list", engine="heuristic")
+    payload = json.loads(raw)
+    assert payload["engine"] == "heuristic"
+    assert payload["rules"]
+
+
+def test_server_security_tool_invalid_action_returns_error() -> None:
+    from better_code_review_graph.server import security as security_tool
+
+    raw = security_tool(action="bogus")
+    payload = json.loads(raw)
+    assert "error" in payload
+    assert "bogus" in payload["error"]


### PR DESCRIPTION
## Summary
- New MCP tool `security` with 4 actions:
  - `scan` — run heuristic (default) or semgrep engine, return aggregated tags + persist to `nodes.security_tags`.
  - `report` — re-emit cached last scan in JSON or SARIF v2.1.0 format.
  - `suppress` — add/remove rule_id from persistent `.code-review-graph/security-suppressions.json`.
  - `rule_list` — enumerate active rules per engine.
- Heuristic engine fetches Function/Class/Method nodes with source_text via direct SQL.
- Semgrep engine wrapped — gracefully returns error when CLI not installed (`[security]` extra missing).
- SARIF output with severity → level mapping (CRITICAL/HIGH→error, MEDIUM→warning, LOW→note).
- Suppressions filtered before tags are bucketed.
- Last-scan cached at `.code-review-graph/security-last-scan.json` for `report` action.

This is **Phase 3 Task 5 of 12** (epic #326). Tier 1 + Tier 2 + suppression list + persistent tags now reachable through one MCP tool.

## Test plan
- [x] `pytest tests/test_security_tool.py -v`: 28 passed (15 spec + 5 server dispatch + 8 edge cases).
- [x] `pytest --cov-fail-under=95 -q`: 1065 passed, coverage 95.36%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## Files
- Modified: `src/better_code_review_graph/tools.py` (4 functions + 7 helpers + `_NodeView` adapter), `src/better_code_review_graph/server.py` (security MCP dispatcher).
- Created: `tests/test_security_tool.py` (28 tests).

## Out of scope
- Tasks 6-7: 005_temporal_columns BREAKING + 006_commits_table.
- Task 8: TemporalIndex.
- Task 9: as_of/diff cross-cutting params.
- Task 10: review.delta line shifts.
- Tasks 11-12: docs + release dry-run.