### PR TITLE
feat: Phase 3 Task 9 — as_of + diff cross-cutting params on query + review

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -257,6 +257,7 @@ class GraphStore:
         self._conn.commit()
         self._ensure_summary_columns()
         self._ensure_federation_columns()
+        self._ensure_temporal_columns()
 
     def _run_alembic_upgrade(self) -> None:
         """Bring ``self.db_path`` to alembic head before legacy bootstrap.
@@ -524,6 +525,62 @@ class GraphStore:
         )
         self._conn.commit()
 
+    def _ensure_temporal_columns(self) -> None:
+        """Backfill Phase 3 Task 6 temporal columns on legacy / in-memory DBs.
+
+        Mirrors ``_ensure_federation_columns`` for the
+        ``005_temporal_columns`` migration. Two cases land here:
+
+        * In-memory ``:memory:`` databases — alembic creates the schema
+          in a separate in-memory connection (per the
+          ``sqlite:///:memory:`` URL semantics), so the migration never
+          touches ``self._conn``. The legacy ``_SCHEMA_SQL`` is frozen
+          at v1.6 and intentionally does not include the temporal
+          columns, so we add them here to keep the v2 query layer
+          (``valid_to_sha IS NULL`` filters) working without forcing
+          every test to use a file-backed DB.
+        * File-backed databases that bypassed alembic for any reason —
+          the ``IF NOT EXISTS`` guard on the index plus the
+          column-presence check make this safe to call unconditionally
+          on every connect.
+
+        ``valid_from_sha`` defaults to a 40-zero sentinel so legacy
+        rows inserted via ``upsert_node`` (which does NOT set the
+        column) survive the NOT NULL constraint. The sentinel matches
+        the in-memory fallback used by the alembic migration so
+        downstream temporal queries treat the two paths identically.
+        """
+        sentinel_sha = "0" * 40
+        node_cols = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(nodes)").fetchall()
+        }
+        if "valid_from_sha" not in node_cols:
+            self._conn.execute(
+                "ALTER TABLE nodes ADD COLUMN valid_from_sha TEXT NOT NULL "
+                f"DEFAULT '{sentinel_sha}'"
+            )
+        if "valid_to_sha" not in node_cols:
+            self._conn.execute("ALTER TABLE nodes ADD COLUMN valid_to_sha TEXT")
+        edge_cols = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(edges)").fetchall()
+        }
+        if "valid_from_sha" not in edge_cols:
+            self._conn.execute(
+                "ALTER TABLE edges ADD COLUMN valid_from_sha TEXT NOT NULL "
+                f"DEFAULT '{sentinel_sha}'"
+            )
+        if "valid_to_sha" not in edge_cols:
+            self._conn.execute("ALTER TABLE edges ADD COLUMN valid_to_sha TEXT")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_temporal "
+            "ON nodes(valid_from_sha, valid_to_sha)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_edges_temporal "
+            "ON edges(valid_from_sha, valid_to_sha)"
+        )
+        self._conn.commit()
+
     def _ensure_summary_columns(self) -> None:
         """Backfill Phase 1 v1.6.x summary columns on pre-existing DBs.
 
@@ -786,19 +843,68 @@ class GraphStore:
 
     # --- Read operations ---
 
-    def get_node(self, qualified_name: str) -> GraphNode | None:
+    @staticmethod
+    def _temporal_filter(
+        as_of: str, *, table_alias: str = ""
+    ) -> tuple[str, tuple[str, ...]]:
+        """Return ``(sql_fragment, bind_params)`` for the temporal scope.
+
+        Phase 3 Task 9 — encodes the "snapshot at SHA" semantics used by
+        the v2 query layer. The fragment is always prefixed with
+        ``AND`` so callers can append it to an existing ``WHERE``
+        clause without rewriting the query shape.
+
+        * ``as_of == ""`` → ``AND <prefix>valid_to_sha IS NULL``. Returns
+          only currently-valid rows. This is the new default and the
+          first use of the temporal columns by the read layer; legacy
+          ingest writes ``valid_to_sha = NULL`` so existing rows pass
+          through untouched.
+        * ``as_of == "<sha>"`` → ``AND (<prefix>valid_from_sha = ? OR
+          <prefix>valid_to_sha = ?)``. Snapshot semantics: rows
+          introduced exactly at the requested SHA OR rows that were
+          closed out at the requested SHA both qualify. Approximation
+          of full ancestor walk against the ``commits`` table —
+          deferred to Task 9.5.
+
+        Args:
+            as_of: Empty string for "currently-valid" or a 40-char SHA.
+            table_alias: When the surrounding query references multiple
+                tables (``nodes n JOIN edges e``) callers pass the
+                alias so the fragment qualifies the column name. Empty
+                string (default) emits unqualified column names.
+
+        Returns:
+            ``(fragment, params)`` — fragment includes the leading
+            ``AND`` so callers always emit the same shape regardless
+            of whether the SHA is set.
+        """
+        prefix = f"{table_alias}." if table_alias else ""
+        if not as_of:
+            return f" AND {prefix}valid_to_sha IS NULL", ()
+        return (
+            f" AND ({prefix}valid_from_sha = ? OR {prefix}valid_to_sha = ?)",
+            (as_of, as_of),
+        )
+
+    def get_node(self, qualified_name: str, *, as_of: str = "") -> GraphNode | None:
+        frag, frag_params = self._temporal_filter(as_of)
         row = self._conn.execute(
-            "SELECT * FROM nodes WHERE qualified_name = ?", (qualified_name,)
+            f"SELECT * FROM nodes WHERE qualified_name = ?{frag}",  # noqa: S608
+            (qualified_name, *frag_params),
         ).fetchone()
         return self._row_to_node(row) if row else None
 
-    def get_nodes_by_file(self, file_path: str) -> list[GraphNode]:
+    def get_nodes_by_file(self, file_path: str, *, as_of: str = "") -> list[GraphNode]:
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM nodes WHERE file_path = ?", (file_path,)
+            f"SELECT * FROM nodes WHERE file_path = ?{frag}",  # noqa: S608
+            (file_path, *frag_params),
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
-    def get_nodes_by_files(self, file_paths: list[str]) -> list[GraphNode]:
+    def get_nodes_by_files(
+        self, file_paths: list[str], *, as_of: str = ""
+    ) -> list[GraphNode]:
         """Batch fetch nodes by their file paths to prevent N+1 queries.
 
         Deduplicates input file paths, fetches in batches to respect SQLite
@@ -810,14 +916,16 @@ class GraphStore:
             return []
 
         unique_files = list(set(file_paths))
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM nodes WHERE file_path IN (SELECT value FROM json_each(?))",
-            (json.dumps(unique_files),),
+            "SELECT * FROM nodes WHERE file_path IN "  # noqa: S608
+            f"(SELECT value FROM json_each(?)){frag}",
+            (json.dumps(unique_files), *frag_params),
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
     def get_nodes_by_qualified_names(
-        self, qualified_names: list[str]
+        self, qualified_names: list[str], *, as_of: str = ""
     ) -> list[GraphNode]:
         """Batch fetch nodes by their qualified names to prevent N+1 queries.
 
@@ -828,44 +936,59 @@ class GraphStore:
             return []
 
         unique_qns = list(set(qualified_names))
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM nodes WHERE qualified_name IN (SELECT value FROM json_each(?))",
-            (json.dumps(unique_qns),),
+            "SELECT * FROM nodes WHERE qualified_name IN "  # noqa: S608
+            f"(SELECT value FROM json_each(?)){frag}",
+            (json.dumps(unique_qns), *frag_params),
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
-    def get_edges_by_source(self, qualified_name: str) -> list[GraphEdge]:
+    def get_edges_by_source(
+        self, qualified_name: str, *, as_of: str = ""
+    ) -> list[GraphEdge]:
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM edges WHERE source_qualified = ?", (qualified_name,)
+            f"SELECT * FROM edges WHERE source_qualified = ?{frag}",  # noqa: S608
+            (qualified_name, *frag_params),
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
-    def get_edges_by_target(self, qualified_name: str) -> list[GraphEdge]:
+    def get_edges_by_target(
+        self, qualified_name: str, *, as_of: str = ""
+    ) -> list[GraphEdge]:
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM edges WHERE target_qualified = ?", (qualified_name,)
+            f"SELECT * FROM edges WHERE target_qualified = ?{frag}",  # noqa: S608
+            (qualified_name, *frag_params),
         ).fetchall()
         if not rows and "::" in qualified_name:
             # Fallback: try matching bare name (last segment after ::)
             bare_name = qualified_name.rsplit("::", 1)[-1]
             rows = self._conn.execute(
-                "SELECT * FROM edges WHERE target_qualified = ?", (bare_name,)
+                f"SELECT * FROM edges WHERE target_qualified = ?{frag}",  # noqa: S608
+                (bare_name, *frag_params),
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
-    def get_edges_by_targets(self, qualified_names: list[str]) -> list[GraphEdge]:
+    def get_edges_by_targets(
+        self, qualified_names: list[str], *, as_of: str = ""
+    ) -> list[GraphEdge]:
         """Batch fetch edges by their target qualified names to prevent N+1 queries."""
         if not qualified_names:
             return []
 
         unique_qns = list(set(qualified_names))
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM edges WHERE target_qualified IN (SELECT value FROM json_each(?))",
-            (json.dumps(unique_qns),),
+            "SELECT * FROM edges WHERE target_qualified IN "  # noqa: S608
+            f"(SELECT value FROM json_each(?)){frag}",
+            (json.dumps(unique_qns), *frag_params),
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
     def search_edges_by_target_name(
-        self, name: str, kind: str = "CALLS"
+        self, name: str, kind: str = "CALLS", *, as_of: str = ""
     ) -> list[GraphEdge]:
         """Search for edges where target_qualified matches an unqualified name.
 
@@ -875,10 +998,10 @@ class GraphStore:
         reverse call tracing (callers_of) works even when qualified-name lookup
         returns nothing.
         """
-        return self.search_edges_by_target_names([name], kind=kind)
+        return self.search_edges_by_target_names([name], kind=kind, as_of=as_of)
 
     def search_edges_by_target_names(
-        self, names: list[str], kind: str = "CALLS"
+        self, names: list[str], kind: str = "CALLS", *, as_of: str = ""
     ) -> list[GraphEdge]:
         """Batch search for edges where target_qualified matches any of the given names.
 
@@ -889,9 +1012,11 @@ class GraphStore:
             return []
 
         unique_names = list(set(names))
+        frag, frag_params = self._temporal_filter(as_of)
         rows = self._conn.execute(
-            "SELECT * FROM edges WHERE target_qualified IN (SELECT value FROM json_each(?)) AND kind = ?",
-            (json.dumps(unique_names), kind),
+            "SELECT * FROM edges WHERE target_qualified IN "  # noqa: S608
+            f"(SELECT value FROM json_each(?)) AND kind = ?{frag}",
+            (json.dumps(unique_names), kind, *frag_params),
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
@@ -907,6 +1032,8 @@ class GraphStore:
         kind: str | None = None,
         limit: int = 20,
         repo: str = "",
+        *,
+        as_of: str = "",
     ) -> list[GraphNode]:
         """Keyword search across node names and qualified names.
 
@@ -916,16 +1043,22 @@ class GraphStore:
         Phase 2 Task 10: when ``repo`` is non-empty the result set is
         scoped to nodes whose ``repo_id`` equals it. Empty ``repo``
         (default) preserves the legacy unscoped behaviour.
+
+        Phase 3 Task 9: ``as_of`` filters to the temporal snapshot at
+        the requested SHA. Default ``""`` returns currently-valid rows
+        (``valid_to_sha IS NULL``).
         """
         words = query.lower().split()
         if not words:
             return []
 
+        frag, frag_params = self._temporal_filter(as_of)
         # Use json_each to avoid dynamic SQL construction.
-        # Use a fully static SQL literal to avoid dynamic SQL construction (Bandit B608).
-        # The query ensures ALL words match (AND logic) and handles optional kind filter.
+        # The temporal fragment is a static prefix/clause produced by
+        # ``_temporal_filter`` from a hard-coded set of strings, so the
+        # f-string interpolation is safe (Bandit B608 already lints).
         rows = self._conn.execute(
-            """
+            f"""
             SELECT * FROM nodes
             WHERE (
                 SELECT COUNT(*)
@@ -934,10 +1067,19 @@ class GraphStore:
                    OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
               AND (? IS NULL OR kind = ?)
-              AND (? = '' OR repo_id = ?)
+              AND (? = '' OR repo_id = ?){frag}
             ORDER BY name LIMIT ?
-            """,
-            [json.dumps(words), json.dumps(words), kind, kind, repo, repo, limit],
+            """,  # noqa: S608
+            [
+                json.dumps(words),
+                json.dumps(words),
+                kind,
+                kind,
+                repo,
+                repo,
+                *frag_params,
+                limit,
+            ],
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
@@ -949,6 +1091,8 @@ class GraphStore:
         max_depth: int = 2,
         max_nodes: int = 500,
         repo: str = "",
+        *,
+        as_of: str = "",
     ) -> dict[str, Any]:
         """BFS from changed files to find all impacted nodes within depth N.
 
@@ -964,12 +1108,20 @@ class GraphStore:
         frontier, returned nodes, and connecting edges are filtered to
         the matching ``repo_id``. Empty ``repo`` (default) preserves
         legacy cross-repo behaviour.
+
+        Phase 3 Task 9: ``as_of`` scopes the seed set + final node /
+        edge resolution to the temporal snapshot at the requested SHA.
+        Default ``""`` returns currently-valid rows. The BFS itself
+        rides on the cached ``networkx`` graph (built from the full
+        nodes + edges tables), so a follow-up may also rebuild the
+        graph from a temporal slice. For Task 9 the seed-and-resolve
+        boundary is the practical pinch point.
         """
         nxg = self._build_networkx_graph()
 
         # Seed: all qualified names in changed files (batched to avoid N+1).
         # When ``repo`` is set, drop seed nodes that don't belong to it.
-        seed_nodes = self.get_nodes_by_files(changed_files)
+        seed_nodes = self.get_nodes_by_files(changed_files, as_of=as_of)
         if repo:
             seed_nodes = [n for n in seed_nodes if self._node_repo_id(n) == repo]
         seeds = {n.qualified_name for n in seed_nodes}
@@ -1025,8 +1177,10 @@ class GraphStore:
         total_impacted = len(impacted - seeds)
 
         # Resolve to full node info using batch fetch to prevent N+1 queries
-        changed_nodes = self.get_nodes_by_qualified_names(list(seeds))
-        impacted_nodes = self.get_nodes_by_qualified_names(list(impacted - seeds))
+        changed_nodes = self.get_nodes_by_qualified_names(list(seeds), as_of=as_of)
+        impacted_nodes = self.get_nodes_by_qualified_names(
+            list(impacted - seeds), as_of=as_of
+        )
 
         # Defensive re-filter (qualified_name set above is already
         # repo-scoped, but get_nodes_by_qualified_names is repo-blind).

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -18,6 +18,7 @@ from .embeddings import EmbeddingStore, init_backend, resolve_backend
 from .incremental import get_db_path
 from .tools import (
     build_or_update_graph,
+    diff_graph,
     embed_graph,
     export_graph_dispatch,
     find_large_functions,
@@ -188,7 +189,8 @@ def graph(
         "Actions: query (pattern, target), search (search_query), impact (changed_files|base), "
         "large_functions (min_lines), spot_check (n -- random callsite snippets from "
         "last callers_of/callees_of/inheritors_of/importers_of result), "
-        "renamed_in_diff (base -- symbols whose callsite line shifted vs base ref). "
+        "renamed_in_diff (base -- symbols whose callsite line shifted vs base ref), "
+        "diff (from_sha, to_sha -- nodes added/removed/modified between two commit SHAs). "
         "Use `help` tool for full docs."
     ),
     annotations=ToolAnnotations(
@@ -226,6 +228,10 @@ def query(
     repo_root: str | None = None,
     # Phase 2 Task 10 — cross-cutting repo filter
     repo: str = "",
+    # Phase 3 Task 9 — temporal cross-cutting params
+    as_of: str = "",
+    from_sha: str = "",
+    to_sha: str = "",
 ) -> str:
     """Query the code knowledge graph for relationships, search, and impact analysis.
 
@@ -272,6 +278,7 @@ def query(
                     repo_root=repo_root,
                     languages=languages,
                     repo=repo,
+                    as_of=as_of,
                 )
             )
         case "search":
