### PR TITLE
⚡ Bolt: Optimize memory usage in _run_security_scan

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2725,12 +2725,14 @@ def security_scan(
                 tags_by_node.setdefault("(repo-wide)", []).append(tag)
         else:
             scanner = HeuristicScanner()
-            rows = store._conn.execute(
+            # ⚡ Bolt: Iterate cursor directly instead of .fetchall() to prevent OOM
+            # on large codebases by lazily streaming the source_text column
+            cursor = store._conn.execute(
                 "SELECT qualified_name, language, line_start, source_text "
                 "FROM nodes WHERE source_text IS NOT NULL "
                 "AND kind IN ('Function','Class','Method')"
-            ).fetchall()
-            for row in rows:
+            )
+            for row in cursor:
                 view = _NodeView(
                     qualified_name=row["qualified_name"],
                     language=row["language"] or "",


### PR DESCRIPTION
💡 What: Replaced `.fetchall()` with a direct cursor iterator in `_run_security_scan`.
🎯 Why: `.fetchall()` materializes a massive intermediate list in Python's memory. When querying nodes with large `source_text` payloads in massive codebases, this causes huge memory spikes and Out-Of-Memory (OOM) errors. Lazily streaming database rows eliminates this bottleneck.
📊 Impact: Prevents massive memory spikes and drastically lowers peak memory usage for heuristic security scans on large repositories.
🔬 Measurement: Run a full graph security scan on a large repository and monitor peak RAM utilization before and after.

*Also added the finding to Bolt's journal.*

---
*PR created automatically by Jules for task [7739774641129605135](https://jules.google.com/task/7739774641129605135) started by @n24q02m*