### PR TITLE
⚡ Bolt: Optimize edge fetching by pushing kind filter to SQLite

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -945,29 +945,74 @@ class GraphStore:
         return [self._row_to_node(r) for r in rows]
 
     def get_edges_by_source(
-        self, qualified_name: str, *, as_of: str = ""
+        self,
+        qualified_name: str,
+        kind: str | tuple[str, ...] | None = None,
+        *,
+        as_of: str = "",
     ) -> list[GraphEdge]:
         frag, frag_params = self._temporal_filter(as_of)
+        kind_frag = ""
+        kind_params = []
+        if kind is not None:
+            if isinstance(kind, str):
+                kind_frag = " AND kind = ?"
+                kind_params.append(kind)
+            elif isinstance(kind, tuple) and kind:
+                placeholders = ",".join("?" for _ in kind)
+                kind_frag = f" AND kind IN ({placeholders})"
+                kind_params.extend(kind)
+
+        # Bolt: Optimized to push kind filtering into SQLite to prevent unnecessary object instantiation.
         rows = self._conn.execute(
-            f"SELECT * FROM edges WHERE source_qualified = ?{frag}",  # noqa: S608
-            (qualified_name, *frag_params),
+            f"SELECT * FROM edges WHERE source_qualified = ?{kind_frag}{frag}",  # noqa: S608
+            (qualified_name, *kind_params, *frag_params),
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
     def get_edges_by_target(
-        self, qualified_name: str, *, as_of: str = ""
+        self,
+        qualified_name: str,
+        kind: str | tuple[str, ...] | None = None,
+        *,
+        as_of: str = "",
     ) -> list[GraphEdge]:
         frag, frag_params = self._temporal_filter(as_of)
+        kind_frag = ""
+        kind_params = []
+        if kind is not None:
+            if isinstance(kind, str):
+                kind_frag = " AND kind = ?"
+                kind_params.append(kind)
+            elif isinstance(kind, tuple) and kind:
+                placeholders = ",".join("?" for _ in kind)
+                kind_frag = f" AND kind IN ({placeholders})"
+                kind_params.extend(kind)
+
+        # Bolt: Optimized to push kind filtering into SQLite to prevent unnecessary object instantiation.
         rows = self._conn.execute(
-            f"SELECT * FROM edges WHERE target_qualified = ?{frag}",  # noqa: S608
-            (qualified_name, *frag_params),
+            f"SELECT * FROM edges WHERE target_qualified = ?{kind_frag}{frag}",  # noqa: S608
+            (qualified_name, *kind_params, *frag_params),
         ).fetchall()
+
+        # We only want to trigger the fallback if the node itself has NO edges at all
+        # (meaning the fully qualified name isn't known to the graph as a target),
+        # not if it just happens to lack edges of this specific `kind`.
         if not rows and "::" in qualified_name:
+            if kind is not None:
+                # Check if it has any edges without the kind filter
+                any_rows = self._conn.execute(
+                    f"SELECT 1 FROM edges WHERE target_qualified = ?{frag} LIMIT 1",  # noqa: S608
+                    (qualified_name, *frag_params),
+                ).fetchall()
+                if any_rows:
+                    return []
+
             # Fallback: try matching bare name (last segment after ::)
             bare_name = qualified_name.rsplit("::", 1)[-1]
             rows = self._conn.execute(
-                f"SELECT * FROM edges WHERE target_qualified = ?{frag}",  # noqa: S608
-                (bare_name, *frag_params),
+                f"SELECT * FROM edges WHERE target_qualified = ?{kind_frag}{frag}",  # noqa: S608
+                (bare_name, *kind_params, *frag_params),
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -941,9 +941,8 @@ def _scan_dynamic_dispatch_hints(
     # import the target's file -- those are the most likely sites for
     # asyncio.to_thread(<target>) / functools.partial(<target>).
     try:
-        for e in store.get_edges_by_target(target_file):  # type: ignore[attr-defined]
-            if e.kind == "IMPORTS_FROM":
-                candidate_files.add(e.file_path)
+        for e in store.get_edges_by_target(target_file, kind="IMPORTS_FROM"):  # type: ignore[attr-defined]
+            candidate_files.add(e.file_path)
     except Exception:
         pass
 
@@ -1015,10 +1014,9 @@ def _handle_callees_of(
     as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_source(qn, as_of=as_of):
-        if e.kind == "CALLS":
-            qns.append(e.target_qualified)
-            edges_out.append(edge_to_dict(e))
+    for e in store.get_edges_by_source(qn, kind="CALLS", as_of=as_of):
+        qns.append(e.target_qualified)
+        edges_out.append(edge_to_dict(e))
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
@@ -1035,10 +1033,9 @@ def _handle_imports_of(
     *,
     as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_source(qn, as_of=as_of):
-        if e.kind == "IMPORTS_FROM":
-            results.append({"import_target": e.target_qualified})
-            edges_out.append(edge_to_dict(e))
+    for e in store.get_edges_by_source(qn, kind="IMPORTS_FROM", as_of=as_of):
+        results.append({"import_target": e.target_qualified})
+        edges_out.append(edge_to_dict(e))
 
 
 def _handle_importers_of(
@@ -1049,19 +1046,17 @@ def _handle_importers_of(
     *,
     as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_target(abs_target, as_of=as_of):
-        if e.kind == "IMPORTS_FROM":
-            results.append({"importer": e.source_qualified, "file": e.file_path})
-            edges_out.append(edge_to_dict(e))
+    for e in store.get_edges_by_target(abs_target, kind="IMPORTS_FROM", as_of=as_of):
+        results.append({"importer": e.source_qualified, "file": e.file_path})
+        edges_out.append(edge_to_dict(e))
 
 
 def _handle_children_of(
     store: Any, qn: str, results: list[dict], *, as_of: str = ""
 ) -> None:
     qns = []
-    for e in store.get_edges_by_source(qn, as_of=as_of):
-        if e.kind == "CONTAINS":
-            qns.append(e.target_qualified)
+    for e in store.get_edges_by_source(qn, kind="CONTAINS", as_of=as_of):
+        qns.append(e.target_qualified)
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
@@ -1080,9 +1075,8 @@ def _handle_tests_for(
     as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_target(qn, as_of=as_of):
-        if e.kind == "TESTED_BY":
-            qns.append(e.source_qualified)
+    for e in store.get_edges_by_target(qn, kind="TESTED_BY", as_of=as_of):
+        qns.append(e.source_qualified)
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}
@@ -1108,10 +1102,11 @@ def _handle_inheritors_of(
     as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_target(qn, as_of=as_of):
-        if e.kind in ("INHERITS", "IMPLEMENTS"):
-            qns.append(e.source_qualified)
-            edges_out.append(edge_to_dict(e))
+    for e in store.get_edges_by_target(
+        qn, kind=("INHERITS", "IMPLEMENTS"), as_of=as_of
+    ):
+        qns.append(e.source_qualified)
+        edges_out.append(edge_to_dict(e))
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
         node_map = {n.qualified_name: n for n in nodes}


### PR DESCRIPTION
💡 **What:** Added a `kind` parameter to `get_edges_by_source` and `get_edges_by_target` in `graph.py` which pushes the filtering logic into the SQLite query instead of loading all edges and filtering them in Python loops.
🎯 **Why:** To prevent massive object instantiation and garbage collection when fetching a highly connected node's edges only to discard most of them.
📊 **Impact:** Reduces object allocation and SQLite read overhead significantly for nodes with many mixed edges.
🔬 **Measurement:** You can verify the behavior via the automated tests. Codebase size stays approximately the same while performance increases.

---
*PR created automatically by Jules for task [7528520434285444830](https://jules.google.com/task/7528520434285444830) started by @n24q02m*