### PR TITLE
[CLEANUP] Unused function search_edges_by_target_name

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1021,19 +1021,6 @@ class GraphStore:
         )
         return [self._row_to_edge(r) for r in cursor]
 
-    def search_edges_by_target_name(
-        self, name: str, kind: str = "CALLS", *, as_of: str = ""
-    ) -> list[GraphEdge]:
-        """Search for edges where target_qualified matches an unqualified name.
-
-        CALLS edges often store unqualified target names (e.g. ``generateTestCode``)
-        rather than fully qualified ones (``file.ts::generateTestCode``).  This
-        method finds those edges by exact match on the plain function name so that
-        reverse call tracing (callers_of) works even when qualified-name lookup
-        returns nothing.
-        """
-        return self.search_edges_by_target_names([name], kind=kind, as_of=as_of)
-
     def search_edges_by_target_names(
         self, names: list[str], kind: str = "CALLS", *, as_of: str = ""
     ) -> list[GraphEdge]:

--- a/tests/test_graph_extra.py
+++ b/tests/test_graph_extra.py
@@ -380,7 +380,7 @@ class TestGraphStoreExtra:
         assert eid1 == eid2
         store.close()
 
-    def test_search_edges_by_target_name(self, tmp_path):
+    def test_search_edges_by_target_names(self, tmp_path):
         store = GraphStore(str(tmp_path / "t.db"))
         store.upsert_edge(
             EdgeInfo(
@@ -393,12 +393,12 @@ class TestGraphStoreExtra:
         )
         store.commit()
 
-        edges = store.search_edges_by_target_name("helper")
+        edges = store.search_edges_by_target_names(["helper"])
         assert len(edges) == 1
         assert edges[0].target_qualified == "helper"
 
         # Wrong kind should return empty
-        edges2 = store.search_edges_by_target_name("helper", kind="IMPORTS_FROM")
+        edges2 = store.search_edges_by_target_names(["helper"], kind="IMPORTS_FROM")
         assert len(edges2) == 0
         store.close()
 

--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -434,7 +434,7 @@ class TestQueryGraph:
         assert result["status"] in ("ok", "ambiguous", "not_found")
 
     def test_callers_of_fallback_bare_name(self, repo_with_graph):
-        """callers_of should use search_edges_by_target_name fallback."""
+        """callers_of should use search_edges_by_target_names fallback."""
         abs_auth = str(repo_with_graph / "auth.py")
         # Add an edge with unqualified target
         db_path = repo_with_graph / ".code-review-graph" / "graph.db"
@@ -1143,12 +1143,12 @@ class TestQueryGraphEdgeCases:
         assert "Fix stuff" in result["content"]
 
     def test_callers_of_bare_name_fallback(self, repo_with_graph):
-        """callers_of should fallback to search_edges_by_target_name when no qualified match.
+        """callers_of should fallback to search_edges_by_target_names when no qualified match.
 
         The first loop (get_edges_by_target) tries the qualified name and its bare
         name fallback in graph.py. For the tools.py fallback (lines 479-484) to run,
         we need a case where get_edges_by_target returns nothing but
-        search_edges_by_target_name finds the edge.
+        search_edges_by_target_names finds the edge.
 
         This happens when the edge target is stored as a bare name that differs
         from the last segment of the qualified name (e.g. "MyTarget" stored as edge
@@ -1210,7 +1210,7 @@ class TestQueryGraphEdgeCases:
             repo_root=str(repo_with_graph),
         )
         assert result["status"] == "ok"
-        # The fallback path should find the edge via search_edges_by_target_name("special_method")
+        # The fallback path should find the edge via search_edges_by_target_names(["special_method"])
         assert len(result["edges"]) >= 1
 
     def test_tests_for_with_tested_by_edge(self, repo_with_graph):

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.1b1"
+version = "3.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Removed the unused singular `search_edges_by_target_name` method from `GraphStore` in `src/better_code_review_graph/graph.py`. All callers (primarily in `tools.py`) had already been migrated to the batched `search_edges_by_target_names` method to avoid N+1 query patterns. Tests in `tests/test_graph_extra.py` were updated to use the batched version, and documentation references in `tests/test_tools_full.py` were modernized.

---
*PR created automatically by Jules for task [10295382830721551520](https://jules.google.com/task/10295382830721551520) started by @n24q02m*