### PR TITLE
[FIX] High nesting depth in _collect_import_names

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -1107,40 +1107,58 @@ class CodeParser:
     ) -> None:
         """Extract imported names and their source modules into import_map."""
         if language == "python":
-            if node.type == "import_from_statement":
-                # from X.Y import A, B → {A: X.Y, B: X.Y}
-                module = None
-                seen_import_keyword = False
-                for child in node.children:
-                    if child.type == "dotted_name" and not seen_import_keyword:
-                        module = child.text.decode("utf-8", errors="replace")
-                    elif child.type == "import":
-                        seen_import_keyword = True
-                    elif seen_import_keyword and module:
-                        if child.type in ("identifier", "dotted_name"):
-                            name = child.text.decode("utf-8", errors="replace")
-                            import_map[name] = module
-                        elif child.type == "aliased_import":
-                            # from X import A as B → {B: X}
-                            names = [
-                                sub.text.decode("utf-8", errors="replace")
-                                for sub in child.children
-                                if sub.type in ("identifier", "dotted_name")
-                            ]
-                            # Last name is the alias (local name)
-                            if names:
-                                import_map[names[-1]] = module
-
+            self._handle_python_import(node, import_map)
         elif language in ("javascript", "typescript", "tsx"):
-            # import { A, B } from './path' → {A: ./path, B: ./path}
-            module = None
-            for child in node.children:
-                if child.type == "string":
-                    module = child.text.decode("utf-8", errors="replace").strip("'\"")
-            if module:
-                for child in node.children:
-                    if child.type == "import_clause":
-                        self._collect_js_import_names(child, module, import_map)
+            self._handle_js_import(node, import_map)
+
+    def _handle_python_import(self, node, import_map: dict[str, str]) -> None:
+        """Handle Python import statements."""
+        if node.type != "import_from_statement":
+            return
+
+        # from X.Y import A, B → {A: X.Y, B: X.Y}
+        module = None
+        seen_import_keyword = False
+        for child in node.children:
+            if child.type == "dotted_name" and not seen_import_keyword:
+                module = child.text.decode("utf-8", errors="replace")
+            elif child.type == "import":
+                seen_import_keyword = True
+            elif seen_import_keyword and module:
+                self._process_python_import_child(child, module, import_map)
+
+    def _process_python_import_child(
+        self, child, module: str, import_map: dict[str, str]
+    ) -> None:
+        """Process individual items in a Python 'from ... import' statement."""
+        if child.type in ("identifier", "dotted_name"):
+            name = child.text.decode("utf-8", errors="replace")
+            import_map[name] = module
+        elif child.type == "aliased_import":
+            # from X import A as B → {B: X}
+            names = [
+                sub.text.decode("utf-8", errors="replace")
+                for sub in child.children
+                if sub.type in ("identifier", "dotted_name")
+            ]
+            # Last name is the alias (local name)
+            if names:
+                import_map[names[-1]] = module
+
+    def _handle_js_import(self, node, import_map: dict[str, str]) -> None:
+        """Handle JS/TS import statements."""
+        # import { A, B } from './path' → {A: ./path, B: ./path}
+        module = None
+        for child in node.children:
+            if child.type == "string":
+                module = child.text.decode("utf-8", errors="replace").strip("\"'")
+
+        if not module:
+            return
+
+        for child in node.children:
+            if child.type == "import_clause":
+                self._collect_js_import_names(child, module, import_map)
 
     def _collect_js_import_names(
         self,


### PR DESCRIPTION
Refactored _collect_import_names in src/better_code_review_graph/parser.py to reduce nesting depth. The language-specific logic for Python and JavaScript imports was extracted into smaller, focused helper methods (_handle_python_import, _process_python_import_child, and _handle_js_import). This improves readability and maintainability. Verified the fix with isolated unit tests.

---
*PR created automatically by Jules for task [10587264334722398500](https://jules.google.com/task/10587264334722398500) started by @n24q02m*