### PR TITLE
⚡ Bolt: Optimize memory usage in security_scan

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2725,12 +2725,14 @@ def security_scan(
                 tags_by_node.setdefault("(repo-wide)", []).append(tag)
         else:
             scanner = HeuristicScanner()
-            rows = store._conn.execute(
+            # Bolt: Replaced .fetchall() with direct cursor iteration to avoid
+            # materializing massive lists of source_text in memory simultaneously.
+            cursor = store._conn.execute(
                 "SELECT qualified_name, language, line_start, source_text "
                 "FROM nodes WHERE source_text IS NOT NULL "
                 "AND kind IN ('Function','Class','Method')"
-            ).fetchall()
-            for row in rows:
+            )
+            for row in cursor:
                 view = _NodeView(
                     qualified_name=row["qualified_name"],
                     language=row["language"] or "",


### PR DESCRIPTION
💡 What: Replaced `.fetchall()` with a direct cursor iterator when fetching node source texts during `security_scan` in `src/better_code_review_graph/tools.py`.
🎯 Why: The original query fetched the entire row (including the potentially large `source_text` column) for all nodes into a massive materialized list in memory via `.fetchall()`. Iterating over the cursor directly streams the rows, mitigating extreme peak memory allocations and potential OOM issues on large codebases.
📊 Impact: Considerably reduces the peak memory footprint during full-repository security scans, specifically dependent on total LOC size.
🔬 Measurement: Run a large repository scan locally and compare the memory profile using tools like `memory-profiler` or observing process footprint. Memory should scale much more linearly with AST depth rather than total project size.

---
*PR created automatically by Jules for task [7915478712300880529](https://jules.google.com/task/7915478712300880529) started by @n24q02m*