### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in export_graph_dispatch

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2485,7 +2485,7 @@ def export_graph_dispatch(
     """
     from .exporter import export_graph
 
-    store, _ = _get_store(repo_root)
+    store, root = _get_store(repo_root)
     try:
         payload = export_graph(store, format=format)
     except ValueError as e:
@@ -2495,7 +2495,13 @@ def export_graph_dispatch(
     byte_count = len(payload.encode("utf-8"))
 
     if output_path:
-        Path(output_path).write_text(payload, encoding="utf-8")
+        out_p = Path(output_path).resolve()
+        if not out_p.is_relative_to(root.resolve()):
+            return {
+                "status": "error",
+                "error": "output_path must be within the repository root",
+            }
+        out_p.write_text(payload, encoding="utf-8")
         return {
             "status": "ok",
             "format": fmt,

--- a/tests/test_export_graph_dispatch.py
+++ b/tests/test_export_graph_dispatch.py
@@ -74,6 +74,25 @@ def test_dispatch_inline_returns_payload(tmp_path):
     assert "output_path" not in result
 
 
+def test_dispatch_output_path_traversal_blocked(tmp_path):
+    """output_path outside repository root should return an error."""
+    out_file = tmp_path.parent / "out.graphml"
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        store = GraphStore(str(tmp_path / "test.db"))
+        try:
+            _populate_store(store)
+            mock_get_store.return_value = (store, tmp_path)
+            result = export_graph_dispatch(
+                repo_root=str(tmp_path),
+                format="graphml",
+                output_path=str(out_file),
+            )
+        finally:
+            store.close()
+    assert result["status"] == "error"
+    assert "within the repository root" in result["error"]
+
+
 def test_dispatch_with_output_path_writes_file(tmp_path):
     """output_path provided → writes file, returns metadata only (no inline payload)."""
     out_file = tmp_path / "out.graphml"

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal (Arbitrary File Write)
🎯 Impact: An attacker could write or overwrite files outside the repository root on the server file system by providing an absolute path or a path containing `../` in the `output_path` parameter of the `export_graph` tool.
🔧 Fix: Used `Path.resolve()` and `Path.is_relative_to()` to ensure that the user-provided `output_path` resolves to a path strictly within the `repo_root` directory.
✅ Verification: Ran `pytest tests/test_export_graph_dispatch.py` which passes with the newly added test `test_dispatch_output_path_traversal_blocked`.

---
*PR created automatically by Jules for task [3304215431180071795](https://jules.google.com/task/3304215431180071795) started by @n24q02m*