### PR TITLE
feat: Phase 3 Task 8 — TemporalIndex (close-out + supersede across commits)

### DIFF
--- a/src/better_code_review_graph/temporal.py
+++ b/src/better_code_review_graph/temporal.py
@@ -1,0 +1,454 @@
+"""Temporal index for the code knowledge graph (Phase 3 Task 8).
+
+Wraps :class:`GraphStore` upsert operations with close-out + supersede
+semantics across commits. The legacy ``GraphStore.upsert_node`` path uses
+``ON CONFLICT(qualified_name) DO UPDATE`` — overwriting in place, which
+loses history. :class:`TemporalIndex` instead preserves prior versions
+of every node by closing them out (``valid_to_sha = current_sha``) and
+inserting a fresh row when the source text diverges.
+
+The contract:
+
+* A node is identified by (``qualified_name``, ``repo_id``) at any point
+  in time.
+* Each row also has (``valid_from_sha``, ``valid_to_sha``) — when
+  ``valid_to_sha`` is NULL the row is currently-valid.
+* When the parser re-emits a node at a new commit:
+
+  * Source text diverged from the currently-valid row → close it out
+    (set ``valid_to_sha = current_sha``) and INSERT a new row with
+    ``valid_from_sha = current_sha``, ``valid_to_sha = NULL``.
+  * Source text unchanged → leave the existing row's ``valid_from_sha``
+    alone (the row is still the same logical version, we just observed
+    it again). Other scalar metadata (line numbers, file path,
+    ``repo_id``, …) is refreshed on the existing row.
+
+Edges follow the same shape but are keyed by
+(``source_qualified``, ``target_qualified``, ``kind``); they have no
+``source_text`` so the divergence branch does not apply — repeat
+observations are always treated as "unchanged" with metadata refresh.
+
+The index is opt-in for now and is NOT yet wired into the parser /
+incremental update paths; that's a follow-up task. Keeping it isolated
+lets the v2 query layer (which depends on the temporal columns Task 6
+landed) be exercised end-to-end without changing the legacy ingest
+surface for callers that still want the fast overwrite-in-place
+behaviour.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .graph import GraphStore
+    from .parser import EdgeInfo, NodeInfo
+
+
+@dataclass(frozen=True)
+class TemporalUpsertResult:
+    """Outcome of a single :meth:`TemporalIndex.upsert_node` /
+    :meth:`TemporalIndex.upsert_edge` call.
+
+    Attributes:
+        action: One of ``"inserted"`` (no prior currently-valid row,
+            fresh INSERT), ``"unchanged"`` (prior row found, source
+            identical or edge already present — metadata refreshed
+            in place), or ``"superseded"`` (prior row closed out,
+            new row INSERTed).
+        closed_out_count: Number of rows whose ``valid_to_sha`` was
+            set in this call. ``1`` on supersede, ``0`` otherwise —
+            exposed as a count rather than a bool so callers can sum
+            it across a scan to report "N rows closed at this commit".
+    """
+
+    action: str  # "inserted" | "superseded" | "unchanged"
+    closed_out_count: int
+
+
+def _hash_source(source_text: str | None) -> str:
+    """Stable hash for source-text equality comparison.
+
+    Matches the Phase 1 summarizer pattern: SHA-256 of the UTF-8
+    encoded source slice. Empty / ``None`` source text both collapse
+    to the empty string so two ``None``-source nodes (e.g. Class /
+    File rows that don't carry source) compare equal.
+    """
+    if not source_text:
+        return ""
+    return hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+
+
+class TemporalIndex:
+    """Temporal-aware upsert layer over :class:`GraphStore`.
+
+    A new instance is constructed per "commit being ingested" so the
+    ``current_sha`` carried by the index is unambiguous. Reusing the
+    same instance across commits would silently mis-attribute the
+    ``valid_from_sha`` / ``valid_to_sha`` writes — the constructor
+    therefore takes the SHA as a required keyword.
+
+    The index reaches into ``store._conn`` directly because the
+    public :class:`GraphStore` surface intentionally does not expose
+    raw temporal-aware INSERT/UPDATE — it's a back door used by the
+    v2 ingest path only.
+    """
+
+    def __init__(self, store: GraphStore, *, current_sha: str) -> None:
+        self._store = store
+        self._current_sha = current_sha
+        self._ensure_temporal_friendly_schema()
+
+    def _ensure_temporal_friendly_schema(self) -> None:
+        """Relax the legacy ``UNIQUE(qualified_name)`` constraint on ``nodes``.
+
+        The Phase 1 schema declared ``qualified_name TEXT NOT NULL UNIQUE``
+        because the legacy upsert path always overwrites in place. The
+        temporal supersede semantics introduced here REQUIRE multiple
+        rows to coexist with the same ``qualified_name`` — one currently-
+        valid row plus N historical rows — so the column-level UNIQUE
+        constraint must be lifted.
+
+        SQLite implements column-level UNIQUE via an auto-generated
+        index (``sqlite_autoindex_nodes_*``) that cannot be dropped
+        directly. The only way to remove it is a table rebuild:
+
+        1. Create ``nodes_new`` mirroring the current schema MINUS the
+           UNIQUE constraint, plus a partial unique index on
+           ``(qualified_name) WHERE valid_to_sha IS NULL`` so the
+           "exactly one currently-valid row per qualified_name"
+           invariant survives.
+        2. Copy data over.
+        3. Drop the old table; rename ``nodes_new`` to ``nodes``.
+        4. Recreate the secondary indexes (other than the autoindex).
+
+        Idempotent: a second call detects the absence of the autoindex
+        and short-circuits. Safe across alembic upgrades because the
+        partial unique index is created with ``IF NOT EXISTS``.
+        """
+        conn = self._store._conn
+
+        # Detect the legacy autoindex. If it's gone we already migrated.
+        legacy = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='nodes' "
+            "AND name LIKE 'sqlite_autoindex_nodes_%'"
+        ).fetchone()
+        if legacy is None:
+            # Already temporal-friendly; just make sure the partial
+            # unique index exists so re-runs converge to the same state.
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_qualified_active "
+                "ON nodes(qualified_name) WHERE valid_to_sha IS NULL"
+            )
+            conn.commit()
+            return
+
+        # Read existing column list verbatim — we want to mirror whatever
+        # alembic last left on the table (Phase 2/3 columns included).
+        cols_info = conn.execute("PRAGMA table_info(nodes)").fetchall()
+        col_names = [row[1] for row in cols_info]
+
+        # Build the new-table DDL. ``id`` keeps its PK + AUTOINCREMENT;
+        # ``qualified_name`` keeps NOT NULL but loses UNIQUE.
+        column_defs: list[str] = []
+        for cid, name, typ, notnull, dflt, pk in cols_info:  # noqa: B007
+            parts: list[str] = [name, typ or "TEXT"]
+            if pk:
+                parts.append("PRIMARY KEY AUTOINCREMENT")
+            if notnull and not pk:
+                parts.append("NOT NULL")
+            if dflt is not None:
+                parts.append(f"DEFAULT {dflt}")
+            column_defs.append(" ".join(parts))
+
+        # Drop conflicting helpers first so the rename succeeds without
+        # collisions on a re-run that aborted mid-way.
+        conn.execute("DROP TABLE IF EXISTS nodes_temporal_new")
+        conn.execute(f"CREATE TABLE nodes_temporal_new ({', '.join(column_defs)})")
+
+        col_list = ", ".join(col_names)
+        conn.execute(
+            f"INSERT INTO nodes_temporal_new ({col_list}) SELECT {col_list} FROM nodes"  # noqa: S608 — names from PRAGMA
+        )
+        conn.execute("DROP TABLE nodes")
+        conn.execute("ALTER TABLE nodes_temporal_new RENAME TO nodes")
+
+        # Recreate the secondary indexes on ``nodes``. We deliberately
+        # do NOT recreate the autoindex; the partial unique index below
+        # replaces it for the temporal-aware invariant.
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_file ON nodes(file_path)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_kind ON nodes(kind)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_qualified ON nodes(qualified_name)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_source_hash ON nodes(source_hash)"
+        )
+        if "repo_id" in col_names:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_nodes_repo_kind ON nodes(repo_id, kind)"
+            )
+        if "valid_from_sha" in col_names:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_nodes_temporal "
+                "ON nodes(valid_from_sha, valid_to_sha)"
+            )
+        # Partial unique index — at most one currently-valid row per
+        # qualified_name. Historical rows (valid_to_sha IS NOT NULL)
+        # are NOT covered, so multiple supersede generations coexist.
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_qualified_active "
+            "ON nodes(qualified_name) WHERE valid_to_sha IS NULL"
+        )
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    # Nodes
+    # ------------------------------------------------------------------
+
+    def upsert_node(
+        self,
+        node: NodeInfo,
+        file_hash: str = "",
+    ) -> TemporalUpsertResult:
+        """Insert or supersede a node row.
+
+        Returns a :class:`TemporalUpsertResult` describing which branch
+        was taken. The three branches:
+
+        * **No prior currently-valid row** → INSERT new with
+          ``valid_from_sha = current_sha``, ``valid_to_sha = NULL``.
+          Returns ``("inserted", 0)``.
+        * **Prior currently-valid row, source unchanged** → UPDATE other
+          fields in place but keep ``valid_from_sha``. Returns
+          ``("unchanged", 0)``.
+        * **Prior currently-valid row, source diverged** → close out
+          (``UPDATE ... SET valid_to_sha = current_sha``) AND INSERT
+          a new row. Returns ``("superseded", 1)``.
+
+        Args:
+            node: Parser-emitted :class:`NodeInfo`. Must carry
+                ``source_text`` for the divergence branch to be
+                meaningful; nodes without source text always collapse
+                to the "unchanged" branch on re-observation because
+                ``_hash_source`` returns the empty string for both.
+            file_hash: Optional file-content hash, propagated to the
+                ``file_hash`` column for incremental-build callers.
+        """
+        qualified = self._store._make_qualified(node)
+        new_hash = _hash_source(getattr(node, "source_text", "") or "")
+
+        # Find the currently-valid row, if any.
+        row = self._store._conn.execute(
+            "SELECT id, source_hash FROM nodes "
+            "WHERE qualified_name = ? AND valid_to_sha IS NULL",
+            (qualified,),
+        ).fetchone()
+
+        now = time.time()
+        if row is None:
+            # No prior currently-valid row → fresh insert.
+            self._insert_node_row(node, qualified, file_hash, new_hash, now)
+            self._store._conn.commit()
+            return TemporalUpsertResult(action="inserted", closed_out_count=0)
+
+        prior_id, prior_hash = row[0], row[1]
+        if prior_hash == new_hash:
+            # Source unchanged → keep valid_from_sha, refresh metadata.
+            self._store._conn.execute(
+                "UPDATE nodes SET kind=?, name=?, file_path=?, line_start=?, "
+                "line_end=?, language=?, parent_name=?, params=?, return_type=?, "
+                "modifiers=?, is_test=?, file_hash=?, extra=?, updated_at=?, "
+                "source_text=?, repo_id=? "
+                "WHERE id = ?",
+                (
+                    node.kind,
+                    node.name,
+                    node.file_path,
+                    node.line_start,
+                    node.line_end,
+                    node.language,
+                    node.parent_name,
+                    node.params,
+                    node.return_type,
+                    node.modifiers,
+                    int(node.is_test),
+                    file_hash,
+                    json.dumps(node.extra) if node.extra else "{}",
+                    now,
+                    getattr(node, "source_text", None),
+                    getattr(node, "repo_id", "") or "",
+                    prior_id,
+                ),
+            )
+            self._store._conn.commit()
+            return TemporalUpsertResult(action="unchanged", closed_out_count=0)
+
+        # Source diverged → close out + insert new.
+        self._store._conn.execute(
+            "UPDATE nodes SET valid_to_sha = ? WHERE id = ?",
+            (self._current_sha, prior_id),
+        )
+        self._insert_node_row(node, qualified, file_hash, new_hash, now)
+        self._store._conn.commit()
+        return TemporalUpsertResult(action="superseded", closed_out_count=1)
+
+    def _insert_node_row(
+        self,
+        node: NodeInfo,
+        qualified: str,
+        file_hash: str,
+        new_hash: str,
+        now: float,
+    ) -> None:
+        """Insert a new currently-valid node row at ``self._current_sha``.
+
+        Shared between the "no prior row" + "supersede" branches of
+        :meth:`upsert_node` so the column list lives in exactly one
+        place. ``valid_to_sha`` is always NULL at INSERT time — the
+        close-out path mutates it later via UPDATE.
+        """
+        self._store._conn.execute(
+            "INSERT INTO nodes "
+            "(kind, name, qualified_name, file_path, line_start, line_end, language, "
+            "parent_name, params, return_type, modifiers, is_test, file_hash, extra, "
+            "updated_at, source_text, source_hash, repo_id, valid_from_sha, valid_to_sha) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+            (
+                node.kind,
+                node.name,
+                qualified,
+                node.file_path,
+                node.line_start,
+                node.line_end,
+                node.language,
+                node.parent_name,
+                node.params,
+                node.return_type,
+                node.modifiers,
+                int(node.is_test),
+                file_hash,
+                json.dumps(node.extra) if node.extra else "{}",
+                now,
+                getattr(node, "source_text", None),
+                new_hash,
+                getattr(node, "repo_id", "") or "",
+                self._current_sha,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Edges
+    # ------------------------------------------------------------------
+
+    def upsert_edge(
+        self,
+        edge: EdgeInfo,
+        file_hash: str = "",  # noqa: ARG002 — kept for symmetry with upsert_node
+    ) -> TemporalUpsertResult:
+        """Insert or refresh an edge row.
+
+        Edges are keyed by (``source_qualified``, ``target_qualified``,
+        ``kind``). They carry no ``source_text`` so the supersede
+        branch does not apply: a repeat observation always lands in
+        the "unchanged" branch with a metadata refresh (line, extra,
+        repo_id). The branch tag is still useful — callers can
+        distinguish "first observation at this commit" (``inserted``)
+        from "edge was already there" (``unchanged``).
+        """
+        # Find the currently-valid row, if any.
+        row = self._store._conn.execute(
+            "SELECT id FROM edges "
+            "WHERE source_qualified = ? AND target_qualified = ? AND kind = ? "
+            "AND valid_to_sha IS NULL",
+            (edge.source, edge.target, edge.kind),
+        ).fetchone()
+
+        now = time.time()
+        if row is None:
+            self._store._conn.execute(
+                "INSERT INTO edges "
+                "(kind, source_qualified, target_qualified, file_path, line, extra, "
+                "updated_at, repo_id, valid_from_sha, valid_to_sha) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+                (
+                    edge.kind,
+                    edge.source,
+                    edge.target,
+                    edge.file_path,
+                    edge.line,
+                    json.dumps(edge.extra) if edge.extra else "{}",
+                    now,
+                    getattr(edge, "repo_id", "") or "",
+                    self._current_sha,
+                ),
+            )
+            self._store._conn.commit()
+            return TemporalUpsertResult(action="inserted", closed_out_count=0)
+        # Edge already exists at current state — refresh metadata in place.
+        # Edges don't have source_text divergence semantics; kind + endpoints
+        # define identity, so we never close-out + insert here.
+        self._store._conn.execute(
+            "UPDATE edges SET file_path = ?, line = ?, extra = ?, updated_at = ?, repo_id = ? "
+            "WHERE id = ?",
+            (
+                edge.file_path,
+                edge.line,
+                json.dumps(edge.extra) if edge.extra else "{}",
+                now,
+                getattr(edge, "repo_id", "") or "",
+                row[0],
+            ),
+        )
+        self._store._conn.commit()
+        return TemporalUpsertResult(action="unchanged", closed_out_count=0)
+
+    # ------------------------------------------------------------------
+    # File-scoped sweeps
+    # ------------------------------------------------------------------
+
+    def close_missing_nodes(
+        self,
+        file_path: str,
+        observed_qualified: set[str],
+    ) -> int:
+        """Close out currently-valid nodes for ``file_path`` not in ``observed_qualified``.
+
+        Used when re-parsing a file: any node previously visible in the
+        file but not produced by the new parse is treated as deleted —
+        close it out with ``valid_to_sha = current_sha``. The row is
+        not deleted from the table; historical queries can still find
+        it via ``WHERE valid_to_sha IS NOT NULL``.
+
+        Args:
+            file_path: The file being re-scanned.
+            observed_qualified: Qualified names produced by the current
+                parse of ``file_path``. Anything currently-valid in
+                ``file_path`` and NOT in this set is closed out.
+
+        Returns:
+            Number of nodes whose ``valid_to_sha`` was set in this call.
+        """
+        rows = self._store._conn.execute(
+            "SELECT id, qualified_name FROM nodes "
+            "WHERE file_path = ? AND valid_to_sha IS NULL",
+            (file_path,),
+        ).fetchall()
+        closed = 0
+        for row in rows:
+            row_id = row[0]
+            qualified = row[1]
+            if qualified not in observed_qualified:
+                self._store._conn.execute(
+                    "UPDATE nodes SET valid_to_sha = ? WHERE id = ?",
+                    (self._current_sha, row_id),
+                )
+                closed += 1
+        if closed:
+            self._store._conn.commit()
+        return closed

--- a/tests/test_temporal_index.py
+++ b/tests/test_temporal_index.py
@@ -1,0 +1,420 @@
+"""Tests for the TemporalIndex (Phase 3 Task 8).
+
+The temporal index wraps :class:`GraphStore` with close-out + supersede
+semantics across commits. Where the legacy ``upsert_node`` path uses
+``ON CONFLICT(qualified_name) DO UPDATE`` (overwriting in place, losing
+history), :class:`TemporalIndex.upsert_node` instead:
+
+* Inserts a new row when no currently-valid row exists for the
+  (qualified_name) key.
+* Leaves the existing row in place — only refreshing scalar metadata —
+  when the source text is unchanged. The ``valid_from_sha`` is NOT
+  rotated because the row is still the same logical version, just
+  re-observed.
+* Closes out the prior currently-valid row (sets
+  ``valid_to_sha = current_sha``) AND inserts a new row when the source
+  text diverges. The old row remains queryable as historical state.
+
+These tests pin those three branches plus the supporting machinery
+(``upsert_edge`` analogue, ``close_missing_nodes`` for file-scoped
+sweeping, repo_id propagation, and post-supersede history queries).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+from better_code_review_graph.temporal import TemporalIndex, TemporalUpsertResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+_SHA_C = "c" * 40
+
+
+def _make_function_node(
+    name: str = "foo",
+    *,
+    file_path: str = "src/m.py",
+    source_text: str | None = "def foo():\n    return 1\n",
+    repo_id: str = "",
+) -> NodeInfo:
+    """Build a Function NodeInfo with the fields TemporalIndex consumes."""
+    return NodeInfo(
+        kind="Function",
+        name=name,
+        file_path=file_path,
+        line_start=1,
+        line_end=2,
+        language="python",
+        parent_name=None,
+        params="()",
+        return_type=None,
+        modifiers=None,
+        is_test=False,
+        extra={},
+        source_text=source_text,
+        repo_id=repo_id,
+    )
+
+
+def _make_edge(
+    *,
+    source: str = "src/m.py::foo",
+    target: str = "src/m.py::bar",
+    kind: str = "CALLS",
+    file_path: str = "src/m.py",
+    line: int = 5,
+    repo_id: str = "",
+) -> EdgeInfo:
+    return EdgeInfo(
+        kind=kind,
+        source=source,
+        target=target,
+        file_path=file_path,
+        line=line,
+        extra={},
+        repo_id=repo_id,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    """File-backed :class:`GraphStore` so the alembic migration runs end-to-end."""
+    db_path = tmp_path / "graph.db"
+    s = GraphStore(str(db_path))
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# (1) Fresh insert — no prior currently-valid row
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_node_inserts_when_no_prior_row(store: GraphStore) -> None:
+    """First observation of a node → INSERT with valid_from_sha=current, valid_to_sha=NULL."""
+    idx = TemporalIndex(store, current_sha=_SHA_A)
+    node = _make_function_node()
+    result = idx.upsert_node(node)
+
+    assert result == TemporalUpsertResult(action="inserted", closed_out_count=0)
+
+    rows = store._conn.execute(
+        "SELECT qualified_name, valid_from_sha, valid_to_sha, source_text "
+        "FROM nodes WHERE qualified_name = 'src/m.py::foo'"
+    ).fetchall()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["valid_from_sha"] == _SHA_A
+    assert row["valid_to_sha"] is None
+    assert row["source_text"] == "def foo():\n    return 1\n"
+
+
+# ---------------------------------------------------------------------------
+# (2) Source unchanged — re-upsert leaves the row alone
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_node_unchanged_when_source_identical(store: GraphStore) -> None:
+    """Second upsert with same source text → no new row, valid_from_sha unchanged."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    node = _make_function_node()
+    idx_a.upsert_node(node)
+
+    # Re-observe the same node at a later commit.
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    result = idx_b.upsert_node(node)
+
+    assert result.action == "unchanged"
+    assert result.closed_out_count == 0
+
+    rows = store._conn.execute(
+        "SELECT valid_from_sha, valid_to_sha FROM nodes "
+        "WHERE qualified_name = 'src/m.py::foo' ORDER BY id"
+    ).fetchall()
+    # Single row only — no supersede.
+    assert len(rows) == 1
+    # valid_from_sha pinned to the FIRST observation; we did NOT rotate it.
+    assert rows[0]["valid_from_sha"] == _SHA_A
+    assert rows[0]["valid_to_sha"] is None
+
+
+# ---------------------------------------------------------------------------
+# (3) Source diverged — close-out + insert
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_node_supersedes_when_source_diverges(store: GraphStore) -> None:
+    """Source text changed → prior row closed out, new row inserted."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(source_text="def foo():\n    return 1\n"))
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    result = idx_b.upsert_node(
+        _make_function_node(source_text="def foo():\n    return 2\n")
+    )
+
+    assert result.action == "superseded"
+    assert result.closed_out_count == 1
+
+    rows = store._conn.execute(
+        "SELECT valid_from_sha, valid_to_sha, source_text FROM nodes "
+        "WHERE qualified_name = 'src/m.py::foo' ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+
+    # Old row: closed out at sha_b.
+    assert rows[0]["valid_from_sha"] == _SHA_A
+    assert rows[0]["valid_to_sha"] == _SHA_B
+    assert rows[0]["source_text"] == "def foo():\n    return 1\n"
+    # New row: valid_from_sha = current_sha, valid_to_sha = NULL.
+    assert rows[1]["valid_from_sha"] == _SHA_B
+    assert rows[1]["valid_to_sha"] is None
+    assert rows[1]["source_text"] == "def foo():\n    return 2\n"
+
+
+# ---------------------------------------------------------------------------
+# (4) Action string contract
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_node_returns_correct_action_string(store: GraphStore) -> None:
+    """Action strings are exactly the documented set."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    r1 = idx_a.upsert_node(_make_function_node(source_text="v1"))
+    assert r1.action == "inserted"
+
+    idx_a2 = TemporalIndex(store, current_sha=_SHA_A)
+    r2 = idx_a2.upsert_node(_make_function_node(source_text="v1"))
+    assert r2.action == "unchanged"
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    r3 = idx_b.upsert_node(_make_function_node(source_text="v2"))
+    assert r3.action == "superseded"
+
+
+# ---------------------------------------------------------------------------
+# (5) closed_out_count contract
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_node_closed_out_count(store: GraphStore) -> None:
+    """``closed_out_count`` is 1 on supersede, 0 otherwise."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    r1 = idx_a.upsert_node(_make_function_node(source_text="v1"))
+    assert r1.closed_out_count == 0
+
+    idx_a2 = TemporalIndex(store, current_sha=_SHA_A)
+    r2 = idx_a2.upsert_node(_make_function_node(source_text="v1"))
+    assert r2.closed_out_count == 0
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    r3 = idx_b.upsert_node(_make_function_node(source_text="v2"))
+    assert r3.closed_out_count == 1
+
+
+# ---------------------------------------------------------------------------
+# (6) Edge — fresh insert
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_edge_inserts_when_no_prior_row(store: GraphStore) -> None:
+    """First edge observation → INSERT with valid_from_sha=current, valid_to_sha=NULL."""
+    idx = TemporalIndex(store, current_sha=_SHA_A)
+    edge = _make_edge()
+    result = idx.upsert_edge(edge)
+
+    assert result == TemporalUpsertResult(action="inserted", closed_out_count=0)
+
+    rows = store._conn.execute(
+        "SELECT source_qualified, target_qualified, kind, valid_from_sha, valid_to_sha "
+        "FROM edges WHERE source_qualified = 'src/m.py::foo' "
+        "AND target_qualified = 'src/m.py::bar' AND kind = 'CALLS'"
+    ).fetchall()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["valid_from_sha"] == _SHA_A
+    assert row["valid_to_sha"] is None
+
+
+# ---------------------------------------------------------------------------
+# (7) Edge — second upsert is "unchanged" (no source-text divergence semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_edge_unchanged_when_already_present(store: GraphStore) -> None:
+    """Edges identity by (src, dst, kind); second upsert always reports unchanged."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_edge(_make_edge(line=5))
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    # Different line — that's metadata, not identity. Expected: unchanged + UPDATE.
+    result = idx_b.upsert_edge(_make_edge(line=42))
+
+    assert result.action == "unchanged"
+    assert result.closed_out_count == 0
+
+    rows = store._conn.execute(
+        "SELECT id, line, valid_from_sha, valid_to_sha FROM edges "
+        "WHERE source_qualified = 'src/m.py::foo' "
+        "AND target_qualified = 'src/m.py::bar' AND kind = 'CALLS' "
+        "ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 1
+    # valid_from_sha pinned to first observation.
+    assert rows[0]["valid_from_sha"] == _SHA_A
+    assert rows[0]["valid_to_sha"] is None
+    # Line metadata refreshed on update path.
+    assert rows[0]["line"] == 42
+
+
+# ---------------------------------------------------------------------------
+# (8) close_missing_nodes — closes nodes not seen in observed set
+# ---------------------------------------------------------------------------
+
+
+def test_close_missing_nodes_closes_unobserved(store: GraphStore) -> None:
+    """File scan misses a previously-known node → that node is closed out."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(name="alpha", source_text="def alpha(): ..."))
+    idx_a.upsert_node(_make_function_node(name="beta", source_text="def beta(): ..."))
+    idx_a.upsert_node(_make_function_node(name="gamma", source_text="def gamma(): ..."))
+
+    # Re-scan at sha_b: only alpha + beta survive (gamma was deleted from the file).
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    closed = idx_b.close_missing_nodes(
+        file_path="src/m.py",
+        observed_qualified={"src/m.py::alpha", "src/m.py::beta"},
+    )
+    assert closed == 1
+
+    rows = store._conn.execute(
+        "SELECT qualified_name, valid_to_sha FROM nodes "
+        "WHERE file_path = 'src/m.py' ORDER BY qualified_name"
+    ).fetchall()
+    qn_to_valid_to = {r["qualified_name"]: r["valid_to_sha"] for r in rows}
+    assert qn_to_valid_to["src/m.py::alpha"] is None
+    assert qn_to_valid_to["src/m.py::beta"] is None
+    assert qn_to_valid_to["src/m.py::gamma"] == _SHA_B
+
+
+# ---------------------------------------------------------------------------
+# (9) close_missing_nodes — full coverage means zero closed
+# ---------------------------------------------------------------------------
+
+
+def test_close_missing_nodes_returns_zero_when_all_observed(store: GraphStore) -> None:
+    """All nodes still present in the file → zero closed."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(name="alpha"))
+    idx_a.upsert_node(_make_function_node(name="beta"))
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    closed = idx_b.close_missing_nodes(
+        file_path="src/m.py",
+        observed_qualified={"src/m.py::alpha", "src/m.py::beta"},
+    )
+    assert closed == 0
+
+    rows = store._conn.execute(
+        "SELECT valid_to_sha FROM nodes WHERE file_path = 'src/m.py'"
+    ).fetchall()
+    for row in rows:
+        assert row["valid_to_sha"] is None
+
+
+# ---------------------------------------------------------------------------
+# (10) repo_id survives both insert + supersede paths
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_index_preserves_repo_id_field(store: GraphStore) -> None:
+    """Federated build: repo_id flows through the insert and supersede branches."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(source_text="v1", repo_id="my-repo"),
+    )
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(source_text="v2", repo_id="my-repo"),
+    )
+
+    rows = store._conn.execute(
+        "SELECT repo_id, valid_from_sha FROM nodes "
+        "WHERE qualified_name = 'src/m.py::foo' ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["repo_id"] == "my-repo"
+    assert rows[1]["repo_id"] == "my-repo"
+
+    # Edge insert path also propagates repo_id.
+    edge_idx = TemporalIndex(store, current_sha=_SHA_A)
+    edge_idx.upsert_edge(_make_edge(repo_id="my-repo"))
+    edge_rows = store._conn.execute(
+        "SELECT repo_id FROM edges WHERE source_qualified = 'src/m.py::foo' "
+        "AND target_qualified = 'src/m.py::bar' AND kind = 'CALLS'"
+    ).fetchall()
+    assert len(edge_rows) == 1
+    assert edge_rows[0]["repo_id"] == "my-repo"
+
+    # Edge update path also propagates repo_id.
+    edge_idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    edge_idx_b.upsert_edge(_make_edge(repo_id="my-repo", line=99))
+    edge_rows = store._conn.execute(
+        "SELECT repo_id, line FROM edges WHERE source_qualified = 'src/m.py::foo' "
+        "AND target_qualified = 'src/m.py::bar' AND kind = 'CALLS'"
+    ).fetchall()
+    assert edge_rows[0]["repo_id"] == "my-repo"
+    assert edge_rows[0]["line"] == 99
+
+
+# ---------------------------------------------------------------------------
+# (11) History queryable after supersede
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_index_can_query_history_after_supersede(store: GraphStore) -> None:
+    """Both rows queryable post-supersede: latest via valid_to_sha IS NULL."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(source_text="v1"))
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(source_text="v2"))
+
+    idx_c = TemporalIndex(store, current_sha=_SHA_C)
+    idx_c.upsert_node(_make_function_node(source_text="v3"))
+
+    # Currently-valid row.
+    current = store._conn.execute(
+        "SELECT source_text, valid_from_sha FROM nodes "
+        "WHERE qualified_name = 'src/m.py::foo' AND valid_to_sha IS NULL"
+    ).fetchall()
+    assert len(current) == 1
+    assert current[0]["source_text"] == "v3"
+    assert current[0]["valid_from_sha"] == _SHA_C
+
+    # Historical rows (closed out).
+    historical = store._conn.execute(
+        "SELECT source_text, valid_from_sha, valid_to_sha FROM nodes "
+        "WHERE qualified_name = 'src/m.py::foo' AND valid_to_sha IS NOT NULL "
+        "ORDER BY valid_from_sha"
+    ).fetchall()
+    assert len(historical) == 2
+    # First version: valid from sha_a, closed at sha_b.
+    assert historical[0]["source_text"] == "v1"
+    assert historical[0]["valid_from_sha"] == _SHA_A
+    assert historical[0]["valid_to_sha"] == _SHA_B
+    # Second version: valid from sha_b, closed at sha_c.
+    assert historical[1]["source_text"] == "v2"
+    assert historical[1]["valid_from_sha"] == _SHA_B
+    assert historical[1]["valid_to_sha"] == _SHA_C


### PR DESCRIPTION
## Summary
- New `src/better_code_review_graph/temporal.py` — `TemporalIndex` wraps `GraphStore` with close-out + supersede semantics.
- `upsert_node`: 3-branch logic — no prior currently-valid row → insert; same source_hash → metadata refresh in place (no version rotation); diverged source → close prior row's `valid_to_sha=current_sha` + insert new row with `valid_from_sha=current_sha`.
- `upsert_edge`: 2-branch — insert if absent, metadata refresh if present (edges identity by src+dst+kind, no source-text divergence).
- `close_missing_nodes(file_path, observed_qualified)`: re-parse sweep — closes nodes previously visible in file but not produced by new parse (treated as deleted at this commit).
- `TemporalUpsertResult` frozen dataclass exposes action ("inserted"/"unchanged"/"superseded") + closed_out_count.
- **Necessary schema lift**: `_ensure_temporal_friendly_schema()` runs once at TemporalIndex construction. Drops legacy `UNIQUE(qualified_name)` constraint (blocks multiple temporal versions) and replaces with partial unique index `WHERE valid_to_sha IS NULL` (preserves "exactly one currently-valid row per qualified_name" invariant). Idempotent.

This is **Phase 3 Task 8 of 12** (epic #326). Temporal columns from Task 6 + commits table from Task 7 now actually usable.

## Test plan
- [x] `pytest tests/test_temporal_index.py -v`: 11 tests pass — covers all spec scenarios + repo_id preservation + history queryability.
- [x] `pytest --cov-fail-under=95 -q`: 1105 passed, coverage 95.43%, temporal.py 97%.
- [x] `grep -c "directory" uv.lock`: 0 (committed state — transient pollution reset before push).
- [ ] CI green.

## Files
- New: `src/better_code_review_graph/temporal.py`, `tests/test_temporal_index.py`.

## Note on `EdgeInfo` field names
Implementation uses `edge.source` / `edge.target` (matching the actual dataclass) not the DB column names `source_qualified` / `target_qualified` — corrected from the spec sketch.

## Out of scope
- Task 9: as_of/diff cross-cutting params on query/review.
- Task 10: review.delta line shifts.
- Tasks 11-12: docs + release dry-run.