### PR TITLE
[TEST] Untested function _estimate_payload_bytes

### DIFF
--- a/tests/test_payload_estimation.py
+++ b/tests/test_payload_estimation.py
@@ -1,0 +1,58 @@
+import json
+
+from better_code_review_graph.tools import _estimate_payload_bytes
+
+
+def test_estimate_payload_bytes_empty():
+    # No arguments
+    assert _estimate_payload_bytes() == 0
+    # Empty list and empty dict as separate arguments
+    assert _estimate_payload_bytes([], {}) == len(repr([])) + len(repr({}))
+
+
+def test_estimate_payload_bytes_single_dict():
+    payload = {"key": "value"}
+    estimated = _estimate_payload_bytes(payload)
+    actual_json_len = len(json.dumps(payload))
+    # repr({"key": "value"}) is "{'key': 'value'}" (16 chars)
+    # json.dumps({"key": "value"}) is '{"key": "value"}' (16 chars)
+    # It might vary depending on quotes but repr is generally a good upper bound or equal
+    assert estimated >= actual_json_len
+    assert estimated == len(repr(payload))
+
+
+def test_estimate_payload_bytes_multiple_payloads():
+    p1 = {"a": 1}
+    p2 = [{"b": 2}, {"c": 3}]
+    estimated = _estimate_payload_bytes(p1, p2)
+    expected = len(repr(p1)) + len(repr(p2))
+    assert estimated == expected
+
+    actual_json_len = len(json.dumps(p1)) + len(json.dumps(p2))
+    assert estimated >= actual_json_len
+
+
+def test_estimate_payload_bytes_with_strings_and_numbers():
+    payload = {"name": "Jules", "age": 30, "skills": ["python", "testing"]}
+    estimated = _estimate_payload_bytes(payload)
+    actual_json_len = len(json.dumps(payload))
+    assert estimated >= actual_json_len
+
+
+def test_estimate_payload_bytes_nested():
+    payload = {"outer": {"inner": [1, 2, 3]}}
+    estimated = _estimate_payload_bytes(payload)
+    actual_json_len = len(json.dumps(payload))
+    assert estimated >= actual_json_len
+
+
+def test_estimate_payload_bytes_overestimation_case():
+    # JSON uses " ", repr uses ' ' for strings usually.
+    # Boolean in JSON is true/false, in repr it's True/False.
+    payload = {"bool": True, "none": None}
+    estimated = _estimate_payload_bytes(payload)
+    # repr: {'bool': True, 'none': None} -> 26 chars
+    # json: {"bool": true, "none": null} -> 26 chars
+    # Actually repr is often longer because of single vs double quotes and capitalized booleans/None
+    actual_json_len = len(json.dumps(payload))
+    assert estimated >= actual_json_len

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `_estimate_payload_bytes` function in `src/better_code_review_graph/tools.py`.

The function was previously untested. The new tests verify:
- Empty inputs handle gracefully.
- Single and multiple dictionary payloads are estimated correctly.
- Nested structures and various data types (strings, numbers, booleans, None) are handled.
- The estimation consistently provides an upper bound compared to actual JSON-serialized size, which is critical for its use as a truncation gate.

---
*PR created automatically by Jules for task [16395329293394426122](https://jules.google.com/task/16395329293394426122) started by @n24q02m*