### PR TITLE
fix: sync docs to actual 6-tool surface (security tool, config setup_* actions, recipes help topic)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 ## Cau truc
 
 - `src/better_code_review_graph/` -- Package chinh (src layout)
-  - `server.py` -- FastMCP server, 5 tools: graph + query + review (3 main) + config + help
+  - `server.py` -- FastMCP server, 6 tools: graph + query + review (3 main) + config + security + help
   - `tools.py` -- MCP tool implementations (build, query, impact, review, search, embed, stats, docs, large functions)
   - `parser.py` -- Tree-sitter parsing (13 langs) + call target resolution
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
@@ -51,7 +51,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 5 tools (graph + query + review + config + help)
+                                     FastMCP server --> 6 tools (graph + query + review + config + security + help)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -59,7 +59,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud multi-provider (Jina > Gemini > OpenAI > Cohere, auto-detected from env vars). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 5 tools — graph (build/update/stats/embed), query (query/search/impact/large_functions), review, config, help. Returns JSON strings.
+- **Server** (server.py): 6 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config, security, help. Returns JSON strings.
 
 ## Embedding backends
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 ## Cau truc
 
 - `src/better_code_review_graph/` -- Package chinh (src layout)
-  - `server.py` -- FastMCP server, 5 tools: graph + query + review (3 main) + config (incl. setup_*) + help
+  - `server.py` -- FastMCP server, 6 tools: graph + query + review (3 main) + config (incl. setup_*) + security + help
   - `tools.py` -- MCP tool implementations (build, query, impact, review, search, embed, stats, docs, large functions)
   - `parser.py` -- Tree-sitter parsing (13 langs) + call target resolution
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
@@ -15,7 +15,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `embeddings.py` -- Dual-mode embedding: ONNX local (qwen3-embed) + cloud (Jina/Gemini/OpenAI/Cohere)
   - `relay_setup.py` -- Zero-config relay: create session, poll for config
   - `relay_schema.py` -- Relay form schema (embedding provider fields)
-  - `docs/` -- Help tool documentation (graph.md, query.md, review.md, config.md)
+  - `docs/` -- Help tool documentation (graph.md, query.md, review.md, config.md, recipes.md, security.md)
   - `cli.py` -- CLI: starts MCP server (pure entry point)
   - `__init__.py` -- Version export
   - `__main__.py` -- `python -m` entry (calls cli.main)
@@ -53,7 +53,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 5 tools (graph + query + review + config + help)
+                                     FastMCP server --> 6 tools (graph + query + review + config + security + help)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -61,7 +61,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud multi-provider (Jina > Gemini > OpenAI > Cohere, auto-detected from env vars). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 5 tools — graph (build/update/stats/embed), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), help. Returns JSON strings.
+- **Server** (server.py): 6 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help. Returns JSON strings.
 
 ## Embedding backends
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ graph(action="embed")
 | callers_of/callees_of | Empty results (bare name targets) | Qualified name resolution + bare fallback |
 | Embedding | sentence-transformers + torch (1.1 GB) | qwen3-embed ONNX + cloud (200 MB), dual-mode |
 | Output size | Unbounded (500K+ chars) | Paginated (max_results, truncated flag) |
-| Tool design | 9 individual tools | 6 tools: graph + query + review + config + setup + help |
+| Tool design | 9 individual tools | 6 tools: graph + query + review + config + security + help |
 | Plugin hooks | Invalid PostEdit/PostGit | Valid PostToolUse |
 
 ## Status
@@ -190,31 +190,35 @@ Actions: `query` | `search` | `impact` | `large_functions`
 
 Token-optimized review context with structural summary, source snippets, and review guidance. Auto-detects changed files from git diff.
 
-### `config` -- Server configuration
+### `config` -- Server configuration and credential setup
 
-Actions: `status` | `set` | `cache_clear`
+Actions: `status` | `set` | `cache_clear` | `setup_status` | `setup_start` | `setup_skip` | `setup_reset` | `setup_complete`
 
 | Action | Description |
 |:-------|:------------|
 | `status` | Server info: version, graph path, node/edge counts, embedding backend. |
 | `set` | Update runtime settings (e.g., `log_level`). |
 | `cache_clear` | Remove all computed embeddings. |
+| `setup_status` | Show current credential state and setup URL. |
+| `setup_start` | Start relay setup to configure API keys via browser. |
+| `setup_skip` | Set local mode (skip relay permanently, use ONNX only). |
+| `setup_reset` | Clear credentials and reset state. |
+| `setup_complete` | Re-resolve credentials from environment variables. |
 
-### `setup` -- Credential setup
+### `security` -- Security scanning
 
-Actions: `status` | `start` | `skip` | `reset` | `complete`
+Actions: `scan` | `report` | `suppress` | `rule_list`
 
 | Action | Description |
 |:-------|:------------|
-| `status` | Show current credential state and setup URL. |
-| `start` | Start relay setup to configure API keys via browser. |
-| `skip` | Set local mode (skip relay permanently, use ONNX only). |
-| `reset` | Clear credentials and reset state. |
-| `complete` | Re-resolve credentials from environment variables. |
+| `scan` | Run a security scan (`engine='heuristic'` default, or `'semgrep'`). Findings persist on `nodes.security_tags`. |
+| `report` | Re-emit cached findings as JSON (`format='json'`) or SARIF v2.1.0 (`format='sarif'`). |
+| `suppress` | Suppress a finding by `rule_id` (or `remove=true` to un-suppress). |
+| `rule_list` | List available rules for an engine. |
 
 ### `help` -- Full documentation
 
-Topics: `graph` | `query` | `review` | `config`
+Topics: `graph` | `query` | `review` | `config` | `recipes`
 
 Returns complete documentation for each tool. Use when the compressed descriptions above are insufficient.
 


### PR DESCRIPTION
Docs-only sync. Every change verified against code file:line.

| doc file:line | claimed | actual (code file:line) |
|---|---|---|
| README:128, CLAUDE:10/56/64, AGENTS:10/54/62 | 5 tools / `...+ setup + help` | 6 tools incl. `security` (server.py:870); setup is not a tool |
| README:195 | config actions = status/set/cache_clear | config also has setup_status/start/skip/reset/complete (server.py:496-500) |
| README:203-213 | `setup` tool w/ status/start/skip/reset/complete | no setup tool; these are config.setup_* actions (server.py match block) |
| README (Tools) | no security section | security tool registered: scan/report/suppress/rule_list (server.py:853-877) |
| README:217 | help topics = graph/query/review/config | valid_topics adds `recipes` (server.py:810-816) |
| CLAUDE:18 | docs/ = graph,query,review,config | on disk also recipes.md, security.md |

Verified accurate, left unchanged: stdio default + HTTP opt-in (server.py:1016-1033); MCP_PORT default 8080, host 0.0.0.0 (server.py:966-968); MCP_DCR_SERVER_SECRET startup gate (server.py:960 — this IS read by CRG, unlike godot); storage path ~/.better-code-review-graph-mcp/config.json (mcp_core per_plugin_store.py:32); requires-python ==3.13.*; CRG_DOWNGRADE_TO_1_X (graph.py:39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)