### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Graph Exporter

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2485,7 +2485,7 @@ def export_graph_dispatch(
     """
     from .exporter import export_graph
 
-    store, _ = _get_store(repo_root)
+    store, root = _get_store(repo_root)
     try:
         payload = export_graph(store, format=format)
     except ValueError as e:
@@ -2495,7 +2495,14 @@ def export_graph_dispatch(
     byte_count = len(payload.encode("utf-8"))
 
     if output_path:
-        Path(output_path).write_text(payload, encoding="utf-8")
+        out_p = Path(output_path).resolve()
+        if not out_p.is_relative_to(root.resolve()):
+            return {
+                "status": "error",
+                "error": "output_path must be relative to repo root",
+            }
+
+        out_p.write_text(payload, encoding="utf-8")
         return {
             "status": "ok",
             "format": fmt,

--- a/tests/test_export_graph_dispatch.py
+++ b/tests/test_export_graph_dispatch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.parser import EdgeInfo, NodeInfo
@@ -72,6 +72,28 @@ def test_dispatch_inline_returns_payload(tmp_path):
     assert "payload" in result
     assert "alpha" in result["payload"]
     assert "output_path" not in result
+
+
+def test_dispatch_path_traversal_blocked(tmp_path):
+    """Ensure output_path cannot write outside the repository root."""
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, tmp_path)
+
+        with patch("better_code_review_graph.exporter.export_graph") as mock_export:
+            mock_export.return_value = "<graphml>...</graphml>"
+
+            # Try to write to a path outside tmp_path
+            out_file = tmp_path.parent / "sneaky_file.graphml"
+            result = export_graph_dispatch(
+                repo_root=str(tmp_path),
+                format="graphml",
+                output_path=str(out_file),
+            )
+
+            assert result["status"] == "error"
+            assert "relative to repo root" in result["error"]
+            assert not out_file.exists()
 
 
 def test_dispatch_with_output_path_writes_file(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Graph Exporter

🚨 Severity: CRITICAL
💡 Vulnerability: `export_graph_dispatch` allowed arbitrary files to be written out of the repository root via the `output_path` parameter.
🎯 Impact: A malicious actor could write payload data into arbitrary files on the local filesystem.
🔧 Fix: Resolved the `output_path` and verified it is safely contained within the repository root before performing file write.
✅ Verification: Covered with `test_dispatch_path_traversal_blocked` test in `test_export_graph_dispatch.py`.

---
*PR created automatically by Jules for task [9290776014724434914](https://jules.google.com/task/9290776014724434914) started by @n24q02m*