### PR TITLE
[TEST] Missing Test: list_graph_stats specific paths

### DIFF
--- a/tests/test_list_graph_stats_coverage.py
+++ b/tests/test_list_graph_stats_coverage.py
@@ -1,0 +1,148 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock missing dependencies before importing anything from the package
+mock_nx = MagicMock()
+sys.modules["networkx"] = mock_nx
+sys.modules["tree_sitter"] = MagicMock()
+sys.modules["tree_sitter_language_pack"] = MagicMock()
+sys.modules["alembic"] = MagicMock()
+sys.modules["alembic.config"] = MagicMock()
+sys.modules["alembic.command"] = MagicMock()
+sys.modules["watchdog"] = MagicMock()
+sys.modules["watchdog.observers"] = MagicMock()
+sys.modules["watchdog.events"] = MagicMock()
+sys.modules["mcp"] = MagicMock()
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.server.fastmcp"] = MagicMock()
+sys.modules["fastmcp"] = MagicMock()
+sys.modules["qwen3_embed"] = MagicMock()
+sys.modules["loguru"] = MagicMock()
+sys.modules["n24q02m_mcp_core"] = MagicMock()
+sys.modules["n24q02m_mcp_core.relay"] = MagicMock()
+sys.modules["n24q02m_mcp_core.relay.tool_helpers"] = MagicMock()
+
+import unittest  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+# Add src to sys.path to allow imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from better_code_review_graph.graph import GraphStats  # noqa: E402
+from better_code_review_graph.tools import list_graph_stats  # noqa: E402
+
+
+class TestListGraphStatsCoverage(unittest.TestCase):
+    def test_list_graph_stats_populated(self):
+        with (
+            unittest.mock.patch(
+                "better_code_review_graph.tools._get_store"
+            ) as mock_get_store,
+            unittest.mock.patch("better_code_review_graph.tools.init_backend"),
+            unittest.mock.patch(
+                "better_code_review_graph.tools.EmbeddingStore"
+            ) as mock_emb_store_class,
+            unittest.mock.patch(
+                "better_code_review_graph.tools.get_db_path"
+            ) as mock_get_db_path,
+            unittest.mock.patch(
+                "better_code_review_graph.tools.resolve_backend"
+            ) as mock_resolve_backend,
+        ):
+            # Setup mock store
+            mock_store = MagicMock()
+            mock_root = MagicMock()
+            mock_root.name = "test-repo"
+            mock_get_store.return_value = (mock_store, mock_root)
+
+            # Setup mock stats
+            stats = GraphStats(
+                total_nodes=100,
+                total_edges=200,
+                nodes_by_kind={"Function": 60, "Class": 40},
+                edges_by_kind={"CALLS": 150, "CONTAINS": 50},
+                languages=["python", "typescript"],
+                files_count=10,
+                last_updated="2023-10-27T10:00:00",
+            )
+            mock_store.get_stats.return_value = stats
+
+            # Setup mock embedding store
+            mock_emb_store = MagicMock()
+            mock_emb_store.count.return_value = 50
+            mock_emb_store_class.return_value = mock_emb_store
+
+            mock_resolve_backend.return_value = "local"
+            mock_get_db_path.return_value = Path("/tmp/fake.db")
+
+            result = list_graph_stats("/fake/repo")
+
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["total_nodes"], 100)
+            self.assertEqual(result["embeddings_count"], 50)
+            self.assertIn("Graph statistics for test-repo:", result["summary"])
+            self.assertIn("python, typescript", result["summary"])
+            self.assertIn("2023-10-27T10:00:00", result["summary"])
+            self.assertIn("Function: 60", result["summary"])
+            self.assertIn("CALLS: 150", result["summary"])
+            self.assertIn(
+                "Embeddings: 50 nodes embedded (backend: local)", result["summary"]
+            )
+
+            mock_store.close.assert_called_once()
+            mock_emb_store.close.assert_called_once()
+
+    def test_list_graph_stats_empty(self):
+        with (
+            unittest.mock.patch(
+                "better_code_review_graph.tools._get_store"
+            ) as mock_get_store,
+            unittest.mock.patch("better_code_review_graph.tools.init_backend"),
+            unittest.mock.patch(
+                "better_code_review_graph.tools.EmbeddingStore"
+            ) as mock_emb_store_class,
+            unittest.mock.patch(
+                "better_code_review_graph.tools.get_db_path"
+            ) as mock_get_db_path,
+            unittest.mock.patch(
+                "better_code_review_graph.tools.resolve_backend"
+            ) as mock_resolve_backend,
+        ):
+            # Setup mock store
+            mock_store = MagicMock()
+            mock_root = MagicMock()
+            mock_root.name = "empty-repo"
+            mock_get_store.return_value = (mock_store, mock_root)
+
+            # Setup mock stats
+            stats = GraphStats(
+                total_nodes=0,
+                total_edges=0,
+                nodes_by_kind={},
+                edges_by_kind={},
+                languages=[],
+                files_count=0,
+                last_updated=None,
+            )
+            mock_store.get_stats.return_value = stats
+
+            # Setup mock embedding store
+            mock_emb_store = MagicMock()
+            mock_emb_store.count.return_value = 0
+            mock_emb_store_class.return_value = mock_emb_store
+
+            mock_resolve_backend.return_value = "cloud"
+            mock_get_db_path.return_value = Path("/tmp/fake.db")
+
+            result = list_graph_stats(None)
+
+            self.assertEqual(result["status"], "ok")
+            self.assertIn("Languages: none", result["summary"])
+            self.assertIn("Last updated: never", result["summary"])
+            self.assertIn(
+                "Embeddings: 0 nodes embedded (backend: cloud)", result["summary"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_list_graph_stats_coverage.py
+++ b/tests/test_list_graph_stats_coverage.py
@@ -1,148 +1,164 @@
 import sys
-from unittest.mock import MagicMock
-
-# Mock missing dependencies before importing anything from the package
-mock_nx = MagicMock()
-sys.modules["networkx"] = mock_nx
-sys.modules["tree_sitter"] = MagicMock()
-sys.modules["tree_sitter_language_pack"] = MagicMock()
-sys.modules["alembic"] = MagicMock()
-sys.modules["alembic.config"] = MagicMock()
-sys.modules["alembic.command"] = MagicMock()
-sys.modules["watchdog"] = MagicMock()
-sys.modules["watchdog.observers"] = MagicMock()
-sys.modules["watchdog.events"] = MagicMock()
-sys.modules["mcp"] = MagicMock()
-sys.modules["mcp.server"] = MagicMock()
-sys.modules["mcp.server.fastmcp"] = MagicMock()
-sys.modules["fastmcp"] = MagicMock()
-sys.modules["qwen3_embed"] = MagicMock()
-sys.modules["loguru"] = MagicMock()
-sys.modules["n24q02m_mcp_core"] = MagicMock()
-sys.modules["n24q02m_mcp_core.relay"] = MagicMock()
-sys.modules["n24q02m_mcp_core.relay.tool_helpers"] = MagicMock()
-
-import unittest  # noqa: E402
-from pathlib import Path  # noqa: E402
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 # Add src to sys.path to allow imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from better_code_review_graph.graph import GraphStats  # noqa: E402
-from better_code_review_graph.tools import list_graph_stats  # noqa: E402
+# Surgical mocking only during import to avoid poisoning CI environment
+modules_to_mock = [
+    "networkx",
+    "tree_sitter",
+    "tree_sitter_language_pack",
+    "watchdog",
+    "watchdog.observers",
+    "watchdog.events",
+    "mcp",
+    "mcp.server",
+    "mcp.server.fastmcp",
+    "fastmcp",
+    "qwen3_embed",
+    "cohere",
+    "google.genai",
+    "openai",
+    "httpx",
+    "pydantic_settings",
+    "n24q02m_mcp_core",
+    "n24q02m_mcp_core.relay",
+    "n24q02m_mcp_core.relay.tool_helpers",
+    "n24q02m_mcp_core.storage",
+    "n24q02m_mcp_core.storage.per_plugin_store",
+    "pygments",
+    "pygments.lexers",
+    "pygments.formatters",
+    "alembic",
+    "alembic.config",
+    "alembic.command",
+]
 
 
-class TestListGraphStatsCoverage(unittest.TestCase):
-    def test_list_graph_stats_populated(self):
-        with (
-            unittest.mock.patch(
-                "better_code_review_graph.tools._get_store"
-            ) as mock_get_store,
-            unittest.mock.patch("better_code_review_graph.tools.init_backend"),
-            unittest.mock.patch(
-                "better_code_review_graph.tools.EmbeddingStore"
-            ) as mock_emb_store_class,
-            unittest.mock.patch(
-                "better_code_review_graph.tools.get_db_path"
-            ) as mock_get_db_path,
-            unittest.mock.patch(
-                "better_code_review_graph.tools.resolve_backend"
-            ) as mock_resolve_backend,
-        ):
-            # Setup mock store
-            mock_store = MagicMock()
-            mock_root = MagicMock()
-            mock_root.name = "test-repo"
-            mock_get_store.return_value = (mock_store, mock_root)
+class MockModule(MagicMock):
+    def __getattr__(self, name):
+        return MagicMock()
 
-            # Setup mock stats
-            stats = GraphStats(
-                total_nodes=100,
-                total_edges=200,
-                nodes_by_kind={"Function": 60, "Class": 40},
-                edges_by_kind={"CALLS": 150, "CONTAINS": 50},
-                languages=["python", "typescript"],
-                files_count=10,
-                last_updated="2023-10-27T10:00:00",
-            )
-            mock_store.get_stats.return_value = stats
 
-            # Setup mock embedding store
-            mock_emb_store = MagicMock()
-            mock_emb_store.count.return_value = 50
-            mock_emb_store_class.return_value = mock_emb_store
+def _get_tools_module():
+    # Mock only the missing ones
+    mocks = {}
+    for mod in modules_to_mock:
+        if mod not in sys.modules:
+            mocks[mod] = MockModule()
 
-            mock_resolve_backend.return_value = "local"
-            mock_get_db_path.return_value = Path("/tmp/fake.db")
+    with patch.dict(sys.modules, mocks):
+        import better_code_review_graph.tools as tools_mod
+        from better_code_review_graph.graph import GraphStats as stats_class
 
-            result = list_graph_stats("/fake/repo")
+        return tools_mod, stats_class
 
-            self.assertEqual(result["status"], "ok")
-            self.assertEqual(result["total_nodes"], 100)
-            self.assertEqual(result["embeddings_count"], 50)
-            self.assertIn("Graph statistics for test-repo:", result["summary"])
-            self.assertIn("python, typescript", result["summary"])
-            self.assertIn("2023-10-27T10:00:00", result["summary"])
-            self.assertIn("Function: 60", result["summary"])
-            self.assertIn("CALLS: 150", result["summary"])
-            self.assertIn(
-                "Embeddings: 50 nodes embedded (backend: local)", result["summary"]
-            )
 
-            mock_store.close.assert_called_once()
-            mock_emb_store.close.assert_called_once()
+tools, GraphStats = _get_tools_module()
 
-    def test_list_graph_stats_empty(self):
-        with (
-            unittest.mock.patch(
-                "better_code_review_graph.tools._get_store"
-            ) as mock_get_store,
-            unittest.mock.patch("better_code_review_graph.tools.init_backend"),
-            unittest.mock.patch(
-                "better_code_review_graph.tools.EmbeddingStore"
-            ) as mock_emb_store_class,
-            unittest.mock.patch(
-                "better_code_review_graph.tools.get_db_path"
-            ) as mock_get_db_path,
-            unittest.mock.patch(
-                "better_code_review_graph.tools.resolve_backend"
-            ) as mock_resolve_backend,
-        ):
-            # Setup mock store
-            mock_store = MagicMock()
-            mock_root = MagicMock()
-            mock_root.name = "empty-repo"
-            mock_get_store.return_value = (mock_store, mock_root)
 
-            # Setup mock stats
-            stats = GraphStats(
-                total_nodes=0,
-                total_edges=0,
-                nodes_by_kind={},
-                edges_by_kind={},
-                languages=[],
-                files_count=0,
-                last_updated=None,
-            )
-            mock_store.get_stats.return_value = stats
+def test_list_graph_stats_populated():
+    with (
+        patch.object(tools, "_get_store") as mock_get_store,
+        patch.object(tools, "init_backend"),
+        patch.object(tools, "EmbeddingStore") as mock_emb_store_class,
+        patch.object(tools, "get_db_path") as mock_get_db_path,
+        patch.object(tools, "resolve_backend") as mock_resolve_backend,
+    ):
+        # Setup mock store
+        mock_store = MagicMock()
+        mock_root = MagicMock()
+        mock_root.name = "test-repo"
+        mock_get_store.return_value = (mock_store, mock_root)
 
-            # Setup mock embedding store
-            mock_emb_store = MagicMock()
-            mock_emb_store.count.return_value = 0
-            mock_emb_store_class.return_value = mock_emb_store
+        # Setup mock stats
+        stats = GraphStats(
+            total_nodes=100,
+            total_edges=200,
+            nodes_by_kind={"Function": 60, "Class": 40},
+            edges_by_kind={"CALLS": 150, "CONTAINS": 50},
+            languages=["python", "typescript"],
+            files_count=10,
+            last_updated="2023-10-27T10:00:00",
+        )
+        mock_store.get_stats.return_value = stats
 
-            mock_resolve_backend.return_value = "cloud"
-            mock_get_db_path.return_value = Path("/tmp/fake.db")
+        # Setup mock embedding store
+        mock_emb_store = MagicMock()
+        mock_emb_store.count.return_value = 50
+        mock_emb_store_class.return_value = mock_emb_store
 
-            result = list_graph_stats(None)
+        mock_resolve_backend.return_value = "local"
+        mock_get_db_path.return_value = Path("/tmp/fake.db")
 
-            self.assertEqual(result["status"], "ok")
-            self.assertIn("Languages: none", result["summary"])
-            self.assertIn("Last updated: never", result["summary"])
-            self.assertIn(
-                "Embeddings: 0 nodes embedded (backend: cloud)", result["summary"]
-            )
+        result = tools.list_graph_stats("/fake/repo")
+
+        assert result["status"] == "ok"
+        assert result["total_nodes"] == 100
+        assert result["embeddings_count"] == 50
+        assert "Graph statistics for test-repo:" in result["summary"]
+        assert "python, typescript" in result["summary"]
+        assert "2023-10-27T10:00:00" in result["summary"]
+        assert "Function: 60" in result["summary"]
+        assert "CALLS: 150" in result["summary"]
+        assert "Embeddings: 50 nodes embedded (backend: local)" in result["summary"]
+
+        mock_store.close.assert_called_once()
+        mock_emb_store.close.assert_called_once()
+
+
+def test_list_graph_stats_empty():
+    with (
+        patch.object(tools, "_get_store") as mock_get_store,
+        patch.object(tools, "init_backend"),
+        patch.object(tools, "EmbeddingStore") as mock_emb_store_class,
+        patch.object(tools, "get_db_path") as mock_get_db_path,
+        patch.object(tools, "resolve_backend") as mock_resolve_backend,
+    ):
+        # Setup mock store
+        mock_store = MagicMock()
+        mock_root = MagicMock()
+        mock_root.name = "empty-repo"
+        mock_get_store.return_value = (mock_store, mock_root)
+
+        # Setup mock stats
+        stats = GraphStats(
+            total_nodes=0,
+            total_edges=0,
+            nodes_by_kind={},
+            edges_by_kind={},
+            languages=[],
+            files_count=0,
+            last_updated=None,
+        )
+        mock_store.get_stats.return_value = stats
+
+        # Setup mock embedding store
+        mock_emb_store = MagicMock()
+        mock_emb_store.count.return_value = 0
+        mock_emb_store_class.return_value = mock_emb_store
+
+        mock_resolve_backend.return_value = "cloud"
+        mock_get_db_path.return_value = Path("/tmp/fake.db")
+
+        result = tools.list_graph_stats(None)
+
+        assert result["status"] == "ok"
+        assert "Languages: none" in result["summary"]
+        assert "Last updated: never" in result["summary"]
+        assert "Embeddings: 0 nodes embedded (backend: cloud)" in result["summary"]
 
 
 if __name__ == "__main__":
-    unittest.main()
+    try:
+        test_list_graph_stats_populated()
+        test_list_graph_stats_empty()
+        print("All isolated tests passed!")
+    except Exception as e:
+        print(f"Tests failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
Adds tests/test_list_graph_stats_coverage.py to provide coverage for
the list_graph_stats MCP tool. The tests use mocking to bypass heavy
dependencies like networkx and tree-sitter, ensuring they can run in
constrained environments.

Covers:
- Populated graph statistics (nodes, edges, languages, embeddings).
- Empty graph statistics (no languages, no last update).
- Correct resource cleanup (closing stores).

---
*PR created automatically by Jules for task [11554214783240856164](https://jules.google.com/task/11554214783240856164) started by @n24q02m*