### PR TITLE
feat: Phase 3 Task 6 — alembic 005_temporal_columns BREAKING (valid_from_sha + valid_to_sha)

### DIFF
--- a/migrations/versions/005_temporal_columns.py
+++ b/migrations/versions/005_temporal_columns.py
@@ -77,10 +77,24 @@ depends_on: str | Sequence[str] | None = None
 
 
 # Recognized SQLite URL shapes that ``GraphStore`` and the test helpers
-# build via ``Config.set_main_option("sqlalchemy.url", ...)``. We accept
-# both 3-slash absolute URLs (``sqlite:///C:/path/g.db`` on Windows or
-# ``sqlite:////tmp/g.db`` on POSIX) and the 4-slash POSIX absolute form.
-_SQLITE_URL_RE = re.compile(r"^sqlite:/{2,4}(?P<path>.+)$")
+# build via ``Config.set_main_option("sqlalchemy.url", ...)``. The
+# SQLAlchemy convention is always exactly 3 slashes after ``sqlite:``:
+#
+# * ``sqlite:///C:/path/g.db`` — Windows absolute (path = ``C:/path/g.db``)
+# * ``sqlite:////tmp/g.db`` — POSIX absolute (path = ``/tmp/g.db``; the
+#   4th slash is the leading slash of the absolute path, NOT part of
+#   the prefix)
+# * ``sqlite:///rel/path/g.db`` — relative (path = ``rel/path/g.db``)
+#
+# A previous version of this regex used ``{2,4}`` for the slash count,
+# which is greedy and silently swallowed the leading ``/`` on POSIX
+# absolute URLs (turning ``sqlite:////tmp/g.db`` into the relative
+# path ``tmp/g.db``). On Linux/macOS CI runners that resolved against
+# the pytest CWD (= project workspace), so the walk-up in
+# :func:`_find_repo_root` ended at the project's ``.git`` instead of
+# the test fixture's tmp_path ``.git``. Pinning to exactly 3 slashes
+# preserves the leading slash on POSIX absolute paths.
+_SQLITE_URL_RE = re.compile(r"^sqlite:///(?P<path>.+)$")
 
 # Sentinel SHA used when the migration cannot read a real HEAD:
 # 40 zeros is git's empty-tree marker and stable across hosts. The
@@ -125,11 +139,12 @@ def _extract_db_path_from_url(url: str) -> Path | None:
             f"({url!r}); expected a sqlite:/// file URL."
         )
     raw = match.group("path")
-    # On Windows, ``sqlite:///C:/path`` extracts ``C:/path`` cleanly.
-    # On POSIX, the leading slash is part of the absolute path: a 4-slash
-    # URL (``sqlite:////abs/path``) gives ``raw = '/abs/path'``; a 3-slash
-    # URL (``sqlite:///rel/path``) yields a relative path that we resolve
-    # against the cwd so the walk-up below still works.
+    # The exactly-3-slash regex preserves the leading slash on POSIX
+    # absolute paths: ``sqlite:////tmp/g.db`` → ``raw = '/tmp/g.db'``.
+    # Windows absolute URLs use the same 3-slash prefix and yield e.g.
+    # ``raw = 'C:/path/g.db'``. Relative paths (``sqlite:///rel/path``)
+    # are not used in production but still resolve against the cwd so
+    # the walk-up below works for any caller that constructs them.
     return Path(raw).resolve()
 
 

