### PR TITLE
fix: copy migrations/ + rules/ into Docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && cp uv.lock /tmp/uv
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
 COPY src/ src/
+COPY migrations/ migrations/
+COPY rules/ rules/
 RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && cp /tmp/uv.lock.docker uv.lock
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable


### PR DESCRIPTION
## Summary
- Phase 2 Task 0 added `[tool.hatch.build.targets.wheel.force-include]` mapping `migrations` -> `better_code_review_graph_migrations`. Phase 3 Task 3 added `rules` -> `better_code_review_graph_security_rules`.
- Dockerfile builder stage only copied `src/` so wheel build at `uv sync --no-editable` failed with: `FileNotFoundError: Forced include not found: /app/migrations`.
- Discovered by BETA CD run #25624422379 (Build Docker amd64 + arm64 both failed; PSR + PyPI succeeded).

## Test plan
- Add `COPY migrations/ migrations/` and `COPY rules/ rules/` before the second `uv sync` in builder stage.
- Re-dispatch `cd.yml -f release_type=beta` after merge to confirm Docker build green.