### PR TITLE
⚡ Bolt: Replace fetchall() with direct cursor iteration to reduce peak memory

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -623,12 +623,14 @@ class EmbeddingStore:
         # Batch fetch existing metadata to prevent N+1 queries
         qns = [n.qualified_name for n in nodes if n.kind != "File"]
         existing_map: dict[str, dict[str, Any]] = {}
-        rows = self._conn.execute(
+        # Iterate over the cursor directly instead of materializing all rows
+        # with .fetchall() to reduce peak memory consumption.
+        cursor = self._conn.execute(
             "SELECT qualified_name, text_hash, provider FROM embeddings "
             "WHERE qualified_name IN (SELECT value FROM json_each(?))",
             (json.dumps(qns),),
-        ).fetchall()
-        for r in rows:
+        )
+        for r in cursor:
             existing_map[r["qualified_name"]] = r
 
         for node in nodes:

--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -90,11 +90,13 @@ class RepoRegistry:
 
     def _load_from_store(self) -> None:
         """Populate the in-memory caches from the ``repos`` table."""
-        rows = self._store._conn.execute(
+        # Iterate over the cursor directly instead of materializing all rows
+        # with .fetchall() to reduce peak memory consumption.
+        cursor = self._store._conn.execute(
             "SELECT repo_id, path, remote_url, last_indexed_sha, "
             "first_indexed_at, last_indexed_at FROM repos"
-        ).fetchall()
-        for row in rows:
+        )
+        for row in cursor:
             entry = RepoEntry(
                 repo_id=row["repo_id"],
                 path=Path(row["path"]),

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.2"
+version = "3.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 **What:** Replaced `.fetchall()` with direct cursor iteration in `src/better_code_review_graph/federation.py` and `src/better_code_review_graph/embeddings.py`. Added comments explaining the optimization rationale to prevent regressions.

🎯 **Why:** Using `.fetchall()` materializes all rows into a Python list in memory at once. For operations dealing with many nodes or embeddings, this can cause significant memory spikes. Iterating over the cursor directly keeps peak memory consumption low, which is particularly beneficial in constrained environments or very large monorepos.

📊 **Impact:** Reduces peak memory overhead during federation index loading and embedding batch fetch operations. This makes the indexing and querying process more robust against out-of-memory issues for extensive codebases.

🔬 **Measurement:** Code changes verified via the existing unit test suite (`uv run pytest`), ensuring no logic breaks. Peak memory benefits can be measured through profiling tools or memory monitors when running operations on large databases.

*Note:* I consciously omitted modifying the `.fetchall()` calls in `temporal.py` and `summarizer.py` because the processing loops for those queries perform modifications (like `UPDATE`s) or long-running network requests, where keeping a `SELECT` cursor open risks `OperationalError` due to database locks.

---
*PR created automatically by Jules for task [1706882591033503310](https://jules.google.com/task/1706882591033503310) started by @n24q02m*