### PR TITLE
fix: correct stale tool names in SessionStart hook guidance

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -9,10 +9,10 @@ if [ -f "$DB_PATH" ]; then
 [better-code-review-graph] Knowledge graph is available.
 
 When answering questions about this codebase, prefer using the better-code-review-graph MCP tools before scanning files manually:
-- Use semantic_search_nodes_tool to find classes, functions, or types by name or keyword.
-- Use query_graph_tool with patterns like callers_of, callees_of, imports_of, importers_of, children_of, tests_for, inheritors_of, or file_summary to explore relationships.
-- Use get_impact_radius_tool to understand the blast radius of changes.
-- Use get_review_context_tool for token-efficient review context.
+- Use the query tool with action="search" (search_query=...) to find classes, functions, or types by name or keyword (semantic search).
+- Use the query tool with action="query" and a pattern like callers_of, callees_of, imports_of, importers_of, children_of, tests_for, inheritors_of, or file_summary (with target=...) to explore relationships.
+- Use the query tool with action="impact" (changed_files=... or base=...) to understand the blast radius of changes.
+- Use the review tool with action="context" for token-efficient review context.
 - Fall back to Grep/Glob/Read only when the graph does not cover what you need.
 
 This saves significant tokens by avoiding full codebase scans.


### PR DESCRIPTION
## Problem

`hooks/session-start.sh` injects startup guidance that tells the agent to call:

- `semantic_search_nodes_tool`
- `query_graph_tool`
- `get_impact_radius_tool`
- `get_review_context_tool`

These are the **pre-consolidation granular tool names** and no longer resolve. The current MCP server (v3.16.1) exposes **6 consolidated tools** dispatched by an `action` argument: `graph`, `query`, `review`, `config`, `security`, `help`. So every session the hook points the agent at tools that don't exist.

## Fix

Update the injected guidance to the real contract:

| Old (dead) | New |
|---|---|
| `semantic_search_nodes_tool` | `query` action=`search` (`search_query=...`) |
| `query_graph_tool` | `query` action=`query` (`pattern=...`, `target=...`) |
| `get_impact_radius_tool` | `query` action=`impact` (`changed_files=...` / `base=...`) |
| `get_review_context_tool` | `review` action=`context` |

The `pattern` value list (`callers_of`, `callees_of`, …) is unchanged — those remain valid on `query` action=`query`.

## Verification

Verified the consolidated signatures against `server.py` and confirmed `query` action=`search` (semantic) and `query` action=`query` (`callers_of`) resolve on a real repo with this plugin installed.

One-file text change.

---

Note: this supersedes ph3on1x/claude-plugins PR (filed against the downstream synced copy). CodeRabbit correctly flagged that `plugins/**` in `claude-plugins` is synced from here, so the fix belongs in this source repo; the downstream PR will be closed in favor of this one.