### PR TITLE
feat: Phase 3 Task 10 — review.delta show_line_shifts mode for refactor auditing (#320)

### DIFF
--- a/src/better_code_review_graph/docs/review.md
+++ b/src/better_code_review_graph/docs/review.md
@@ -2,7 +2,14 @@
 
 Generate focused, token-efficient review context for code changes. Combines impact analysis with source snippets and review guidance.
 
+## Actions
+
+- `context` (default): Auto-detects changed files from git diff and returns the structural summary, impacted nodes, source snippets, and review guidance.
+- `delta`: Wraps the `query.diff` buckets (added / removed / modified) and, when `show_line_shifts=true`, surfaces qualified_names whose `line_start` moved between two commits — useful for refactor auditing ("this function moved from line 10 to line 42, did anything break?").
+
 ## Parameters
+
+### context action
 
 - `changed_files`: Files to review (auto-detected from git diff if omitted)
 - `max_depth`: Impact radius depth (default: 2)
@@ -10,17 +17,29 @@ Generate focused, token-efficient review context for code changes. Combines impa
 - `max_lines_per_file`: Max source lines per file (default: 200)
 - `base`: Git ref for change detection (default: HEAD~1)
 - `repo_root`: Repository root path (auto-detected)
+- `languages`: Optional list of language names (e.g. `["python"]`) to scope the `untested_functions` list. Excludes functions whose language doesn't match.
 - `repo`: Federated repo filter (Phase 2). When non-empty, scopes the impact subgraph and untested-function audit to nodes whose `repo_id` matches. Default `""` includes every federated repo, so cross-repo callers/importers contribute to the review context. Useful when a PR touches one repo in a federated graph but you only want review guidance about that repo. See `graph.md` "Federation: cross-repo graphs" for `repo_id` discovery.
 
-## Example
+### delta action
+
+- `from_sha`: Earlier commit SHA (required).
+- `to_sha`: Later commit SHA (required).
+- `show_line_shifts`: When true, include nodes whose `line_start` moved between `from_sha` and `to_sha` in the response (default: false). Each entry is `{qualified_name, before_line, after_line}`.
+- `repo`: Federated repo filter (same semantics as context).
+- `repo_root`: Repository root path (auto-detected).
+
+## Examples
 
 ```json
 {"changed_files": ["src/auth.py"]}
-{"include_source": false, "base": "main"}
+{"action": "context", "include_source": false, "base": "main"}
 {"changed_files": ["src/auth.py"], "repo": "repo_a-3f2a91bc"}
+{"action": "delta", "from_sha": "abc123...", "to_sha": "def456...", "show_line_shifts": true}
 ```
 
 ## What It Returns
+
+### context action
 
 1. **Changed files** — auto-detected from git diff
 2. **Impacted nodes and files** — blast radius via BFS traversal
@@ -31,8 +50,14 @@ Generate focused, token-efficient review context for code changes. Combines impa
    - Inheritance/implementation relationship changes
    - Cross-file impact assessment
 
+### delta action
+
+- `diff`: The full `query.diff` payload (`from_sha`, `to_sha`, `added`, `removed`, `modified`).
+- `line_shifts` (only when `show_line_shifts=true`): list of `{qualified_name, before_line, after_line}` for every symbol whose `line_start` moved across the supersede pair at `to_sha`. Same-line supersedes (body changed but `line_start` unchanged) are excluded.
+
 ## Usage Tips
 
 - Use `base="main"` when reviewing a full PR (instead of just last commit)
 - Set `include_source=false` to reduce token usage when you only need structural info
 - Combine with `query(action="query", pattern="tests_for", target=<func>)` for deeper test coverage analysis
+- Use `action="delta"` with `show_line_shifts=true` to audit pure refactors — when no logic changed but functions moved, the `line_shifts` list pinpoints exactly which callsites a reviewer should re-verify.

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -28,6 +28,7 @@ from .tools import (
     list_graph_stats,
     query_graph,
     renamed_in_diff,
+    review_delta,
     security_report,
     security_rule_list,
     security_scan,
@@ -373,9 +374,13 @@ def query(
 @mcp.tool(
     description=(
         "Generate token-efficient review context for code changes. "
-        "Auto-detects changed files from git diff. Returns structural summary, "
-        "impacted nodes, source snippets, and review guidance. "
-        "Params: changed_files (auto), max_depth=2, include_source=true, max_lines_per_file=200, base='HEAD~1', repo_root (auto). "
+        "Actions: context (default — auto-detects changed files from git diff, returns "
+        "structural summary, impacted nodes, source snippets, and review guidance), "
+        "delta (from_sha, to_sha — wraps the `query.diff` buckets and, when "
+        "show_line_shifts=true, surfaces qualified_names whose line_start moved "
+        "between the two commits for refactor auditing). "
+        "Context params: changed_files (auto), max_depth=2, include_source=true, max_lines_per_file=200, base='HEAD~1', repo_root (auto). "
+        "Delta params: from_sha, to_sha, show_line_shifts=false, repo, repo_root. "
         "Use `help` tool for full docs."
     ),
     annotations=ToolAnnotations(
@@ -387,6 +392,7 @@ def query(
     ),
 )
 def review(
+    action: str = "context",
     changed_files: list[str] | None = None,
     max_depth: int = 2,
     include_source: bool = True,
@@ -395,40 +401,88 @@ def review(
     repo_root: str | None = None,
     languages: list[str] | None = None,
     repo: str = "",
+    # Phase 3 Task 10 — review.delta params
+    from_sha: str = "",
+    to_sha: str = "",
+    show_line_shifts: bool = False,
 ) -> str:
     """Generate focused review context for code changes.
 
-    Auto-detects changed files from git diff. Returns structural summary,
-    impacted nodes/files, source snippets, and review guidance.
+    Actions:
+
+    * ``context`` (default): Auto-detects changed files from git diff
+      and returns the structural summary + impacted nodes/files +
+      source snippets + review guidance produced by
+      :func:`get_review_context`. This is the original review tool
+      behaviour — calls without an explicit ``action`` continue to
+      hit this path.
+    * ``delta``: Wraps :func:`review_delta`. Given ``from_sha`` and
+      ``to_sha``, returns the ``diff`` buckets (added / removed /
+      modified) and, when ``show_line_shifts=True``, an extra
+      ``line_shifts`` list of ``{qualified_name, before_line,
+      after_line}`` entries for refactor auditing (Phase 3 Task 10).
 
     Args:
-        changed_files: Files to review (auto-detected from git if omitted)
-        max_depth: Impact radius depth (default: 2)
-        include_source: Include source code snippets (default: true)
-        max_lines_per_file: Max source lines per file (default: 200)
-        base: Git ref for change detection (default: HEAD~1)
-        repo_root: Repository root path (auto-detected)
-        languages: Optional list of language names (e.g. ``["python"]``) to
-            scope the ``untested_functions`` list. Excludes functions whose
-            language doesn't match. Fixes false positives on cross-language
-            repos (D16, fixes #340).
-        repo: Phase 2 Task 10 — when non-empty, scope the impact subgraph
-            to nodes whose ``repo_id`` matches (e.g.
-            ``repo='repo_a-aaaaaaaa'``). Default ``""`` includes every
-            federated repo.
+        action: ``context`` (default) or ``delta``.
+        changed_files: ``context`` action — files to review (auto-detected
+            from git if omitted).
+        max_depth: ``context`` action — impact radius depth (default: 2).
+        include_source: ``context`` action — include source code snippets
+            (default: true).
+        max_lines_per_file: ``context`` action — max source lines per file
+            (default: 200).
+        base: ``context`` action — git ref for change detection
+            (default: ``HEAD~1``).
+        repo_root: Repository root path (auto-detected). Both actions.
+        languages: ``context`` action — optional list of language names
+            (e.g. ``["python"]``) to scope the ``untested_functions``
+            list. Excludes functions whose language doesn't match. Fixes
+            false positives on cross-language repos (D16, fixes #340).
+        repo: Phase 2 Task 10 — when non-empty, scope to nodes whose
+            ``repo_id`` matches (e.g. ``repo='repo_a-aaaaaaaa'``).
+            Default ``""`` includes every federated repo. Both actions.
+        from_sha: ``delta`` action — earlier commit SHA. Required.
+        to_sha: ``delta`` action — later commit SHA. Required.
+        show_line_shifts: ``delta`` action — when True, include nodes
+            whose ``line_start`` moved between ``from_sha`` and
+            ``to_sha`` in the response (default False).
     """
-    return _json(
-        get_review_context(
-            changed_files=changed_files,
-            max_depth=max_depth,
-            include_source=include_source,
-            max_lines_per_file=max_lines_per_file,
-            repo_root=repo_root,
-            base=base,
-            languages=languages,
-            repo=repo,
-        )
-    )
+    match action:
+        case "context":
+            return _json(
+                get_review_context(
+                    changed_files=changed_files,
+                    max_depth=max_depth,
+                    include_source=include_source,
+                    max_lines_per_file=max_lines_per_file,
+                    repo_root=repo_root,
+                    base=base,
+                    languages=languages,
+                    repo=repo,
+                )
+            )
+        case "delta":
+            return _json(
+                review_delta(
+                    repo_root=repo_root,
+                    from_sha=from_sha,
+                    to_sha=to_sha,
+                    show_line_shifts=show_line_shifts,
+                    repo=repo,
+                )
+            )
+        case _:
+            import difflib
+
+            valid_actions = ["context", "delta"]
+            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
+            return _json(
+                {
+                    "error": f"Unknown action '{action}'.{suggestion}",
+                    "valid_actions": valid_actions,
+                }
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1475,6 +1475,108 @@ def diff_graph(
         store.close()
 
 
+def review_delta(
+    repo_root: str | None = None,
+    *,
+    from_sha: str = "",
+    to_sha: str = "",
+    show_line_shifts: bool = False,
+    repo: str = "",
+) -> dict[str, Any]:
+    """Review what changed between two commit SHAs (token-efficient).
+
+    Wraps :func:`diff_graph` with an opt-in ``show_line_shifts`` mode.
+    When the flag is set, the response gains a ``line_shifts`` list
+    pointing at every symbol whose ``line_start`` moved between the
+    two commits — useful for refactor auditing ("this function moved
+    from line 10 to line 42, did anything break?").
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        from_sha: Earlier commit SHA. Required.
+        to_sha: Later commit SHA. Required.
+        show_line_shifts: When True, include nodes whose ``line_start``
+            changed between ``from_sha`` and ``to_sha``. Default False
+            (response is just the ``diff`` payload to keep it light).
+        repo: Optional ``repo_id`` filter (Phase 2 Task 10 semantics).
+            Empty (default) returns the delta across every registered
+            repo.
+
+    Returns:
+        ``{"diff": <diff_graph payload>, "line_shifts": [...] (when
+        requested)}``. ``line_shifts`` entries are dicts with
+        ``qualified_name``, ``before_line`` (the closed-out row's
+        ``line_start``) and ``after_line`` (the freshly introduced
+        row's ``line_start``).
+    """
+    if not from_sha or not to_sha:
+        return {"error": "review_delta requires both from_sha and to_sha"}
+    diff_result = diff_graph(repo_root, from_sha=from_sha, to_sha=to_sha, repo=repo)
+    if "error" in diff_result:
+        return diff_result
+    payload: dict[str, Any] = {"diff": diff_result}
+    if show_line_shifts:
+        payload["line_shifts"] = _collect_line_shifts(repo_root, from_sha, to_sha, repo)
+    return payload
+
+
+def _collect_line_shifts(
+    repo_root: str | None,
+    from_sha: str,
+    to_sha: str,
+    repo: str,
+) -> list[dict[str, Any]]:
+    """Return ``line_start`` shifts across the close-out + new-row pair at ``to_sha``.
+
+    Joins the row closed at ``to_sha`` (``valid_to_sha = to_sha``)
+    against the row introduced at ``to_sha`` (``valid_from_sha =
+    to_sha``) on ``qualified_name`` and surfaces the line-number
+    delta. Same-line supersedes (body changed but ``line_start``
+    unchanged) are excluded by the SQL ``!=`` predicate.
+
+    The ``from_sha`` argument is reserved for a future ancestor-walk
+    scope check; the v1 implementation only needs ``to_sha`` because
+    every supersede transition is anchored on the new commit's SHA.
+    """
+    del from_sha  # reserved for future ancestor-walk scope check
+    store, _ = _get_store(repo_root)
+    try:
+        if repo:
+            rows = store._conn.execute(
+                "SELECT old.qualified_name, old.line_start AS before_line, "
+                "new.line_start AS after_line "
+                "FROM nodes old "
+                "JOIN nodes new ON old.qualified_name = new.qualified_name "
+                "WHERE old.valid_to_sha = ? "
+                "  AND new.valid_from_sha = ? "
+                "  AND old.line_start != new.line_start "
+                "  AND old.repo_id = ? "
+                "  AND new.repo_id = ?",
+                (to_sha, to_sha, repo, repo),
+            ).fetchall()
+        else:
+            rows = store._conn.execute(
+                "SELECT old.qualified_name, old.line_start AS before_line, "
+                "new.line_start AS after_line "
+                "FROM nodes old "
+                "JOIN nodes new ON old.qualified_name = new.qualified_name "
+                "WHERE old.valid_to_sha = ? "
+                "  AND new.valid_from_sha = ? "
+                "  AND old.line_start != new.line_start",
+                (to_sha, to_sha),
+            ).fetchall()
+        return [
+            {
+                "qualified_name": row[0],
+                "before_line": row[1],
+                "after_line": row[2],
+            }
+            for row in rows
+        ]
+    finally:
+        store.close()
+
+
 def spot_check_last_callers(
     n: int = 3,
     repo_root: str | None = None,

--- a/tests/test_review_delta_line_shifts.py
+++ b/tests/test_review_delta_line_shifts.py
@@ -1,0 +1,376 @@
+"""Phase 3 Task 10: ``review.delta(show_line_shifts=True)``.
+
+When a refactor moves a function (e.g. it shifts 30 lines down) the
+existing diff/added/removed/modified buckets only tell the reviewer
+that the symbol was modified — they do not surface the line-number
+shift itself. This test module pins the new ``show_line_shifts``
+opt-in flag on :func:`review_delta`.
+
+Behaviour pinned here:
+
+* ``show_line_shifts=False`` (default) returns just the ``diff`` payload
+  produced by :func:`diff_graph` (no ``line_shifts`` key).
+* ``show_line_shifts=True`` returns ``diff`` plus a ``line_shifts``
+  list of ``{qualified_name, before_line, after_line}`` for every
+  qualified_name that was superseded at ``to_sha`` AND whose
+  ``line_start`` actually changed across the close-out + new row pair.
+* Symbols superseded with the SAME ``line_start`` are excluded.
+* Repo filter narrows the line_shifts list to the requested ``repo_id``.
+* Multiple shifts in the same revision are all aggregated.
+* Missing ``from_sha`` or ``to_sha`` returns an error (parity with
+  :func:`diff_graph`).
+* The MCP ``review`` tool exposes ``show_line_shifts`` via the new
+  ``delta`` action.
+
+Fixtures use :class:`TemporalIndex` to build supersede state directly
+so the tests do not depend on the parser end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import NodeInfo
+from better_code_review_graph.temporal import TemporalIndex
+from better_code_review_graph.tools import review_delta
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+def _make_function_node(
+    name: str = "retry",
+    *,
+    file_path: str = "src/m.py",
+    line_start: int = 10,
+    line_end: int = 12,
+    source_text: str = "def retry():\n    return 1\n",
+    repo_id: str = "",
+) -> NodeInfo:
+    return NodeInfo(
+        kind="Function",
+        name=name,
+        file_path=file_path,
+        line_start=line_start,
+        line_end=line_end,
+        language="python",
+        parent_name=None,
+        params="()",
+        return_type=None,
+        modifiers=None,
+        is_test=False,
+        extra={},
+        source_text=source_text,
+        repo_id=repo_id,
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Iterator[Path]:
+    """Build a fake repo workspace with .git + .code-review-graph/graph.db."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    crg_dir = ws / ".code-review-graph"
+    crg_dir.mkdir()
+    (crg_dir / ".gitignore").write_text("*\n")
+    yield ws
+
+
+@pytest.fixture
+def store(workspace: Path) -> Iterator[GraphStore]:
+    """File-backed GraphStore inside the fake workspace."""
+    db_path = workspace / ".code-review-graph" / "graph.db"
+    s = GraphStore(str(db_path))
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# (1) show_line_shifts=False -> no line_shifts key
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_returns_diff_only_when_line_shifts_disabled(
+    workspace: Path, store: GraphStore
+) -> None:
+    """Default (show_line_shifts=False) returns diff payload without line_shifts."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 1\n")
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(line_start=42, source_text="def retry():\n    return 2\n")
+    )
+    store.close()
+
+    result = review_delta(repo_root=str(workspace), from_sha=_SHA_A, to_sha=_SHA_B)
+    assert "diff" in result
+    assert "line_shifts" not in result
+
+
+# ---------------------------------------------------------------------------
+# (2) show_line_shifts=True -> line_shifts populated for moved function
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_returns_line_shifts_when_enabled(
+    workspace: Path, store: GraphStore
+) -> None:
+    """show_line_shifts=True returns line_shifts entry for the moved function."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 1\n")
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(line_start=42, source_text="def retry():\n    return 2\n")
+    )
+    store.close()
+
+    result = review_delta(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+    )
+    shifts = result["line_shifts"]
+    assert len(shifts) == 1
+    assert shifts[0]["qualified_name"] == "src/m.py::retry"
+    assert shifts[0]["before_line"] == 10
+    assert shifts[0]["after_line"] == 42
+
+
+# ---------------------------------------------------------------------------
+# (3) Supersede with unchanged line_start -> excluded from line_shifts
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_line_shifts_skips_unchanged_lines(
+    workspace: Path, store: GraphStore
+) -> None:
+    """Supersede at to_sha but line_start unchanged -> not a line_shift."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 1\n")
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    # Same line_start=10 but body changes -> still a supersede, but no shift.
+    idx_b.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 2\n")
+    )
+    store.close()
+
+    result = review_delta(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+    )
+    assert result["line_shifts"] == []
+
+
+# ---------------------------------------------------------------------------
+# (4) Missing SHAs -> error
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_returns_error_without_shas(
+    workspace: Path, store: GraphStore
+) -> None:
+    """review_delta requires both from_sha and to_sha."""
+    store.close()
+    err = review_delta(repo_root=str(workspace), from_sha="", to_sha=_SHA_B)
+    assert "error" in err
+    err = review_delta(repo_root=str(workspace), from_sha=_SHA_A, to_sha="")
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# (5) Repo filter narrows line_shifts to the requested repo_id
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_with_repo_filter(workspace: Path, store: GraphStore) -> None:
+    """repo='repo_a-...' excludes line shifts from other federated repos."""
+    repo_a = "repo_a-aaaaaaaa"
+    repo_b = "repo_b-bbbbbbbb"
+
+    idx_a_repo_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a_repo_a.upsert_node(
+        _make_function_node(
+            name="moved_a",
+            file_path="a/m.py",
+            line_start=10,
+            source_text="def moved_a():\n    return 1\n",
+            repo_id=repo_a,
+        )
+    )
+    idx_a_repo_b = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a_repo_b.upsert_node(
+        _make_function_node(
+            name="moved_b",
+            file_path="b/m.py",
+            line_start=20,
+            source_text="def moved_b():\n    return 1\n",
+            repo_id=repo_b,
+        )
+    )
+
+    idx_b_repo_a = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b_repo_a.upsert_node(
+        _make_function_node(
+            name="moved_a",
+            file_path="a/m.py",
+            line_start=42,
+            source_text="def moved_a():\n    return 2\n",
+            repo_id=repo_a,
+        )
+    )
+    idx_b_repo_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b_repo_b.upsert_node(
+        _make_function_node(
+            name="moved_b",
+            file_path="b/m.py",
+            line_start=80,
+            source_text="def moved_b():\n    return 2\n",
+            repo_id=repo_b,
+        )
+    )
+    store.close()
+
+    only_a = review_delta(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+        repo=repo_a,
+    )
+    qns_a = [s["qualified_name"] for s in only_a["line_shifts"]]
+    assert "a/m.py::moved_a" in qns_a
+    assert "b/m.py::moved_b" not in qns_a
+
+
+# ---------------------------------------------------------------------------
+# (6) Multiple shifts aggregated
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_aggregates_multiple_shifts(
+    workspace: Path, store: GraphStore
+) -> None:
+    """3 functions all moved in the same commit -> all 3 in line_shifts."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    for i, name in enumerate(("alpha", "beta", "gamma")):
+        idx_a.upsert_node(
+            _make_function_node(
+                name=name,
+                file_path=f"src/{name}.py",
+                line_start=10 + i,
+                source_text=f"def {name}():\n    return 1\n",
+            )
+        )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    for i, name in enumerate(("alpha", "beta", "gamma")):
+        idx_b.upsert_node(
+            _make_function_node(
+                name=name,
+                file_path=f"src/{name}.py",
+                line_start=100 + i,
+                source_text=f"def {name}():\n    return 2\n",
+            )
+        )
+    store.close()
+
+    result = review_delta(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+    )
+    qns = sorted(s["qualified_name"] for s in result["line_shifts"])
+    assert qns == [
+        "src/alpha.py::alpha",
+        "src/beta.py::beta",
+        "src/gamma.py::gamma",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (7) Both diff and line_shifts present
+# ---------------------------------------------------------------------------
+
+
+def test_review_delta_diff_section_present_with_line_shifts(
+    workspace: Path, store: GraphStore
+) -> None:
+    """Both diff and line_shifts keys present when show_line_shifts=True."""
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 1\n")
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(line_start=42, source_text="def retry():\n    return 2\n")
+    )
+    store.close()
+
+    result = review_delta(
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+    )
+    assert "diff" in result
+    assert "line_shifts" in result
+    # The diff payload itself is the full diff_graph response.
+    assert result["diff"]["from_sha"] == _SHA_A
+    assert result["diff"]["to_sha"] == _SHA_B
+    modified_qns = [r["qualified_name"] for r in result["diff"]["modified"]]
+    assert "src/m.py::retry" in modified_qns
+
+
+# ---------------------------------------------------------------------------
+# (8) MCP review tool dispatches show_line_shifts via action='delta'
+# ---------------------------------------------------------------------------
+
+
+def test_server_review_tool_dispatches_show_line_shifts(
+    workspace: Path, store: GraphStore
+) -> None:
+    """The MCP `review` tool with action='delta' surfaces line_shifts."""
+    from better_code_review_graph.server import review as review_tool
+
+    idx_a = TemporalIndex(store, current_sha=_SHA_A)
+    idx_a.upsert_node(
+        _make_function_node(line_start=10, source_text="def retry():\n    return 1\n")
+    )
+    idx_b = TemporalIndex(store, current_sha=_SHA_B)
+    idx_b.upsert_node(
+        _make_function_node(line_start=42, source_text="def retry():\n    return 2\n")
+    )
+    store.close()
+
+    raw = review_tool(
+        action="delta",
+        repo_root=str(workspace),
+        from_sha=_SHA_A,
+        to_sha=_SHA_B,
+        show_line_shifts=True,
+    )
+    payload = json.loads(raw)
+    assert "diff" in payload
+    assert "line_shifts" in payload
+    qns = [s["qualified_name"] for s in payload["line_shifts"]]
+    assert "src/m.py::retry" in qns


### PR DESCRIPTION
## Summary
- New `review_delta(repo_root, from_sha, to_sha, show_line_shifts, repo)` returns `{diff, line_shifts?}` payload.
- New `_collect_line_shifts` SQL: JOINs nodes table with itself on qualified_name where one row has `valid_to_sha=to_sha` (closed at this commit) and another has `valid_from_sha=to_sha` (introduced at this commit), filters by `line_start` mismatch.
- `server.py` `review` tool now accepts `action="context"` (default, backwards-compat — original `get_review_context` path) or `action="delta"` (forwards to `review_delta`).
- `docs/review.md` documents the new delta action.
- Closes #320.

This is **Phase 3 Task 10 of 12** (epic #326).

## Test plan
- [x] `pytest tests/test_review_delta_line_shifts.py -v`: 8 tests pass.
- [x] `pytest --cov-fail-under=95 -q`: 1123 passed, coverage 95.32%.
- [x] Backwards compat: existing `test_review`/`test_review_defaults` in test_server.py still pass.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## Files
- Modified: `src/better_code_review_graph/tools.py` (review_delta + _collect_line_shifts), `server.py` (review tool action dispatch), `docs/review.md`.
- Created: `tests/test_review_delta_line_shifts.py` (8 tests).

## Out of scope
- Tasks 11-12: docs sweep + release dry-run.