### PR TITLE
fix: Phase 3 Task 11 — document security tool + temporal tracking + breaking migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,43 @@ mcp-name: io.github.n24q02m/better-code-review-graph
 
 Fork of [code-review-graph](https://github.com/tirth8205/code-review-graph) with critical bug fixes, configurable embeddings, and production CI/CD. Parses your codebase with [Tree-sitter](https://tree-sitter.github.io/tree-sitter/), builds a structural graph of functions/classes/imports, and gives Claude (or any MCP client) precise context so it reads only what matters.
 
+## v2.0 migration (BREAKING)
+
+This release adds **temporal columns** (`valid_from_sha` /
+`valid_to_sha` on every node + edge) and an opt-in **security
+scanner**. The schema migration is auto-applied on first
+`GraphStore` open, and a backup of the pre-2.0 DB is saved to
+`<graph_db>.pre-2.0.bak` so you can roll back if needed.
+
+To downgrade and restore the pre-2.0 backup:
+
+```sh
+CRG_DOWNGRADE_TO_1_X=1 uv run better-code-review-graph
+```
+
+The backup is created the first time alembic crosses the breaking
+boundary (revision `005_temporal_columns`); subsequent runs reuse
+the existing backup file. After a downgrade the v2-state DB is
+preserved at `<graph_db>.post-2.0.archived` so you can forward-roll
+again later.
+
+What you get on v2.0+:
+
+- **Temporal queries** -- `query`/`search`/`impact` accept
+  `as_of=<sha>` for snapshot semantics; `query(action="diff",
+  from_sha=X, to_sha=Y)` returns `{added, removed, modified}`
+  buckets driven entirely by the temporal columns (no re-parse).
+  See `help(topic="query")`.
+- **Refactor auditing** -- `review(action="delta",
+  show_line_shifts=true, ...)` surfaces symbols whose `line_start`
+  moved between two commits.
+- **Security scanning** -- `security(action="scan", ...)` runs a
+  regex-based Tier-1 scanner (5 rules) by default; pass
+  `engine="semgrep"` (after `uv add 'better-code-review-graph[security]'`)
+  for the ~120-rule Tier-2 overlay. Findings persist on
+  `nodes.security_tags`; `report` re-emits the cache as JSON or
+  SARIF v2.1.0. See `help(topic="security")`.
+
 ## What's new in v1.6
 
 - **LLM-generated summaries** -- `graph(action="summarize")` writes a one-paragraph docstring for each `Function` node via Gemini or OpenAI (cloud opt-in, no key = no-op). Run it after `graph(action="update")` to lift semantic-search recall by ~15% on repos with terse function names.

--- a/src/better_code_review_graph/docs/query.md
+++ b/src/better_code_review_graph/docs/query.md
@@ -91,3 +91,86 @@ Find functions, classes, or files exceeding a line-count threshold. Useful for d
 {"action": "large_functions", "file_path_pattern": "src/", "limit": 20}
 {"action": "large_functions", "min_lines": 100, "repo": "repo_a-3f2a91bc"}
 ```
+
+---
+
+## Temporal queries (Phase 3 v2.0+)
+
+Every `query` / `search` / `impact` action accepts an optional
+`as_of: str = ""` cross-cutting param for snapshot semantics. Default
+(`""`) returns currently-valid rows only -- the SQL filter is
+`WHERE valid_to_sha IS NULL`. The temporal columns are populated by
+the v2 ingest path (alembic revision `005_temporal_columns`), which
+auto-applies on first `GraphStore` open and seeds `valid_from_sha`
+from `git rev-parse HEAD`.
+
+### `as_of`
+
+When set, returns rows that were valid at the given commit SHA. MVP
+scope: matches rows where `valid_from_sha == as_of` OR
+`valid_to_sha == as_of`. Useful for "show me what `authenticate`
+looked like three commits ago" style queries.
+
+**Example:**
+```json
+{"action": "query", "pattern": "callers_of",
+ "target": "src/auth.py::authenticate",
+ "as_of": "abc12345"}
+```
+
+```json
+{"action": "search", "search_query": "authenticate",
+ "as_of": "abc12345"}
+```
+
+### `diff` action
+
+`query(action="diff", from_sha=X, to_sha=Y)` returns three buckets
+identifying nodes that changed between two commit SHAs. The diff is
+computed entirely from the temporal columns -- the parser does NOT
+re-run.
+
+| Bucket | Meaning |
+|---|---|
+| `added` | Introduced at `to_sha` (no prior row with same `qualified_name`). |
+| `removed` | Closed at `to_sha` with no replacement. |
+| `modified` | Superseded at `to_sha` -- one row closed AND a new row opened (function body changed). |
+
+**Parameters:**
+- `from_sha` (required): Earlier commit SHA.
+- `to_sha` (required): Later commit SHA.
+- `repo`: Optional `repo_id` filter.
+- `repo_root`: Repository root path (auto-detected).
+
+**Example:**
+```json
+{"action": "diff", "from_sha": "abc12345", "to_sha": "def67890"}
+```
+
+**Returns:**
+```json
+{
+  "from_sha": "abc12345",
+  "to_sha": "def67890",
+  "added": [
+    {"id": 17, "qualified_name": "src/auth.py::login_v2", "kind": "Function"}
+  ],
+  "removed": [
+    {"id": 4, "qualified_name": "src/auth.py::login_legacy", "kind": "Function"}
+  ],
+  "modified": [
+    {"qualified_name": "src/auth.py::authenticate"}
+  ]
+}
+```
+
+### Recipe -- audit a refactor commit
+
+```json
+{"tool": "query", "action": "diff",
+ "from_sha": "abc12345", "to_sha": "def67890"}
+```
+
+Pair with `review(action="delta", show_line_shifts=true, ...)` (see
+`review.md`) when you want callsite-line shifts on top of the
+add/remove/modify buckets.

--- a/src/better_code_review_graph/docs/recipes.md
+++ b/src/better_code_review_graph/docs/recipes.md
@@ -118,6 +118,44 @@ qualified-name format.
 
 ---
 
+## Security scanning
+
+Run a security scan over the graph and re-emit the cached result as
+SARIF for CI ingest:
+
+```json
+{"tool": "security", "action": "scan"}
+{"tool": "security", "action": "report", "format": "sarif"}
+```
+
+Tier 1 (heuristic, default) needs no extra deps. Tier 2 (Semgrep,
+~120 rules) is opt-in via `uv add 'better-code-review-graph[security]'`
+and `engine="semgrep"`. Suppress noisy rules persistently with
+`security(action="suppress", rule_id=...)`. See `security.md` for the
+bundled ruleset, SARIF envelope shape, and the Semgrep install recipe.
+
+---
+
+## Temporal review (v2.0+)
+
+Every `query` / `search` / `impact` accepts `as_of=<sha>` to pin
+results to a historical commit (default returns currently-valid
+rows). For two-point comparisons:
+
+```json
+{"tool": "query", "action": "diff",
+ "from_sha": "<earlier-sha>", "to_sha": "<later-sha>"}
+```
+
+Returns `{added, removed, modified}` buckets. Pair with
+`review(action="delta", show_line_shifts=true, from_sha=..., to_sha=...)`
+to also surface symbols whose `line_start` shifted between the two
+commits -- useful for refactor auditing. See `query.md` "Temporal
+queries" and `review.md` "delta action" for the full parameter
+reference.
+
+---
+
 ## Tips
 
 - `query.action="callers_of"` auto-resolves the bare-name File+Function

--- a/src/better_code_review_graph/docs/security.md
+++ b/src/better_code_review_graph/docs/security.md
@@ -1,0 +1,267 @@
+# `security` -- code security scanning
+
+The `security` tool surfaces vulnerability findings on `Function` /
+`Class` / `Method` nodes via two complementary engines:
+
+- **Tier 1 (heuristic)** -- always available, regex-based, ~5 rules
+  covering OWASP top sinks (SQL injection, shell injection, hardcoded
+  secrets, dynamic-evaluation, path traversal). Zero extra
+  dependencies; bundled rule files live under
+  `better_code_review_graph_security_rules/heuristic/*.yaml`.
+- **Tier 2 (semgrep)** -- opt-in via the `[security]` extra; wraps
+  the [Semgrep](https://semgrep.dev/) CLI for ~120 curated rules
+  drawn from the project's overlay set.
+
+Findings are persisted to `nodes.security_tags` as a JSON array of
+`<rule_id>:<severity>` strings so subsequent queries (or the
+`review` tool) can filter by tag without re-scanning.
+
+The four actions below operate on the graph DB at
+`<repo_root>/.code-review-graph/graph.db` (auto-detected when
+`repo_root` is omitted). Cached scan payloads land at
+`.code-review-graph/last-security-scan.json` and the
+suppression list at `.code-review-graph/security-suppressions.json`.
+
+## Actions
+
+### `scan`
+
+Run a security scan over every `Function` / `Class` / `Method` node
+in the graph. The result is cached on disk (so `report` can re-emit
+it without re-running the engine) and the per-node tags are
+persisted into `nodes.security_tags`.
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `repo_root` | str | None | Auto-detected from the current dir (looks for `.code-review-graph/graph.db`). |
+| `engine` | str | `"heuristic"` | `"heuristic"` (default, regex tier-1) or `"semgrep"` (tier-2; requires the `[security]` extra). |
+
+**Example:**
+
+```json
+{"action": "scan"}
+{"action": "scan", "engine": "semgrep"}
+```
+
+**Returns:**
+
+```json
+{
+  "engine": "heuristic",
+  "total": 3,
+  "by_severity": {"HIGH": 2, "MEDIUM": 1},
+  "by_rule": {
+    "cwe-89-sql-string-format": 1,
+    "cwe-78-shell-command-sink": 1,
+    "hardcoded-secret": 1
+  },
+  "tags_by_node": {
+    "src/db.py::run_query": [
+      {
+        "rule_id": "cwe-89-sql-string-format",
+        "severity": "HIGH",
+        "message": "Possible SQL injection via Python f-string or .format() in execute()",
+        "line": 42
+      }
+    ],
+    "src/cli.py::shell_out": [
+      {
+        "rule_id": "cwe-78-shell-command-sink",
+        "severity": "HIGH",
+        "message": "Possible shell command injection -- subprocess called with shell=True",
+        "line": 17
+      }
+    ],
+    "src/config.py::Settings": [
+      {
+        "rule_id": "hardcoded-secret",
+        "severity": "MEDIUM",
+        "message": "Possible hardcoded secret -- high-entropy string assigned to credential-like variable",
+        "line": 8
+      }
+    ]
+  },
+  "suppressed_count": 0
+}
+```
+
+When `engine="semgrep"` is requested but the CLI is not installed
+the action returns `{"error": "...", "engine": "semgrep"}` instead
+of raising -- install the extra and re-run (see Recipe 3).
+
+The Tier 1 ruleset bundled with v2.0:
+
+| `rule_id` | severity | languages | message |
+|---|---|---|---|
+| `cwe-89-sql-string-format` | HIGH | python | SQL injection via f-string / `.format()` in `execute()` |
+| `cwe-78-shell-command-sink` | HIGH | python | `subprocess.*` invoked with `shell=True` |
+| `cwe-22-path-traversal` | HIGH | python | File path concatenated with `request.*` data |
+| `cwe-95-eval-on-input` | CRITICAL | python, javascript | Dynamic-evaluation builtin applied directly to user input |
+| `hardcoded-secret` | MEDIUM | (any) | High-entropy string assigned to a credential-like variable |
+
+---
+
+### `report`
+
+Re-emit the most recent scan in JSON or SARIF v2.1.0 format. Reads
+the cached payload at `.code-review-graph/last-security-scan.json`
+-- does not re-run the engine.
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `repo_root` | str | None | Auto-detected. |
+| `format` | str | `"json"` | `"json"` returns the cached payload directly; `"sarif"` wraps it in a SARIF v2.1.0 envelope suitable for GitHub code-scanning ingest. |
+
+**Example:**
+
+```json
+{"action": "report"}
+{"action": "report", "format": "sarif"}
+```
+
+If no scan has run yet the action returns
+`{"error": "No prior scan found. Run security_scan first."}`.
+
+---
+
+### `suppress`
+
+Add (or remove) a `rule_id` from the persistent suppression list at
+`.code-review-graph/security-suppressions.json`. Suppressed rules
+are silently dropped from subsequent `scan` results -- the rule
+itself is NOT removed from the engine, only filtered out at
+aggregation time.
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `rule_id` | str | (required) | Rule identifier, e.g. `"hardcoded-secret"`. |
+| `remove` | bool | `false` | When `true`, removes `rule_id` from the suppression list instead of adding it. |
+| `repo_root` | str | None | Auto-detected. |
+
+**Example:**
+
+```json
+{"action": "suppress", "rule_id": "hardcoded-secret"}
+{"action": "suppress", "rule_id": "hardcoded-secret", "remove": true}
+```
+
+**Returns:**
+
+```json
+{
+  "rule_id": "hardcoded-secret",
+  "suppressed": true,
+  "total_suppressed": 1
+}
+```
+
+---
+
+### `rule_list`
+
+Enumerate active rules for the given engine.
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `engine` | str | `"heuristic"` | `"heuristic"` returns full rule metadata; `"semgrep"` returns the names of bundled overlay YAML files. |
+
+**Example:**
+
+```json
+{"action": "rule_list"}
+{"action": "rule_list", "engine": "semgrep"}
+```
+
+**Returns (heuristic):**
+
+```json
+{
+  "engine": "heuristic",
+  "rules": [
+    {
+      "id": "cwe-89-sql-string-format",
+      "severity": "HIGH",
+      "languages": ["python"],
+      "message": "Possible SQL injection via Python f-string or .format() in execute()"
+    }
+  ]
+}
+```
+
+**Returns (semgrep, when no overlay is bundled):**
+
+```json
+{"engine": "semgrep", "rules": [], "note": "no curated overlay found"}
+```
+
+---
+
+## Recipes
+
+### Recipe 1 -- scan + JSON report
+
+Run a heuristic scan, then re-emit the cached payload as JSON for
+downstream tooling (e.g. piping into `jq`):
+
+```json
+{"tool": "security", "action": "scan"}
+{"tool": "security", "action": "report"}
+```
+
+Use the same flow with `format="sarif"` to produce a SARIF v2.1.0
+envelope suitable for `github/codeql-action/upload-sarif`:
+
+```json
+{"tool": "security", "action": "report", "format": "sarif"}
+```
+
+---
+
+### Recipe 2 -- suppress a noisy rule
+
+If `hardcoded-secret` is firing on test fixtures full of fake API
+keys, suppress it persistently:
+
+```json
+{"tool": "security", "action": "suppress", "rule_id": "hardcoded-secret"}
+{"tool": "security", "action": "scan"}
+```
+
+The second `scan` returns the same shape as before but with
+`hardcoded-secret` entries filtered out and `suppressed_count`
+incremented. Lift the suppression later with `remove=true`:
+
+```json
+{"tool": "security", "action": "suppress", "rule_id": "hardcoded-secret", "remove": true}
+```
+
+---
+
+### Recipe 3 -- install the Semgrep tier
+
+The Tier 2 engine is intentionally opt-in -- Semgrep pulls in a
+sizeable runtime, so we don't ship it in the default install. Add
+the `[security]` extra to opt in:
+
+```sh
+uv add 'better-code-review-graph[security]'
+```
+
+Then run `scan` with `engine="semgrep"`:
+
+```json
+{"tool": "security", "action": "scan", "engine": "semgrep"}
+```
+
+If Semgrep is not installed the action returns
+`{"error": "...", "engine": "semgrep"}` -- install the extra and
+re-run, no scan state is mutated on the failure path.
+
+---
+
+## See also
+
+- `query.md` -- the `as_of` / `diff` cross-cutting params land
+  scanner findings on the right historical commit when used
+  together with `security.scan`.
+- `recipes.md` -- "Security scanning" pointer entry.


### PR DESCRIPTION
## Summary
- New `src/better_code_review_graph/docs/security.md` — 267 lines covering all 4 security actions (scan/report/suppress/rule_list), bundled 5-rule Tier-1 ruleset table, return shapes, 3 worked recipes (scan+report, suppress noisy rule, install Semgrep tier).
- `docs/query.md` — new "Temporal queries (Phase 3 v2.0+)" section: `as_of`, `diff` action with params + return shape, recipe pointer to review.md.
- `docs/recipes.md` — two new pointer sections: "Security scanning", "Temporal review (v2.0+)".
- `README.md` — new "v2.0 migration (BREAKING)" section: backup file, CRG_DOWNGRADE_TO_1_X=1 rollback, 3-bullet feature summary.
- `docs/review.md` already covered show_line_shifts from Task 10 PR #479.

This is **Phase 3 Task 11 of 12** (epic #326). 11/12 done.

## Test plan
- [x] All param signatures verified against `tools.py` (security_scan/report/suppress/rule_list, diff_graph, review_delta).
- [x] No emojis. No code changes.
- [x] `grep -c "directory" uv.lock`: 0.
- [ ] CI green.

## Files
- New: `src/better_code_review_graph/docs/security.md`.
- Modified: `README.md`, `src/better_code_review_graph/docs/query.md`, `src/better_code_review_graph/docs/recipes.md`.

## Note (out of scope)
- `help` MCP tool's `valid_topics` registry in `server.py` doesn't include `security` topic. The new `security.md` ships in the package data without an in-tool help shortcut. Follow-up task could wire it; the task spec explicitly forbade touching `src/*.py`.

## Out of scope (Task 12)
- Release dry-run + pre-2.0 release smoke + breaking-change banner.