### PR TITLE
[FIX] Unnecessary Multiple Queries for Test Nodes

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1081,10 +1081,9 @@ def _handle_tests_for(
         for qn_src in qns:
             if qn_src in node_map:
                 results.append(node_to_dict(node_map[qn_src]))
-    # Also search by naming convention
+    # Also search by naming convention (Bolt: combined into single query to reduce DB trips)
     name = node.name if node else target
-    test_nodes = store.search_nodes(f"test_{name}", limit=10, as_of=as_of)
-    test_nodes += store.search_nodes(f"Test{name}", limit=10, as_of=as_of)
+    test_nodes = store.search_nodes(f"test {name}", limit=20, as_of=as_of)
     seen = {r.get("qualified_name") for r in results}
     for t in test_nodes:
         if t.qualified_name not in seen and t.is_test:

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.1b1"
+version = "3.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Combined multiple `store.search_nodes` calls in `_handle_tests_for` into a single query using a multi-word query string. This reduces database trips during review context expansion by leveraging the search engine's AND logic for keyword matching.

---
*PR created automatically by Jules for task [5059380210678168325](https://jules.google.com/task/5059380210678168325) started by @n24q02m*