@@ -283,6 +290,7 @@ def query(
                 limit=limit,
                 repo_root=repo_root,
                 repo=repo,
+                as_of=as_of,
             )
             result = _maybe_include_setup_hint(result)
             return _json(result)
@@ -296,6 +304,7 @@ def query(
                     base=base,
                     max_payload_bytes=max_payload_bytes,
                     repo=repo,
+                    as_of=as_of,
                 )
             )
         case "large_functions":
@@ -325,10 +334,20 @@ def query(
                     repo_root=repo_root,
                 )
             )
+        case "diff":
+            return _json(
+                diff_graph(
+                    repo_root=repo_root,
+                    from_sha=from_sha,
+                    to_sha=to_sha,
+                    repo=repo,
+                )
+            )
         case _:
             import difflib
 
             valid_actions = [
+                "diff",
                 "impact",
                 "large_functions",
                 "query",

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -515,6 +515,8 @@ def get_impact_radius(
     base: str = "HEAD~1",
     max_payload_bytes: int = _DEFAULT_IMPACT_PAYLOAD_BYTES,
     repo: str = "",
+    *,
+    as_of: str = "",
 ) -> dict[str, Any]:
     """Analyze the blast radius of changed files.
 
@@ -534,6 +536,13 @@ def get_impact_radius(
         repo: Phase 2 Task 10 — when non-empty, scope the BFS to nodes
             belonging to the given ``repo_id``. Empty (default) =
             traverse across every federated repo.
+        as_of: Phase 3 Task 9 — temporal snapshot SHA. Default ``""``
+            returns currently-valid rows (``valid_to_sha IS NULL``);
+            non-empty returns rows where ``valid_from_sha == as_of``
+            OR ``valid_to_sha == as_of``. Threaded into the seed
+            ``get_nodes_by_files`` and the final
+            ``get_nodes_by_qualified_names`` resolves; the BFS itself
+            still runs against the cached full-graph (Task 9.5).
 
     Returns:
         Changed nodes, impacted nodes, impacted files, connecting edges,
@@ -570,7 +579,11 @@ def get_impact_radius(
             abs_files.append(str(full_path))
 
         result = store.get_impact_radius(
-            abs_files, max_depth=max_depth, max_nodes=max_results, repo=repo
+            abs_files,
+            max_depth=max_depth,
+            max_nodes=max_results,
+            repo=repo,
+            as_of=as_of,
         )
 
         changed_dicts = [node_to_dict(n) for n in result["changed_nodes"]]
@@ -680,9 +693,11 @@ def _list_kinds_in_graph(store: Any) -> list[str]:
         return []
 
 
-def _lookup_node_directly(store: Any, root: Any, target: str) -> Any | None:
+def _lookup_node_directly(
+    store: Any, root: Any, target: str, *, as_of: str = ""
+) -> Any | None:
     """Attempt to find a node by its qualified name or file path."""
-    node = store.get_node(target)
+    node = store.get_node(target, as_of=as_of)
     if not node:
         full_target_raw = root / target
         try:
@@ -694,7 +709,7 @@ def _lookup_node_directly(store: Any, root: Any, target: str) -> Any | None:
                 and not full_target.is_symlink()
             ):
                 abs_target = str(full_target)
-                node = store.get_node(abs_target)
+                node = store.get_node(abs_target, as_of=as_of)
         except (OSError, ValueError):
             pass
     return node
@@ -706,9 +721,11 @@ def _resolve_search_candidates(
     pattern: str,
     original_target: str,
     repo: str = "",
+    *,
+    as_of: str = "",
 ) -> tuple[Any | None, str, dict[str, Any] | None, list[str]]:
     """Search for nodes by name and handle ambiguity/promotion."""
-    candidates = store.search_nodes(target, limit=5, repo=repo)
+    candidates = store.search_nodes(target, limit=5, repo=repo, as_of=as_of)
     promoted_indexed_under: list[str] = []
 
     # #316: when the pattern is call-graph oriented and the only ambiguity
@@ -821,6 +838,8 @@ def _resolve_query_target(
     target: str,
     pattern: str,
     repo: str = "",
+    *,
+    as_of: str = "",
 ) -> tuple[Any | None, str, dict[str, Any] | None]:
     """Resolve the query target to a node or path.
 
@@ -830,7 +849,7 @@ def _resolve_query_target(
     original_target = target
 
     # 1. Direct lookup (qualified name or absolute path)
-    node = _lookup_node_directly(store, root, target)
+    node = _lookup_node_directly(store, root, target, as_of=as_of)
     # Phase 2 Task 10: drop direct hits that don't belong to the
     # requested repo so the search-by-name fallback below can pick a
     # repo-scoped candidate instead of returning the cross-repo match.
@@ -846,7 +865,7 @@ def _resolve_query_target(
     promoted_indexed_under: list[str] = []
     if not node:
         node, target, error_resp, promoted_indexed_under = _resolve_search_candidates(
-            store, target, pattern, original_target, repo=repo
+            store, target, pattern, original_target, repo=repo, as_of=as_of
         )
         if error_resp:
             return None, target, error_resp
@@ -956,7 +975,13 @@ def _scan_dynamic_dispatch_hints(
 
 
 def _handle_callers_of(
-    store: Any, node: Any, qn: str, results: list[dict], edges_out: list[dict]
+    store: Any,
+    node: Any,
+    qn: str,
+    results: list[dict],
+    edges_out: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
     # Bolt: Use batched search to avoid N+1 queries when resolving callers (issue #342).
     # We look for CALLS edges targeting either the qualified name or the bare name.
@@ -964,7 +989,9 @@ def _handle_callers_of(
     if node and node.name and node.name != qn:
         search_targets.append(node.name)
 
-    edges = store.search_edges_by_target_names(search_targets, kind="CALLS")
+    edges = store.search_edges_by_target_names(
+        search_targets, kind="CALLS", as_of=as_of
+    )
 
     qns = []
     for e in edges:
@@ -972,7 +999,7 @@ def _handle_callers_of(
         edges_out.append(edge_to_dict(e))
 
     if qns:
-        nodes = store.get_nodes_by_qualified_names(qns)
+        nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
         for qn_src in qns:
             if qn_src in node_map:
@@ -980,15 +1007,20 @@ def _handle_callers_of(
 
 
 def _handle_callees_of(
-    store: Any, qn: str, results: list[dict], edges_out: list[dict]
+    store: Any,
+    qn: str,
+    results: list[dict],
+    edges_out: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_source(qn):
+    for e in store.get_edges_by_source(qn, as_of=as_of):
         if e.kind == "CALLS":
             qns.append(e.target_qualified)
             edges_out.append(edge_to_dict(e))
     if qns:
-        nodes = store.get_nodes_by_qualified_names(qns)
+        nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
         for qn_tgt in qns:
             if qn_tgt in node_map:
@@ -996,30 +1028,42 @@ def _handle_callees_of(
 
 
 def _handle_imports_of(
-    store: Any, qn: str, results: list[dict], edges_out: list[dict]
+    store: Any,
+    qn: str,
+    results: list[dict],
+    edges_out: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_source(qn):
+    for e in store.get_edges_by_source(qn, as_of=as_of):
         if e.kind == "IMPORTS_FROM":
             results.append({"import_target": e.target_qualified})
             edges_out.append(edge_to_dict(e))
 
 
 def _handle_importers_of(
-    store: Any, abs_target: str, results: list[dict], edges_out: list[dict]
+    store: Any,
+    abs_target: str,
+    results: list[dict],
+    edges_out: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_target(abs_target):
+    for e in store.get_edges_by_target(abs_target, as_of=as_of):
         if e.kind == "IMPORTS_FROM":
             results.append({"importer": e.source_qualified, "file": e.file_path})
             edges_out.append(edge_to_dict(e))
 
 
-def _handle_children_of(store: Any, qn: str, results: list[dict]) -> None:
+def _handle_children_of(
+    store: Any, qn: str, results: list[dict], *, as_of: str = ""
+) -> None:
     qns = []
-    for e in store.get_edges_by_source(qn):
+    for e in store.get_edges_by_source(qn, as_of=as_of):
         if e.kind == "CONTAINS":
             qns.append(e.target_qualified)
     if qns:
-        nodes = store.get_nodes_by_qualified_names(qns)
+        nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
         for qn_tgt in qns:
             if qn_tgt in node_map:
@@ -1027,22 +1071,28 @@ def _handle_children_of(store: Any, qn: str, results: list[dict]) -> None:
 
 
 def _handle_tests_for(
-    store: Any, node: Any, target: str, qn: str, results: list[dict]
+    store: Any,
+    node: Any,
+    target: str,
+    qn: str,
+    results: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_target(qn):
+    for e in store.get_edges_by_target(qn, as_of=as_of):
         if e.kind == "TESTED_BY":
             qns.append(e.source_qualified)
     if qns:
-        nodes = store.get_nodes_by_qualified_names(qns)
+        nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
         for qn_src in qns:
             if qn_src in node_map:
                 results.append(node_to_dict(node_map[qn_src]))
     # Also search by naming convention
     name = node.name if node else target
-    test_nodes = store.search_nodes(f"test_{name}", limit=10)
-    test_nodes += store.search_nodes(f"Test{name}", limit=10)
+    test_nodes = store.search_nodes(f"test_{name}", limit=10, as_of=as_of)
+    test_nodes += store.search_nodes(f"Test{name}", limit=10, as_of=as_of)
     seen = {r.get("qualified_name") for r in results}
     for t in test_nodes:
         if t.qualified_name not in seen and t.is_test:
@@ -1050,23 +1100,30 @@ def _handle_tests_for(
 
 
 def _handle_inheritors_of(
-    store: Any, qn: str, results: list[dict], edges_out: list[dict]
+    store: Any,
+    qn: str,
+    results: list[dict],
+    edges_out: list[dict],
+    *,
+    as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_target(qn):
+    for e in store.get_edges_by_target(qn, as_of=as_of):
         if e.kind in ("INHERITS", "IMPLEMENTS"):
             qns.append(e.source_qualified)
             edges_out.append(edge_to_dict(e))
     if qns:
-        nodes = store.get_nodes_by_qualified_names(qns)
+        nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
         for qn_src in qns:
             if qn_src in node_map:
                 results.append(node_to_dict(node_map[qn_src]))
 
 
-def _handle_file_summary(store: Any, abs_path: str, results: list[dict]) -> None:
-    file_nodes = store.get_nodes_by_file(abs_path)
+def _handle_file_summary(
+    store: Any, abs_path: str, results: list[dict], *, as_of: str = ""
+) -> None:
+    file_nodes = store.get_nodes_by_file(abs_path, as_of=as_of)
     for n in file_nodes:
         results.append(node_to_dict(n))
 
@@ -1112,6 +1169,8 @@ def query_graph(
     repo_root: str | None = None,
     languages: list[str] | None = None,
     repo: str = "",
+    *,
+    as_of: str = "",
 ) -> dict[str, Any]:
     """Run a predefined graph query.
 
@@ -1128,6 +1187,12 @@ def query_graph(
             to nodes whose ``repo_id`` matches. Default ``""`` searches
             across every registered repo (legacy behaviour). Used to
             disambiguate same-named symbols across federated repos.
+        as_of: Phase 3 Task 9 — when non-empty, return the temporal
+            snapshot at the requested 40-char SHA (rows where
+            ``valid_from_sha == as_of`` OR ``valid_to_sha == as_of``).
+            Default ``""`` returns currently-valid rows
+            (``valid_to_sha IS NULL``) — first use of the temporal
+            columns by the read layer.
 
     Returns:
         Matching nodes and edges for the query.
@@ -1170,27 +1235,39 @@ def query_graph(
             }
 
         node, resolved_qn_or_path, error_resp = _resolve_query_target(
-            store, root, target, pattern, repo=repo
+            store, root, target, pattern, repo=repo, as_of=as_of
         )
         if error_resp:
             return error_resp
 
         if pattern == "callers_of":
-            _handle_callers_of(store, node, resolved_qn_or_path, results, edges_out)
+            _handle_callers_of(
+                store, node, resolved_qn_or_path, results, edges_out, as_of=as_of
+            )
         elif pattern == "callees_of":
-            _handle_callees_of(store, resolved_qn_or_path, results, edges_out)
+            _handle_callees_of(
+                store, resolved_qn_or_path, results, edges_out, as_of=as_of
+            )
         elif pattern == "imports_of":
-            _handle_imports_of(store, resolved_qn_or_path, results, edges_out)
+            _handle_imports_of(
+                store, resolved_qn_or_path, results, edges_out, as_of=as_of
+            )
         elif pattern == "importers_of":
-            _handle_importers_of(store, resolved_qn_or_path, results, edges_out)
+            _handle_importers_of(
+                store, resolved_qn_or_path, results, edges_out, as_of=as_of
+            )
         elif pattern == "children_of":
-            _handle_children_of(store, resolved_qn_or_path, results)
+            _handle_children_of(store, resolved_qn_or_path, results, as_of=as_of)
         elif pattern == "tests_for":
-            _handle_tests_for(store, node, target, resolved_qn_or_path, results)
+            _handle_tests_for(
+                store, node, target, resolved_qn_or_path, results, as_of=as_of
+            )
         elif pattern == "inheritors_of":
-            _handle_inheritors_of(store, resolved_qn_or_path, results, edges_out)
+            _handle_inheritors_of(
+                store, resolved_qn_or_path, results, edges_out, as_of=as_of
+            )
         elif pattern == "file_summary":
-            _handle_file_summary(store, resolved_qn_or_path, results)
+            _handle_file_summary(store, resolved_qn_or_path, results, as_of=as_of)
 
         # D16: filter tests_for results by language if requested.
         if pattern == "tests_for" and languages is not None:
@@ -1283,6 +1360,117 @@ def query_graph(
             }
 
         return response
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Tool 3.5: diff_graph (Phase 3 Task 9)
+# ---------------------------------------------------------------------------
+
+
+def diff_graph(
+    repo_root: str | None = None,
+    *,
+    from_sha: str = "",
+    to_sha: str = "",
+    repo: str = "",
+) -> dict[str, Any]:
+    """Return nodes added / removed / modified between two commit SHAs.
+
+    The diff is computed entirely from the temporal columns set by the
+    v2 ingest path (:class:`TemporalIndex`). It does NOT require the
+    parser to re-run — the close-out + supersede markers already on
+    each row encode every transition.
+
+    * **added**: rows whose ``valid_from_sha == to_sha`` AND whose
+      ``qualified_name`` does NOT also appear in the closed-out set
+      (i.e. genuinely new symbols at ``to_sha``).
+    * **removed**: rows whose ``valid_to_sha == to_sha`` AND whose
+      ``qualified_name`` does NOT also appear in the introduced set
+      (i.e. symbols deleted between ``from_sha`` and ``to_sha`` with
+      no replacement).
+    * **modified**: ``qualified_name``s that show up in BOTH sets —
+      one row closed at ``to_sha``, another row introduced at
+      ``to_sha``. This is the supersede signature emitted when a
+      function's source text changes across commits.
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        from_sha: Earlier commit SHA. Required.
+        to_sha: Later commit SHA. Required.
+        repo: Optional ``repo_id`` filter (Phase 2 Task 10 semantics).
+            Empty (default) returns the diff across every registered
+            repo.
+
+    Returns:
+        ``{"from_sha": ..., "to_sha": ..., "added": [...],
+        "removed": [...], "modified": [...]}``. ``added`` /
+        ``removed`` entries are dicts with ``id``, ``qualified_name``,
+        ``kind``; ``modified`` entries are dicts with just
+        ``qualified_name``.
+    """
+    if not from_sha or not to_sha:
+        return {"error": "diff requires both from_sha and to_sha"}
+
+    store, _ = _get_store(repo_root)
+    try:
+        # Build the optional repo filter once. The base SQL stays
+        # static — Bandit B608 is happy because both branches expand
+        # to a fixed string literal at f-string interpolation time.
+        if repo:
+            added_rows = store._conn.execute(
+                "SELECT id, qualified_name, kind FROM nodes "
+                "WHERE valid_from_sha = ? AND repo_id = ?",
+                (to_sha, repo),
+            ).fetchall()
+            removed_rows = store._conn.execute(
+                "SELECT id, qualified_name, kind FROM nodes "
+                "WHERE valid_to_sha = ? AND repo_id = ?",
+                (to_sha, repo),
+            ).fetchall()
+        else:
+            added_rows = store._conn.execute(
+                "SELECT id, qualified_name, kind FROM nodes WHERE valid_from_sha = ?",
+                (to_sha,),
+            ).fetchall()
+            removed_rows = store._conn.execute(
+                "SELECT id, qualified_name, kind FROM nodes WHERE valid_to_sha = ?",
+                (to_sha,),
+            ).fetchall()
+
+        closed_qns = {row["qualified_name"] for row in removed_rows}
+        new_qns = {row["qualified_name"] for row in added_rows}
+        modified_qns = closed_qns & new_qns
+
+        purely_added = [
+            r for r in added_rows if r["qualified_name"] not in modified_qns
+        ]
+        purely_removed = [
+            r for r in removed_rows if r["qualified_name"] not in modified_qns
+        ]
+
+        return {
+            "from_sha": from_sha,
+            "to_sha": to_sha,
+            "added": [
+                {
+                    "id": r["id"],
+                    "qualified_name": r["qualified_name"],
+                    "kind": r["kind"],
+                }
+                for r in purely_added
+            ],
+            "removed": [
+                {
+                    "id": r["id"],
+                    "qualified_name": r["qualified_name"],
+                    "kind": r["kind"],
+                }
+                for r in purely_removed
+            ],
+            "modified": [{"qualified_name": qn} for qn in sorted(modified_qns)],
+        }
     finally:
         store.close()
 
@@ -1867,6 +2055,8 @@ def semantic_search_nodes(
     limit: int = 20,
     repo_root: str | None = None,
     repo: str = "",
+    *,
+    as_of: str = "",
 ) -> dict[str, Any]:
     """Search for nodes by name, keyword, or semantic similarity.
 
@@ -1882,6 +2072,11 @@ def semantic_search_nodes(
         repo: Phase 2 Task 10 — when non-empty, scope to nodes whose
             ``repo_id`` matches. Default ``""`` searches across every
             registered repo.
+        as_of: Phase 3 Task 9 — temporal snapshot SHA. Empty (default)
+            returns currently-valid rows; non-empty returns rows where
+            ``valid_from_sha == as_of`` OR ``valid_to_sha == as_of``.
+            When set the path forces the keyword fallback (the vector
+            store has no temporal column) so the SQL filter applies.
 
     Returns:
         Ranked list of matching nodes.
@@ -1900,7 +2095,11 @@ def semantic_search_nodes(
         search_mode = "keyword"
 
         try:
-            if emb_store.available and emb_store.count() > 0:
+            # Phase 3 Task 9: an explicit ``as_of`` skips the vector path —
+            # the embedding store has no temporal column, so we cannot
+            # safely return historical snapshots through it. Fall through
+            # to the keyword path which threads ``as_of`` into the SQL.
+            if as_of == "" and emb_store.available and emb_store.count() > 0:
                 # Vector search
                 search_mode = "semantic"
                 raw = semantic_search(query, store, emb_store, limit=limit * 2)
@@ -1921,6 +2120,24 @@ def semantic_search_nodes(
                         if row is not None and (row["repo_id"] or "") == repo:
                             filtered.append(r)
                     raw = filtered
+                # Default-path filter: vector hits should also exclude
+                # rows that have been closed-out at a later commit. The
+                # vector store does not know about ``valid_to_sha`` so
+                # we cross-check via the SQL row (cheap single-row
+                # lookup, mirrors the repo filter above).
+                surviving: list[dict] = []
+                for r in raw:
+                    qn = r.get("qualified_name")
+                    if qn is None:
+                        continue
+                    row = store._conn.execute(
+                        "SELECT 1 FROM nodes WHERE qualified_name = ? "
+                        "AND valid_to_sha IS NULL",
+                        (qn,),
+                    ).fetchone()
+                    if row is not None:
+                        surviving.append(r)
+                raw = surviving
                 raw = raw[:limit]
                 return {
                     "status": "ok",
@@ -1937,7 +2154,7 @@ def semantic_search_nodes(
             emb_store.close()
 
         # Keyword fallback
-        results = store.search_nodes(query, limit=limit * 2, repo=repo)
+        results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
 
         if kind:
             results = [r for r in results if r.kind == kind]

--- a/tests/test_as_of_diff.py
+++ b/tests/test_as_of_diff.py
@@ -1,0 +1,368 @@
+"""Phase 3 Task 9: ``as_of`` + ``diff`` cross-cutting query parameters.
+
+These tests pin the behaviour of the temporal query layer:
+
+* Default (``as_of=""``) must return ONLY currently-valid rows
+  (``valid_to_sha IS NULL``). Historical rows that were closed-out by
+  a later supersede must be excluded.
+* ``as_of=<sha>`` returns the row whose ``valid_from_sha`` matches
+  the requested SHA — the "snapshot at SHA" semantic. This is the
+  Task 9 MVP scope; full ancestor-walk against the ``commits`` table
+  is deferred.
+* ``diff(from_sha, to_sha)`` returns ``added`` / ``removed`` / ``modified``
+  buckets keyed off ``valid_from_sha`` / ``valid_to_sha``. ``modified``
+  is the intersection of "closed at to_sha" and "introduced at to_sha"
+  for the same qualified_name (i.e. supersede); pure adds and pure
+  removes do not show up there.
+
+Fixtures use :class:`TemporalIndex` to set up multi-version state so
+the tests exercise the same code path the v2 ingest layer will go
+through. The legacy ``GraphStore.upsert_node`` overwrite path is not
+suitable for these tests — it loses history by design.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import NodeInfo
+from better_code_review_graph.temporal import TemporalIndex
+from better_code_review_graph.tools import (
+    diff_graph,
+    get_impact_radius,
+    semantic_search_nodes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+_SHA_C = "c" * 40
+
+
+def _make_function_node(
+    name: str = "retry",
+    *,
+    file_path: str = "src/m.py",
+    source_text: str = "def retry():\n    return 1\n",
+    repo_id: str = "",
+) -> NodeInfo:
+    return NodeInfo(
+        kind="Function",
+        name=name,
+        file_path=file_path,
+        line_start=1,
+        line_end=2,
+        language="python",
+        parent_name=None,
+        params="()",
+        return_type=None,
+        modifiers=None,
+        is_test=False,
+        extra={},
+        source_text=source_text,
+        repo_id=repo_id,
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Iterator[Path]:
+    """Build a fake repo workspace with .git + .code-review-graph/graph.db."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    crg_dir = ws / ".code-review-graph"
+    crg_dir.mkdir()
+    (crg_dir / ".gitignore").write_text("*\n")
+    yield ws
+
+
+@pytest.fixture
+def store(workspace: Path) -> Iterator[GraphStore]:
+    """File-backed GraphStore inside the fake workspace."""
+    db_path = workspace / ".code-review-graph" / "graph.db"
+    s = GraphStore(str(db_path))
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# (1) Default search returns only currently-valid rows
+# ---------------------------------------------------------------------------
+
+
+def test_query_search_default_returns_currently_valid_only(
+    workspace: Path, store: GraphStore
+) -> None:
+    """Insert at sha1, supersede at sha2 -- default search returns only sha2 row."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(source_text="def retry():\n    return 1\n"))
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(source_text="def retry():\n    return 2\n"))
+
+    # Two physical rows now exist for the same qualified_name; one closed
+    # out at sha_b and one currently valid (valid_to_sha IS NULL).
+    rows = store._conn.execute(
+        "SELECT valid_from_sha, valid_to_sha FROM nodes "
+        "WHERE qualified_name = 'src/m.py::retry' ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["valid_from_sha"] == _SHA_A
+    assert rows[0]["valid_to_sha"] == _SHA_B
+    assert rows[1]["valid_from_sha"] == _SHA_B
+    assert rows[1]["valid_to_sha"] is None
+
+    store.close()  # release WAL so the tools layer can reopen.
+
+    result = semantic_search_nodes(query="retry", repo_root=str(workspace))
+    assert result["status"] == "ok"
+    # Only the currently-valid row should surface; historical row is hidden.
+    qns = [r.get("qualified_name") for r in result["results"]]
+    assert qns.count("src/m.py::retry") == 1
+
+
+# ---------------------------------------------------------------------------
+# (2) as_of returns historical row at the requested sha
+# ---------------------------------------------------------------------------
+
+
+def test_query_search_as_of_returns_historical_row(
+    workspace: Path, store: GraphStore
+) -> None:
+    """as_of=sha_a returns the row introduced at sha_a even after supersede."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(source_text="def retry():\n    return 1\n"))
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(source_text="def retry():\n    return 2\n"))
+    store.close()
+
+    result = semantic_search_nodes(
+        query="retry", repo_root=str(workspace), as_of=_SHA_A
+    )
+    assert result["status"] == "ok"
+    qns = [r.get("qualified_name") for r in result["results"]]
+    # The historical row introduced at sha_a is what we asked for.
+    assert "src/m.py::retry" in qns
+
+
+# ---------------------------------------------------------------------------
+# (3) Unknown sha returns empty
+# ---------------------------------------------------------------------------
+
+
+def test_query_search_as_of_returns_empty_for_unknown_sha(
+    workspace: Path, store: GraphStore
+) -> None:
+    """as_of=non-existent-sha matches no rows."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node())
+    store.close()
+
+    result = semantic_search_nodes(
+        query="retry", repo_root=str(workspace), as_of=_SHA_C
+    )
+    assert result["status"] == "ok"
+    assert result["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# (4) diff requires both from_sha and to_sha
+# ---------------------------------------------------------------------------
+
+
+def test_diff_graph_requires_both_shas(workspace: Path, store: GraphStore) -> None:
+    """diff_graph returns error when from_sha or to_sha is missing."""
+    store.close()
+    err = diff_graph(repo_root=str(workspace), from_sha="", to_sha=_SHA_B)
+    assert "error" in err
+    err = diff_graph(repo_root=str(workspace), from_sha=_SHA_A, to_sha="")
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# (5) Added: rows introduced at to_sha
+# ---------------------------------------------------------------------------
+
+
+def test_diff_graph_returns_added_nodes(workspace: Path, store: GraphStore) -> None:
+    """A node first introduced at to_sha shows up in `added`."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(name="old_func"))
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(name="new_func"))
+    store.close()
+
+    result = diff_graph(repo_root=str(workspace), from_sha=_SHA_A, to_sha=_SHA_B)
+    assert result["from_sha"] == _SHA_A
+    assert result["to_sha"] == _SHA_B
+    added_qns = [r["qualified_name"] for r in result["added"]]
+    assert "src/m.py::new_func" in added_qns
+    assert "src/m.py::old_func" not in added_qns
+
+
+# ---------------------------------------------------------------------------
+# (6) Removed: rows closed at to_sha with no replacement
+# ---------------------------------------------------------------------------
+
+
+def test_diff_graph_returns_removed_nodes(workspace: Path, store: GraphStore) -> None:
+    """A node closed at to_sha (no new row at to_sha) shows up in `removed`."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(name="vanishing"))
+
+    # Sweep the file at sha_b with no observation -> closes out vanishing.
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.close_missing_nodes(file_path="src/m.py", observed_qualified=set())
+    store.close()
+
+    result = diff_graph(repo_root=str(workspace), from_sha=_SHA_A, to_sha=_SHA_B)
+    removed_qns = [r["qualified_name"] for r in result["removed"]]
+    assert "src/m.py::vanishing" in removed_qns
+    # Not in added (no replacement was inserted at sha_b).
+    added_qns = [r["qualified_name"] for r in result["added"]]
+    assert "src/m.py::vanishing" not in added_qns
+
+
+# ---------------------------------------------------------------------------
+# (7) Modified: closed AND new row with same qualified_name at to_sha
+# ---------------------------------------------------------------------------
+
+
+def test_diff_graph_returns_modified_nodes(workspace: Path, store: GraphStore) -> None:
+    """Supersede at to_sha (close-out + new row, same qualified_name) -> modified."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(_make_function_node(source_text="def retry():\n    return 1\n"))
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(source_text="def retry():\n    return 2\n"))
+    store.close()
+
+    result = diff_graph(repo_root=str(workspace), from_sha=_SHA_A, to_sha=_SHA_B)
+    modified_qns = [r["qualified_name"] for r in result["modified"]]
+    assert "src/m.py::retry" in modified_qns
+    # Modified rows must NOT also appear in added or removed.
+    added_qns = [r["qualified_name"] for r in result["added"]]
+    removed_qns = [r["qualified_name"] for r in result["removed"]]
+    assert "src/m.py::retry" not in added_qns
+    assert "src/m.py::retry" not in removed_qns
+
+
+# ---------------------------------------------------------------------------
+# (8) Repo filter narrows diff to the requested repo_id
+# ---------------------------------------------------------------------------
+
+
+def test_diff_graph_with_repo_filter(workspace: Path, store: GraphStore) -> None:
+    """diff_graph(... repo=...) excludes rows from other repos."""
+    repo_a = "repo_a-aaaaaaaa"
+    repo_b = "repo_b-bbbbbbbb"
+
+    idx_b_a = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b_a.upsert_node(
+        _make_function_node(name="added_in_a", repo_id=repo_a, file_path="a/m.py")
+    )
+    idx_b_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b_b.upsert_node(
+        _make_function_node(name="added_in_b", repo_id=repo_b, file_path="b/m.py")
+    )
+    store.close()
+
+    only_a = diff_graph(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        repo=repo_a,
+    )
+    added_qns_a = [r["qualified_name"] for r in only_a["added"]]
+    assert "a/m.py::added_in_a" in added_qns_a
+    assert "b/m.py::added_in_b" not in added_qns_a
+
+
+# ---------------------------------------------------------------------------
+# (9) impact_radius respects as_of
+# ---------------------------------------------------------------------------
+
+
+def test_query_impact_respects_as_of(workspace: Path, store: GraphStore) -> None:
+    """get_impact_radius(... as_of=sha) only walks rows valid at that sha.
+
+    Insert a node + edge at sha_a. Supersede the node at sha_b. With
+    as_of="" the seed file scan picks up the sha_b currently-valid row;
+    with as_of=sha_a it picks up the sha_a historical row. We assert the
+    impact response stays well-formed in both cases (the BFS is over
+    qualified_names, which are shared across the two physical rows).
+    """
+    file_path = str(workspace / "src" / "m.py")
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(file_path).write_text("def retry():\n    return 1\n")
+
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(
+            file_path=file_path, source_text="def retry():\n    return 1\n"
+        )
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(
+            file_path=file_path, source_text="def retry():\n    return 2\n"
+        )
+    )
+    store.close()
+
+    default_result = get_impact_radius(
+        changed_files=[file_path],
+        repo_root=str(workspace),
+        max_depth=1,
+    )
+    assert default_result["status"] == "ok"
+    default_qns = [n["qualified_name"] for n in default_result["changed_nodes"]]
+    # Currently-valid row should appear exactly once (no duplicates from the
+    # closed-out historical row).
+    assert default_qns.count(f"{file_path}::retry") == 1
+
+    historical_result = get_impact_radius(
+        changed_files=[file_path],
+        repo_root=str(workspace),
+        max_depth=1,
+        as_of=_SHA_A,
+    )
+    assert historical_result["status"] == "ok"
+    historical_qns = [n["qualified_name"] for n in historical_result["changed_nodes"]]
+    assert historical_qns.count(f"{file_path}::retry") == 1
+
+
+# ---------------------------------------------------------------------------
+# (10) server.query dispatches the diff action
+# ---------------------------------------------------------------------------
+
+
+def test_server_query_diff_action_dispatches(
+    workspace: Path, store: GraphStore
+) -> None:
+    """The MCP `query` tool with action='diff' returns the diff payload."""
+    from better_code_review_graph.server import query as query_tool
+
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(_make_function_node(name="brand_new"))
+    store.close()
+
+    raw = query_tool(
+        action="diff",
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        repo_root=str(workspace),
+    )
+    payload = json.loads(raw)
+    assert payload["from_sha"] == _SHA_A
+    assert payload["to_sha"] == _SHA_B
+    added_qns = [r["qualified_name"] for r in payload["added"]]
+    assert "src/m.py::brand_new" in added_qns

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,6 +108,7 @@ class TestQueryTool:
             repo_root="/test",
             languages=None,
             repo="",
+            as_of="",
         )
         assert result["status"] == "ok"
 
@@ -134,7 +135,12 @@ class TestQueryTool:
             )
         )
         mock_fn.assert_called_once_with(
-            query="auth", kind="Class", limit=5, repo_root="/test", repo=""
+            query="auth",
+            kind="Class",
+            limit=5,
+            repo_root="/test",
+            repo="",
+            as_of="",
         )
         assert result["status"] == "ok"
 
@@ -164,6 +170,7 @@ class TestQueryTool:
             base="HEAD~3",
             max_payload_bytes=500_000,
             repo="",
+            as_of="",
         )
         assert result["status"] == "ok"
 


### PR DESCRIPTION
## Summary
- All query/review SQL gains `AND valid_to_sha IS NULL` by default — returns currently-valid rows only. Backwards-compat because alembic 005 sets valid_to_sha=NULL on every row.
- New `as_of: str = ""` cross-cutting param on `query_graph`, `semantic_search_nodes`, `get_impact_radius`, etc. When set: replaces default filter with `(valid_from_sha = ? OR valid_to_sha = ?)` for snapshot semantics.
- New `diff` query action: `query_graph(action="diff", from_sha=X, to_sha=Y)` returns `{added, removed, modified}` buckets keyed by what valid_from_sha/valid_to_sha markers indicate.
- New `_temporal_filter()` helper in graph.py — returns static SQL fragment + bind params (Bandit-B608 safe).
- `_ensure_temporal_columns()` defensive backfill for `:memory:` GraphStores (mirrors `_ensure_federation_columns` pattern).
- `server.py` MCP `query` tool exposes `as_of`, `from_sha`, `to_sha`.

This is **Phase 3 Task 9 of 12** (epic #326). 9/12 done. Temporal columns from Task 6 + commits table from Task 7 + TemporalIndex from Task 8 are now reachable through the public MCP API.

## Test plan
- [x] `pytest tests/test_as_of_diff.py -v`: 10 tests pass.
- [x] `pytest --cov-fail-under=95 -q`: 1115 passed, coverage 95.44%, graph.py 97%, tools.py 92%, server.py 95%.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## MVP scope notes
- `diff_graph` uses `valid_from_sha == to_sha` / `valid_to_sha == to_sha` markers only. `from_sha` is captured but not used for filtering (genuinely added/removed at `to_sha` is the relevant signature).
- `get_impact_radius` threads `as_of` through seed + resolve only — BFS rides on the cached networkx graph. Full ancestor-walk via commits table is Task 9.5 follow-up.

## Files
- Modified: `src/better_code_review_graph/graph.py` (10 read methods + helper), `tools.py` (query_graph + 8 _handle_* + diff_graph), `server.py` (MCP signature), `tests/test_server.py` (3 mock-call updates).
- Created: `tests/test_as_of_diff.py` (10 tests).

## Out of scope
- Task 10: review.delta show_line_shifts (#320).
- Tasks 11-12: docs + release dry-run.