### PR TITLE
fix: repoint dead docs/setup-manual.md link to hosted setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ graph(action="embed")
 >
 > Past months saw significant churn around credential handling and the daemon-bridge auto-spawn pattern. This caused multi-process races, browser tab spam, and inconsistent setup UX across plugins. **As of v<auto>, the architecture is stable**: 2 clean modes (stdio + HTTP), no daemon-bridge layer, no auto-spawn from stdio.
 >
-> Apologies for the instability period. If you encountered issues with prior versions, please update to v<auto>+ and follow the current `docs/setup-manual.md` -- most prior workarounds are no longer needed.
+> Apologies for the instability period. If you encountered issues with prior versions, please update to v<auto>+ and follow the current [Setup guide](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/) -- most prior workarounds are no longer needed.
 >
 > **Related plugins from the same author**:
 > - [wet-mcp](https://github.com/n24q02m/wet-mcp) -- Web search + content extraction


### PR DESCRIPTION
## Summary
The Status section linked `docs/setup-manual.md`, which does not exist in this repo (404). Repointed it to the hosted **Setup guide** already referenced in the Documentation section: https://mcp.n24q02m.com/servers/better-code-review-graph/setup/ (verified HTTP 200).

Same treatment applied consistently across all server READMEs that had this dead link (email, notion, crg, godot).

## Verification
- `docs/setup-manual.md` confirmed absent in repo.
- Target URL returns HTTP 200 and matches the URL already used in the README Documentation section.
- No source code touched; README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)