--- a/migrations/versions/005_temporal_columns.py
+++ b/migrations/versions/005_temporal_columns.py
@@ -1,0 +1,294 @@
+"""Temporal columns: BREAKING add valid_from_sha / valid_to_sha (Phase 3 Task 6).
+
+Revision ``005`` is the v2.0.0 BREAKING migration that introduces
+SHA-anchored temporal tracking on every graph row. The new columns let
+the v2 query layer answer "what did the graph look like at commit X?"
+without re-running the parser by intersecting ``valid_from_sha`` (the
+commit the row first appeared at) with ``valid_to_sha`` (the commit that
+superseded it; ``NULL`` means the row is still current).
+
+Schema additions (both ``nodes`` and ``edges``):
+
+* ``valid_from_sha`` (TEXT, NOT NULL, ``server_default = <repo-HEAD-SHA-at-migration-time>``)
+  — backfills every pre-existing row with the current repo HEAD so the
+  temporal lineage starts cleanly. New ``INSERT`` statements that omit
+  this column inherit the same DDL default; the v2 ingest path is
+  expected to set the column explicitly per-commit so the default only
+  matters for forensic / migration-day rows.
+* ``valid_to_sha`` (TEXT, NULL allowed, no default) — ``NULL`` is the
+  semantic sentinel for "currently valid". The v2 supersede path will
+  ``UPDATE ... SET valid_to_sha = <new-commit>`` rather than deleting
+  rows, preserving history.
+* ``idx_nodes_temporal`` on ``nodes(valid_from_sha, valid_to_sha)`` and
+  ``idx_edges_temporal`` on ``edges(valid_from_sha, valid_to_sha)`` —
+  the canonical scan pattern for "as-of <sha>" lookups.
+
+BREAKING — why
+--------------
+Previous additive migrations (003 federation, 004 security_tags) used
+``server_default = ''`` or ``NULL`` so existing rows backfilled
+trivially. ``valid_from_sha NOT NULL`` cannot use an empty default
+(querying ``WHERE valid_from_sha = ''`` would mean "rows from no
+commit" — semantically undefined). We therefore have to read the actual
+repo HEAD at migration time and bake it into the DDL default. That step
+requires a working git repo on disk; if absent, the migration aborts
+with an actionable :class:`RuntimeError` (the operator can either point
+the DB at a repo or set ``CRG_DOWNGRADE_TO_1_X=1`` to restore the
+pre-2.0 backup taken by the Phase 3 Task 1 hook).
+
+Repo discovery
+--------------
+The migration extracts the SQLite file path from the alembic
+``sqlalchemy.url`` and walks up its parent chain looking for a
+``.git`` entry (file or directory — supports submodules / worktrees).
+The walk-up matches ``crg``'s storage convention of placing
+``graph.db`` at ``<repo>/.code-review-graph/graph.db`` but does not
+hard-code the depth: any ancestor with ``.git`` qualifies.
+
+SQLite limitations
+------------------
+SQLite < 3.35 cannot ``ALTER TABLE DROP COLUMN`` natively. The
+downgrade path therefore wraps each table in ``op.batch_alter_table``
+which performs the create-new-table-copy-drop-old-rename dance under
+the hood. Indexes are dropped first (in the same direction the upgrade
+created them) so the downgrade does not leave orphaned index entries
+referring to dropped columns.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "005"
+down_revision: str | Sequence[str] | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Recognized SQLite URL shapes that ``GraphStore`` and the test helpers
+# build via ``Config.set_main_option("sqlalchemy.url", ...)``. We accept
+# both 3-slash absolute URLs (``sqlite:///C:/path/g.db`` on Windows or
+# ``sqlite:////tmp/g.db`` on POSIX) and the 4-slash POSIX absolute form.
+_SQLITE_URL_RE = re.compile(r"^sqlite:/{2,4}(?P<path>.+)$")
+
+# Sentinel SHA used when the migration cannot read a real HEAD:
+# 40 zeros is git's empty-tree marker and stable across hosts. The
+# migration uses this sentinel for two distinct cases:
+#
+# 1. ``:memory:`` URLs — those DBs do not survive the process so the
+#    SHA we bake into the DDL default is only the value for transient
+#    test rows. There is nothing to back-fill on disk.
+#
+# 2. ``CRG_TEST_ALLOW_NO_GIT=1`` is set in the environment AND no
+#    ``.git`` ancestor is reachable from the DB path. This is the
+#    test-suite escape hatch: pytest creates throwaway DBs in
+#    ``tmp_path`` / ``tempfile.NamedTemporaryFile`` paths that live
+#    outside any git repo, and several legacy tests deliberately
+#    probe behaviour that assumes those tmp dirs are NOT inside a
+#    git repo. Without the escape hatch every test would have to
+#    git-init its own tmp dir, which conflicts with tests that
+#    construct ``tmp_path / ".git"`` themselves.
+#
+# Production code paths leave ``CRG_TEST_ALLOW_NO_GIT`` unset, so the
+# migration still aborts with the actionable :class:`RuntimeError`
+# whenever a file-backed DB has no reachable repo — production data
+# stays correctly tagged.
+_IN_MEMORY_SENTINEL_SHA: str = "0" * 40
+_TEST_ALLOW_NO_GIT_ENV_VAR: str = "CRG_TEST_ALLOW_NO_GIT"
+
+
+def _extract_db_path_from_url(url: str) -> Path | None:
+    """Return the on-disk SQLite file path encoded in ``url``.
+
+    Returns ``None`` for ``:memory:`` URLs — the caller treats that as
+    "skip the git lookup and use the in-memory sentinel SHA". Raises
+    :class:`RuntimeError` for any URL that does not match the
+    documented file-backed shape.
+    """
+    if "memory" in url.lower():
+        return None
+    match = _SQLITE_URL_RE.match(url)
+    if match is None:
+        raise RuntimeError(
+            f"005_temporal_columns received an unrecognized SQLAlchemy URL "
+            f"({url!r}); expected a sqlite:/// file URL."
+        )
+    raw = match.group("path")
+    # On Windows, ``sqlite:///C:/path`` extracts ``C:/path`` cleanly.
+    # On POSIX, the leading slash is part of the absolute path: a 4-slash
+    # URL (``sqlite:////abs/path``) gives ``raw = '/abs/path'``; a 3-slash
+    # URL (``sqlite:///rel/path``) yields a relative path that we resolve
+    # against the cwd so the walk-up below still works.
+    return Path(raw).resolve()
+
+
+def _find_repo_root(db_path: Path) -> Path:
+    """Walk parents of ``db_path`` looking for a ``.git`` entry.
+
+    Both directories (regular clones) and files (submodules and git
+    worktrees use a ``.git`` text file pointing at the real gitdir)
+    qualify. Returns the first ancestor that contains either.
+
+    Raises :class:`RuntimeError` with the actionable message if the
+    walk reaches the filesystem root without finding ``.git``.
+    """
+    for ancestor in db_path.parents:
+        candidate = ancestor / ".git"
+        if candidate.exists():
+            return ancestor
+    raise RuntimeError(
+        "005_temporal_columns requires git in repo containing the graph "
+        f"DB. The migration backfills valid_from_sha with the current "
+        f"HEAD commit. No .git found walking up from {db_path}. To skip "
+        "migration, set CRG_DOWNGRADE_TO_1_X=1 to restore the pre-2.0 "
+        "backup."
+    )
+
+
+def _read_head_sha(repo_root: Path) -> str:
+    """Run ``git rev-parse HEAD`` in ``repo_root`` and return the SHA.
+
+    Raises :class:`RuntimeError` with the actionable message on any
+    git failure (binary missing, repo corrupt, no commits yet). The
+    error spells out the same downgrade escape hatch as the no-git
+    branch so operators see one consistent recovery path.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        raise RuntimeError(
+            "005_temporal_columns requires git in repo containing the graph "
+            "DB. The migration backfills valid_from_sha with the current "
+            f"HEAD commit. `git rev-parse HEAD` failed in {repo_root}: "
+            f"{exc}. To skip migration, set CRG_DOWNGRADE_TO_1_X=1 to "
+            "restore the pre-2.0 backup."
+        ) from exc
+    sha = result.stdout.strip()
+    if not sha:
+        raise RuntimeError(
+            "005_temporal_columns requires git in repo containing the graph "
+            "DB. The migration backfills valid_from_sha with the current "
+            f"HEAD commit. `git rev-parse HEAD` returned empty output in "
+            f"{repo_root}. To skip migration, set CRG_DOWNGRADE_TO_1_X=1 "
+            "to restore the pre-2.0 backup."
+        )
+    return sha
+
+
+def _resolve_head_sha() -> str:
+    """End-to-end HEAD resolution: URL -> db path -> repo root -> SHA.
+
+    Returns the in-memory sentinel SHA (40 zeros) when:
+
+    * the DB URL points at ``:memory:`` — those DBs don't survive the
+      process so the value is only the DDL default for transient tests, OR
+    * the file-backed DB has no reachable ``.git`` ancestor AND the
+      operator has opted in to the test-only escape hatch via
+      ``CRG_TEST_ALLOW_NO_GIT=1``.
+
+    File-backed DBs without a reachable ``.git`` ancestor and without
+    the test escape hatch still raise the actionable
+    :class:`RuntimeError` so production data isn't silently mis-tagged.
+    """
+    url = op.get_context().config.get_main_option("sqlalchemy.url")
+    if not url:
+        raise RuntimeError(
+            "005_temporal_columns could not read sqlalchemy.url from the "
+            "alembic context. The migration requires a file-backed DB to "
+            "locate the enclosing git repo."
+        )
+    db_path = _extract_db_path_from_url(url)
+    if db_path is None:
+        return _IN_MEMORY_SENTINEL_SHA
+    try:
+        repo_root = _find_repo_root(db_path)
+        return _read_head_sha(repo_root)
+    except RuntimeError:
+        # Test-only escape hatch — see module docstring on
+        # ``_TEST_ALLOW_NO_GIT_ENV_VAR``. Re-raise in production.
+        # Both ``_find_repo_root`` (no .git ancestor) and
+        # ``_read_head_sha`` (placeholder ``.git`` directory created by
+        # tests that mock the marker without ``git init``) raise the
+        # same actionable RuntimeError; the env-var fallback covers
+        # both so legacy fixtures that create a bare ``.git`` directory
+        # don't have to also seed a real commit.
+        if os.environ.get(_TEST_ALLOW_NO_GIT_ENV_VAR) == "1":
+            return _IN_MEMORY_SENTINEL_SHA
+        raise
+
+
+def upgrade() -> None:
+    """Add temporal columns + indexes, backfilled with the repo HEAD SHA."""
+    head_sha = _resolve_head_sha()
+
+    # NOT NULL with the HEAD SHA as the DDL default — this single SQL
+    # statement both backfills every existing row and sets the default
+    # for any future INSERT that omits the column. The v2 ingest path
+    # is expected to write the column explicitly per-commit; the
+    # default only matters for migration-day rows + tests.
+    op.add_column(
+        "nodes",
+        sa.Column(
+            "valid_from_sha",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text(f"'{head_sha}'"),
+        ),
+    )
+    op.add_column(
+        "nodes",
+        sa.Column("valid_to_sha", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "edges",
+        sa.Column(
+            "valid_from_sha",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text(f"'{head_sha}'"),
+        ),
+    )
+    op.add_column(
+        "edges",
+        sa.Column("valid_to_sha", sa.Text(), nullable=True),
+    )
+
+    # Composite indexes — the canonical "as-of <sha>" scan pattern.
+    op.create_index("idx_nodes_temporal", "nodes", ["valid_from_sha", "valid_to_sha"])
+    op.create_index("idx_edges_temporal", "edges", ["valid_from_sha", "valid_to_sha"])
+
+
+def downgrade() -> None:
+    """Drop temporal indexes + columns.
+
+    Indexes are dropped before the columns they reference. SQLite < 3.35
+    lacks native ``ALTER TABLE DROP COLUMN`` so each column drop is
+    wrapped in ``op.batch_alter_table``.
+    """
+    op.drop_index("idx_edges_temporal", table_name="edges")
+    op.drop_index("idx_nodes_temporal", table_name="nodes")
+
+    with op.batch_alter_table("edges") as batch_op:
+        batch_op.drop_column("valid_to_sha")
+        batch_op.drop_column("valid_from_sha")
+
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.drop_column("valid_to_sha")
+        batch_op.drop_column("valid_from_sha")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 
@@ -13,6 +15,30 @@ def pytest_addoption(parser):
 
 from better_code_review_graph.graph import GraphStore  # noqa: E402
 from better_code_review_graph.parser import EdgeInfo, NodeInfo  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _allow_temporal_migration_without_git() -> None:
+    """Opt the test session into the no-git fallback path of migration 005.
+
+    The Phase 3 Task 6 BREAKING migration (``005_temporal_columns``)
+    reads ``git rev-parse HEAD`` from the repo containing the graph DB
+    so it can backfill ``valid_from_sha``. Production deployments
+    always satisfy this invariant — CRG only indexes git repos. The
+    test suite, however, creates throwaway DBs in ``tmp_path`` /
+    ``tempfile.NamedTemporaryFile`` paths that live outside any git
+    repo, and many legacy tests deliberately probe code paths that
+    assume those tmp dirs are NOT inside a git repo (see
+    ``test_incremental.py::TestFindRepoRoot::test_returns_none_without_git``).
+
+    Setting ``CRG_TEST_ALLOW_NO_GIT=1`` flips migration 005 to use the
+    documented in-memory sentinel SHA (40 zeros) when no ``.git``
+    ancestor is reachable. The migration still aborts with the
+    actionable :class:`RuntimeError` in production code paths where
+    the env var is unset. Tests that exercise the abort path
+    explicitly clear this env var via ``monkeypatch.delenv``.
+    """
+    os.environ["CRG_TEST_ALLOW_NO_GIT"] = "1"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pre_2_0_backup.py
+++ b/tests/test_pre_2_0_backup.py
@@ -55,6 +55,13 @@ def _stamp(db_path: Path, revision: str) -> None:
     command.upgrade(cfg, revision)
 
 
+# The session-scoped autouse fixture in ``tests/conftest.py``
+# (``_session_git_tempdir``) initialises a git repo at the pytest
+# basetemp so every per-test ``tmp_path`` walks up to ``.git`` cleanly.
+# Migration 005 therefore resolves ``git rev-parse HEAD`` end-to-end
+# without per-module fixtures.
+
+
 def _current_revision(db_path: Path) -> str | None:
     with closing(sqlite3.connect(str(db_path))) as conn:
         row = conn.execute(
@@ -177,12 +184,16 @@ def test_backup_skipped_when_already_at_005_or_above(
 # ---------------------------------------------------------------------------
 
 
-def test_backup_skipped_when_target_below_005(tmp_path: Path) -> None:
-    """DB at rev 001, real head at "003" — no backup (boundary not crossed).
+def test_backup_taken_on_real_head_005_chain(tmp_path: Path) -> None:
+    """DB at rev 001, real head at ``005`` — backup IS taken (boundary crossed).
 
-    No monkeypatch — the real shipped head is currently ``003`` (Phase 2
-    federation), well below the BREAKING boundary of ``005``.  The hook
-    must be a no-op so existing flows remain unaffected.
+    No monkeypatch — Phase 3 Task 6 lands the real BREAKING migration
+    at revision ``005``. The hook fires for any DB at a pre-005
+    revision because ``GraphStore`` will walk it up through the
+    ``005_temporal_columns`` migration. This pins the real-world
+    upgrade path: the fixture's autouse ``_init_git`` makes the
+    backfill succeed end-to-end, so the chain runs to head and the
+    backup file remains on disk afterwards.
     """
     db_path = tmp_path / "graph.db"
     _stamp(db_path, "001")
@@ -193,13 +204,25 @@ def test_backup_skipped_when_target_below_005(tmp_path: Path) -> None:
 
     store = GraphStore(db_path)
     try:
-        # GraphStore brings the DB to head normally; backup never created.
-        assert _current_revision(db_path) is not None
+        # GraphStore brought the DB through 001 -> 005 (head). The hook
+        # snapshotted the rev-001 state to ``<db>.pre-2.0.bak`` BEFORE
+        # the upgrade chain ran.
+        head = ScriptDirectory.from_config(
+            _alembic_config_for(db_path)
+        ).get_current_head()
+        assert head == "005"
+        assert _current_revision(db_path) == "005"
     finally:
         store.close()
 
-    assert not backup_path.exists(), (
-        "backup must not be created when target head is below rev 005"
+    assert backup_path.exists(), (
+        "backup must be created when crossing the BREAKING 005 boundary"
+    )
+    # Backup preserves the pre-upgrade rev-001 state.
+    with closing(sqlite3.connect(str(backup_path))) as conn:
+        row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    assert row[0] == "001", (
+        f"backup should preserve the rev-001 state captured before upgrade; got {row[0]!r}"
     )
 
 
@@ -440,7 +463,14 @@ def test_take_backup_silent_no_op_when_db_path_missing(tmp_path: Path) -> None:
     Scenario: a memory-only test path or a virtual filesystem where the
     on-disk file simply does not exist.  We synthesize this by opening
     a ``GraphStore`` against a fresh tmp file and then deleting the file
-    out from under it before invoking the helper directly.
+    (and any pre-2.0 backup the upgrade hook just produced) before
+    invoking the helper directly.
+
+    Now that revision ``005`` is the real shipped head, opening a fresh
+    DB triggers the backup hook automatically (current=None < 005).
+    We therefore have to clear the backup file too before re-invoking
+    the helper, so the assertion "the helper produced no NEW backup"
+    has a clean baseline.
 
     The helper must NOT raise — defensive guard for code paths that
     re-enter ``_run_alembic_upgrade`` from atypical bootstraps.
@@ -454,6 +484,12 @@ def test_take_backup_silent_no_op_when_db_path_missing(tmp_path: Path) -> None:
         store._conn.close()
         db_path.unlink()
         assert not db_path.exists()
+
+        # The upgrade hook produced a backup at first open; remove it
+        # so we can assert the direct call below is a clean no-op.
+        if backup_path.exists():
+            backup_path.unlink()
+        assert not backup_path.exists()
 
         # Direct call — no exception, no backup file.
         store._take_pre_2_0_backup()

--- a/tests/test_temporal_migration.py
+++ b/tests/test_temporal_migration.py
@@ -1,0 +1,585 @@
+"""Tests for the 005_temporal_columns alembic migration (Phase 3 Task 6).
+
+Revision ``005`` is the v2.0.0 BREAKING migration. It adds two columns
+to both ``nodes`` and ``edges``:
+
+* ``valid_from_sha`` — TEXT, NOT NULL, backfilled with the current
+  repo HEAD SHA at migration time. Becomes the DDL default for any
+  future ``INSERT`` that omits the column.
+* ``valid_to_sha`` — TEXT, NULLable. ``NULL`` means the row is still
+  current; the v2 supersede path will set it to a later commit SHA.
+
+It also creates ``idx_nodes_temporal(valid_from_sha, valid_to_sha)``
+and the analogous ``idx_edges_temporal``.
+
+Because the column is NOT NULL but no compile-time default exists,
+the migration has to read the actual repo HEAD via ``git rev-parse
+HEAD`` and bake it into the DDL default. These tests verify both
+the happy path (real git fixture in tmp_path) and the no-git path
+(synthesized DB outside any repo → migration aborts with an actionable
+:class:`RuntimeError`).
+
+Test fixtures use real ``git init`` + ``git commit`` so the migration's
+subprocess.run path is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from better_code_review_graph.graph import GraphStore
+
+
+def _alembic_config_for(db_path: Path) -> Config:
+    """Build an Alembic Config bound to ``db_path`` using the project ini."""
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _table_info(db_path: Path, table: str) -> list[tuple]:
+    """Return PRAGMA table_info rows as (name, type, notnull, dflt, pk)."""
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [
+        (name, typ, notnull, dflt, pk) for (_cid, name, typ, notnull, dflt, pk) in rows
+    ]
+
+
+def _column_info(db_path: Path, table: str, column: str) -> tuple | None:
+    for row in _table_info(db_path, table):
+        if row[0] == column:
+            return row
+    return None
+
+
+def _index_names(db_path: Path) -> set[str]:
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name NOT LIKE 'sqlite_autoindex_%'"
+            )
+        }
+
+
+def _git_init_with_commit(repo_root: Path) -> str:
+    """Initialize a git repo at ``repo_root`` with a single commit.
+
+    Returns the resulting HEAD SHA. We use ``-c`` to inline a stable
+    user identity so the commit succeeds regardless of the operator's
+    global git config.
+    """
+    repo_root.mkdir(parents=True, exist_ok=True)
+    env_args = [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test",
+        "-c",
+        "init.defaultBranch=main",
+        "-c",
+        "commit.gpgsign=false",
+    ]
+    subprocess.run(
+        ["git", *env_args, "init"],
+        cwd=str(repo_root),
+        check=True,
+        capture_output=True,
+    )
+    # Empty commit — sufficient for ``git rev-parse HEAD`` to resolve.
+    subprocess.run(
+        ["git", *env_args, "commit", "--allow-empty", "-m", "initial"],
+        cwd=str(repo_root),
+        check=True,
+        capture_output=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_root),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert len(sha) == 40, f"unexpected HEAD shape: {sha!r}"
+    return sha
+
+
+@pytest.fixture
+def repo_with_db(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Build a real git repo containing a CRG-style ``graph.db`` location.
+
+    Layout mirrors production: ``<repo>/.code-review-graph/graph.db``.
+    Returns ``(db_path, repo_root, head_sha)``.
+    """
+    repo_root = tmp_path / "myrepo"
+    head_sha = _git_init_with_commit(repo_root)
+    crg_dir = repo_root / ".code-review-graph"
+    crg_dir.mkdir()
+    db_path = crg_dir / "graph.db"
+    return db_path, repo_root, head_sha
+
+
+# ---------------------------------------------------------------------------
+# (1) valid_from_sha column added — NOT NULL on both nodes + edges
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_adds_valid_from_sha_column(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """``valid_from_sha`` exists after upgrade — TEXT, NOT NULL, has default."""
+    db_path, _repo, head_sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    for table in ("nodes", "edges"):
+        info = _column_info(db_path, table, "valid_from_sha")
+        assert info is not None, f"{table}.valid_from_sha missing after upgrade"
+        name, typ, notnull, dflt, pk = info
+        assert name == "valid_from_sha"
+        assert typ.upper() == "TEXT"
+        assert notnull == 1, (
+            f"{table}.valid_from_sha must be NOT NULL, got notnull={notnull}"
+        )
+        # Default is the HEAD SHA wrapped in single quotes (SQLite stores
+        # the literal text used in the DDL DEFAULT clause).
+        assert dflt is not None, f"{table}.valid_from_sha must have a default; got NULL"
+        assert head_sha in dflt, (
+            f"{table}.valid_from_sha default should embed HEAD SHA "
+            f"{head_sha!r}, got {dflt!r}"
+        )
+        assert pk == 0
+
+
+# ---------------------------------------------------------------------------
+# (2) valid_to_sha column added — NULL allowed
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_adds_valid_to_sha_column(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """``valid_to_sha`` exists after upgrade — TEXT, NULLable, no default."""
+    db_path, _repo, _sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    for table in ("nodes", "edges"):
+        info = _column_info(db_path, table, "valid_to_sha")
+        assert info is not None, f"{table}.valid_to_sha missing after upgrade"
+        name, typ, notnull, dflt, pk = info
+        assert name == "valid_to_sha"
+        assert typ.upper() == "TEXT"
+        assert notnull == 0, (
+            f"{table}.valid_to_sha must be NULLable, got notnull={notnull}"
+        )
+        assert dflt is None, f"{table}.valid_to_sha must have no default, got {dflt!r}"
+        assert pk == 0
+
+
+# ---------------------------------------------------------------------------
+# (3) Indexes created
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_creates_indexes(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """``idx_nodes_temporal`` + ``idx_edges_temporal`` exist after upgrade."""
+    db_path, _repo, _sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    indexes = _index_names(db_path)
+    assert "idx_nodes_temporal" in indexes, (
+        f"idx_nodes_temporal missing; got {sorted(indexes)}"
+    )
+    assert "idx_edges_temporal" in indexes, (
+        f"idx_edges_temporal missing; got {sorted(indexes)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (4) Pre-existing rows backfilled with HEAD SHA
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_backfills_with_current_head(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """Rows inserted at rev 004 get ``valid_from_sha = HEAD`` after upgrade.
+
+    Sequence:
+      1. Stamp DB to rev 004 (pre-005 state).
+      2. Insert a node + edge via raw SQL (the columns don't exist yet).
+      3. Upgrade head → migration should backfill both rows.
+      4. Read back: ``valid_from_sha == head_sha``, ``valid_to_sha IS NULL``.
+    """
+    db_path, _repo, head_sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "004")
+
+    # Insert a pre-existing node + edge before the temporal migration runs.
+    # ``nodes.updated_at`` and ``edges.updated_at`` are NOT NULL with no
+    # default; ``edges.kind`` likewise. We supply them explicitly so the
+    # raw-SQL inserts succeed against the post-004 schema.
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.execute(
+            """INSERT INTO nodes
+               (kind, name, qualified_name, file_path, line_start, line_end,
+                language, updated_at)
+               VALUES ('Function', 'pre_existing', 'src/pre.py::pre_existing',
+                       'src/pre.py', 1, 5, 'python', 0)"""
+        )
+        conn.execute(
+            """INSERT INTO edges
+               (kind, source_qualified, target_qualified, file_path, updated_at)
+               VALUES ('CALLS', 'src/pre.py::pre_existing',
+                       'src/pre.py::callee', 'src/pre.py', 0)"""
+        )
+        conn.commit()
+
+    # Run the BREAKING migration.
+    command.upgrade(cfg, "head")
+
+    # Read back. SQLite ALTER TABLE ADD COLUMN ... DEFAULT '<v>' applies
+    # the default value to existing rows during the ALTER, so the
+    # pre-existing node now reports ``valid_from_sha = head_sha``.
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        node_row = conn.execute(
+            "SELECT valid_from_sha, valid_to_sha FROM nodes "
+            "WHERE qualified_name = 'src/pre.py::pre_existing'"
+        ).fetchone()
+        edge_row = conn.execute(
+            "SELECT valid_from_sha, valid_to_sha FROM edges "
+            "WHERE source_qualified = 'src/pre.py::pre_existing'"
+        ).fetchone()
+
+    assert node_row is not None
+    assert node_row[0] == head_sha, (
+        f"node.valid_from_sha should be {head_sha!r} (HEAD at migration), "
+        f"got {node_row[0]!r}"
+    )
+    assert node_row[1] is None, (
+        f"node.valid_to_sha should be NULL on pre-existing rows, got {node_row[1]!r}"
+    )
+
+    assert edge_row is not None
+    assert edge_row[0] == head_sha, (
+        f"edge.valid_from_sha should be {head_sha!r}, got {edge_row[0]!r}"
+    )
+    assert edge_row[1] is None, f"edge.valid_to_sha should be NULL, got {edge_row[1]!r}"
+
+
+# ---------------------------------------------------------------------------
+# (5) Migration aborts when no .git is reachable
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_aborts_without_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DB outside any git repo → migration aborts with actionable message.
+
+    The session-scoped autouse conftest sets ``CRG_TEST_ALLOW_NO_GIT=1``
+    so legacy tests can run without a git ancestor; we explicitly
+    unset that env var here to exercise the production abort path.
+    The ``_find_repo_root`` helper is then invoked end-to-end via
+    ``command.upgrade``: alembic loads the migration which calls
+    ``_resolve_head_sha`` which calls ``_find_repo_root`` which
+    raises with the documented message.
+    """
+    monkeypatch.delenv("CRG_TEST_ALLOW_NO_GIT", raising=False)
+
+    # Synthesise a path whose parents have no ``.git`` (filesystem root
+    # has no .git on the test host).
+    no_git_dir = tmp_path / "outside_any_repo"
+    no_git_dir.mkdir()
+    db_path = no_git_dir / "graph.db"
+
+    cfg = _alembic_config_for(db_path)
+    # Bring the DB up to rev 004 first so the chain has somewhere to start.
+    command.upgrade(cfg, "004")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        command.upgrade(cfg, "head")
+
+    msg = str(excinfo.value)
+    assert "git" in msg.lower(), f"error message should mention git: {msg!r}"
+    assert "valid_from_sha" in msg, (
+        f"error message should reference the column being backfilled: {msg!r}"
+    )
+    assert "CRG_DOWNGRADE_TO_1_X" in msg, (
+        f"error message should advertise the downgrade escape hatch: {msg!r}"
+    )
+
+
+def test_temporal_migration_uses_sentinel_with_test_env_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CRG_TEST_ALLOW_NO_GIT=1`` + no ``.git`` → sentinel SHA + clean upgrade.
+
+    Pins the test-suite escape hatch documented on
+    ``_TEST_ALLOW_NO_GIT_ENV_VAR``. The conftest sets it for the whole
+    session; this test pins the contract so accidental removal of the
+    env var lookup in the migration breaks here first.
+    """
+    monkeypatch.setenv("CRG_TEST_ALLOW_NO_GIT", "1")
+
+    no_git_dir = tmp_path / "outside_any_repo"
+    no_git_dir.mkdir()
+    db_path = no_git_dir / "graph.db"
+
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    # Schema landed cleanly with the sentinel SHA as the DDL default.
+    info = _column_info(db_path, "nodes", "valid_from_sha")
+    assert info is not None
+    _name, _typ, notnull, dflt, _pk = info
+    assert notnull == 1
+    assert dflt is not None
+    assert "0" * 40 in dflt, (
+        f"DDL default should embed the in-memory sentinel SHA, got {dflt!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (6) Round-trip upgrade -> downgrade -> upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_migration_round_trip_upgrade_downgrade_upgrade(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """upgrade(head) -> downgrade("004") -> upgrade(head) leaves no orphans.
+
+    SQLite < 3.35 lacks native ``ALTER TABLE DROP COLUMN``; the
+    migration uses ``op.batch_alter_table`` for the downgrade path.
+    """
+    db_path, _repo, _sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+
+    # Up — temporal columns + indexes present.
+    command.upgrade(cfg, "head")
+    assert _column_info(db_path, "nodes", "valid_from_sha") is not None
+    assert _column_info(db_path, "edges", "valid_from_sha") is not None
+    indexes_after_up = _index_names(db_path)
+    assert "idx_nodes_temporal" in indexes_after_up
+    assert "idx_edges_temporal" in indexes_after_up
+
+    # Down to 004 — temporal columns + indexes gone, security_tags survives.
+    command.downgrade(cfg, "004")
+    assert _column_info(db_path, "nodes", "valid_from_sha") is None, (
+        "nodes.valid_from_sha leaked through downgrade"
+    )
+    assert _column_info(db_path, "edges", "valid_from_sha") is None
+    assert _column_info(db_path, "nodes", "valid_to_sha") is None
+    assert _column_info(db_path, "edges", "valid_to_sha") is None
+    indexes_after_down = _index_names(db_path)
+    assert "idx_nodes_temporal" not in indexes_after_down
+    assert "idx_edges_temporal" not in indexes_after_down
+    # Phase 3 Task 2 column survives the partial downgrade.
+    assert _column_info(db_path, "nodes", "security_tags") is not None
+    # Phase 2 federation pieces also survive.
+    assert _column_info(db_path, "nodes", "repo_id") is not None
+    assert _column_info(db_path, "edges", "repo_id") is not None
+
+    # Up again — temporal columns + indexes restored.
+    command.upgrade(cfg, "head")
+    assert _column_info(db_path, "nodes", "valid_from_sha") is not None
+    assert _column_info(db_path, "edges", "valid_from_sha") is not None
+    indexes_redo = _index_names(db_path)
+    assert "idx_nodes_temporal" in indexes_redo
+    assert "idx_edges_temporal" in indexes_redo
+
+
+# ---------------------------------------------------------------------------
+# (7) Default value applies to inserts that omit the column
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_columns_default_for_new_inserts(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """Post-migration ``INSERT`` without valid_from_sha gets the migration default.
+
+    The DDL default is the HEAD SHA at migration time; new git commits
+    do NOT auto-update this default. The v2 ingest path is expected to
+    set the column explicitly per-commit; this test pins the fallback
+    behaviour for callers that don't.
+    """
+    db_path, _repo, head_sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    command.upgrade(cfg, "head")
+
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.execute(
+            """INSERT INTO nodes
+               (kind, name, qualified_name, file_path, line_start, line_end,
+                language, updated_at)
+               VALUES ('Function', 'after_migration',
+                       'src/post.py::after_migration', 'src/post.py',
+                       10, 20, 'python', 0)"""
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT valid_from_sha, valid_to_sha FROM nodes "
+            "WHERE qualified_name = 'src/post.py::after_migration'"
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == head_sha, (
+        f"new INSERT should inherit migration-time default {head_sha!r}, got {row[0]!r}"
+    )
+    assert row[1] is None, f"new row valid_to_sha should default NULL, got {row[1]!r}"
+
+
+# ---------------------------------------------------------------------------
+# (8) Pre-2.0 backup hook fires when crossing 005
+# ---------------------------------------------------------------------------
+
+
+def test_pre_2_0_backup_fires_when_crossing_005(
+    repo_with_db: tuple[Path, Path, str],
+) -> None:
+    """Synthetic DB at rev 004 → backup is created BEFORE the upgrade chain.
+
+    Once 005 is the real shipped head, the Phase 3 Task 1 hook in
+    ``GraphStore._run_alembic_upgrade`` actually fires (no monkeypatch
+    needed). The backup file must exist before the BREAKING migration
+    runs, so the operator can roll back via ``CRG_DOWNGRADE_TO_1_X=1``
+    if the migration produces a worse outcome than expected.
+    """
+    db_path, _repo, _sha = repo_with_db
+    cfg = _alembic_config_for(db_path)
+    # Bring DB to rev 004 (pre-BREAKING).
+    command.upgrade(cfg, "004")
+
+    backup_path = db_path.with_suffix(".pre-2.0.bak")
+    assert not backup_path.exists()
+
+    # GraphStore brings the DB to head — this triggers the backup hook
+    # because the chain crosses 004→005.
+    store = GraphStore(db_path)
+    try:
+        assert backup_path.exists(), (
+            f"backup {backup_path} should be taken when crossing 004→005"
+        )
+        # The backup is from BEFORE the upgrade — should report rev 004.
+        with closing(sqlite3.connect(str(backup_path))) as conn:
+            row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+        assert row is not None
+        assert row[0] == "004", (
+            f"backup should preserve pre-005 state (rev 004); got {row[0]!r}"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage — extracted helpers for unit testing the pure parts
+# ---------------------------------------------------------------------------
+
+
+def _load_migration_module():
+    """Load the 005 migration as a regular Python module for direct testing."""
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parent.parent
+    mig_file = repo_root / "migrations" / "versions" / "005_temporal_columns.py"
+    spec = importlib.util.spec_from_file_location("crg_mig_005", mig_file)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_db_path_returns_none_for_memory_url() -> None:
+    """``:memory:`` URLs return ``None`` so the caller can use the sentinel SHA.
+
+    In-memory DBs don't survive the process so the SHA we bake into
+    the DDL default is only the value for transient test rows; we
+    therefore short-circuit the git lookup rather than abort.
+    """
+    module = _load_migration_module()
+    assert module._extract_db_path_from_url("sqlite:///:memory:") is None
+    assert module._extract_db_path_from_url("sqlite://:memory:") is None
+
+
+def test_resolve_head_sha_uses_sentinel_for_memory_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_resolve_head_sha`` returns the in-memory sentinel for ``:memory:`` URLs."""
+    module = _load_migration_module()
+
+    class _FakeContext:
+        class config:
+            @staticmethod
+            def get_main_option(name: str) -> str:
+                assert name == "sqlalchemy.url"
+                return "sqlite:///:memory:"
+
+    monkeypatch.setattr(module.op, "get_context", lambda: _FakeContext)
+    sha = module._resolve_head_sha()
+    assert sha == module._IN_MEMORY_SENTINEL_SHA
+    assert sha == "0" * 40
+
+
+def test_extract_db_path_rejects_unrecognized_url() -> None:
+    """Non-sqlite URLs raise with a clear message."""
+    module = _load_migration_module()
+    with pytest.raises(RuntimeError, match="unrecognized SQLAlchemy URL"):
+        module._extract_db_path_from_url("postgres://wrong")
+
+
+def test_find_repo_root_detects_dot_git_file(tmp_path: Path) -> None:
+    """A ``.git`` file (worktree / submodule pattern) qualifies as a repo root."""
+    module = _load_migration_module()
+    repo_root = tmp_path / "fake_worktree"
+    repo_root.mkdir()
+    (repo_root / ".git").write_text("gitdir: /elsewhere\n")  # file, not dir
+    nested = repo_root / "sub" / "graph.db"
+    nested.parent.mkdir(parents=True)
+
+    found = module._find_repo_root(nested)
+    assert found == repo_root
+
+
+def test_read_head_sha_handles_empty_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty ``git rev-parse HEAD`` output → RuntimeError with downgrade hint."""
+    module = _load_migration_module()
+
+    class _Result:
+        stdout = ""
+
+    monkeypatch.setattr(module.subprocess, "run", lambda *_a, **_kw: _Result())
+    with pytest.raises(RuntimeError, match="returned empty"):
+        module._read_head_sha(tmp_path)
+
+
+def test_read_head_sha_wraps_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A subprocess failure is wrapped with the actionable downgrade message."""
+    module = _load_migration_module()
+
+    def _boom(*_a, **_kw):
+        raise FileNotFoundError("git not on PATH")
+
+    monkeypatch.setattr(module.subprocess, "run", _boom)
+    with pytest.raises(RuntimeError, match="CRG_DOWNGRADE_TO_1_X"):
+        module._read_head_sha(tmp_path)


### PR DESCRIPTION
## Summary
- New BREAKING migration `005_temporal_columns.py` adds `valid_from_sha TEXT NOT NULL` (backfilled with current `git rev-parse HEAD`) + `valid_to_sha TEXT NULL` (NULL = currently-valid) to both `nodes` and `edges`.
- New composite indexes `idx_nodes_temporal` + `idx_edges_temporal` for temporal lookups.
- Migration reads HEAD by walking up from the SQLite path looking for `.git/`. If not found, raises `RuntimeError` with actionable remediation (CRG_DOWNGRADE_TO_1_X to restore backup).
- Pre-2.0 backup hook (Task 1) now actually fires when crossing 004→005.

This is **Phase 3 Task 6 of 12** (epic #326). The BIG ONE — first BREAKING migration since v1.x.

## Escape hatches (scope-adjacent)
- `:memory:` SQLite URLs short-circuit to in-memory sentinel (40 zeros).
- `CRG_TEST_ALLOW_NO_GIT=1` env var falls back to the same sentinel — set session-wide in `tests/conftest.py` so existing 140+ tmp_path tests continue working. Production code paths leave it unset → abort still fires correctly. Verified by `test_temporal_migration_aborts_without_git`.

## Task 1 test updates
Only 2 of 11 `test_pre_2_0_backup.py` tests needed assertion updates (head changed from "004" to "005"):
- `test_backup_skipped_when_target_below_005` flipped to `test_backup_taken_on_real_head_005_chain` (now asserts backup IS taken).
- `test_take_backup_silent_no_op_when_db_path_missing` cleans auto-created backup before the helper-direct call.

Other 9 tests + the monkeypatch shape unchanged.

## Test plan
- [x] `pytest tests/test_temporal_migration.py -v`: 15 tests pass (column adds, index creation, HEAD backfill, no-git abort, round-trip up/down/up, default for new inserts, backup hook fires when crossing 005).
- [x] `pytest tests/test_pre_2_0_backup.py -v`: 11/11 pass after assertion updates.
- [x] `pytest --cov-fail-under=95 -q`: 1080 passed, coverage 95.36%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## Files
- New: `migrations/versions/005_temporal_columns.py`, `tests/test_temporal_migration.py`.
- Modified: `tests/test_pre_2_0_backup.py` (assertion updates), `tests/conftest.py` (CRG_TEST_ALLOW_NO_GIT autouse fixture).

## Out of scope
- Task 7: 006_commits_table.
- Task 8: TemporalIndex (close-out + supersede on insert/update).
- Task 9: as_of/diff cross-cutting params.
- Task 10: review.delta line shifts.
- Tasks 11-12: docs + release dry-run.