### PR TITLE
[FIX] Long function: _run_alembic_upgrade

### DIFF
--- a/refactor_graph.py
+++ b/refactor_graph.py
@@ -1,0 +1,127 @@
+import sys
+
+def refactor():
+    with open('src/better_code_review_graph/graph.py', 'r') as f:
+        lines = f.readlines()
+
+    start_line = -1
+    end_line = -1
+    for i, line in enumerate(lines):
+        if 'def _run_alembic_upgrade(self) -> None:' in line:
+            start_line = i
+        if start_line != -1 and 'def _read_alembic_version(self) -> str | None:' in line:
+            end_line = i
+            break
+
+    if start_line == -1 or end_line == -1:
+        print(f"Could not find boundaries: start={start_line}, end={end_line}")
+        return
+
+    new_methods = """    def _run_alembic_upgrade(self) -> None:
+        \"\"\"Bring ``self.db_path`` to alembic head before legacy bootstrap.
+
+        Four cases are handled:
+
+        * Empty DB (no tables) — alembic creates everything from scratch.
+        * Legacy DB created by Phase 1's ``executescript(_SCHEMA_SQL)`` +
+          ``_ensure_summary_columns`` (so it already has ``nodes``/``edges``/
+          ``metadata`` but no ``alembic_version`` table) — we stamp it to
+          revision ``002`` before upgrading so the baseline ``CREATE TABLE``
+          statements are skipped.
+        * DB already managed by alembic — ``upgrade("head")`` is a no-op.
+        * DB recorded at a revision the package does not ship (user
+          fast-forwarded by hand, or the package was downgraded).  We
+          re-raise as a :class:`RuntimeError` with a human-readable
+          recovery hint instead of leaking an opaque
+          ``alembic.util.exc.CommandError``.
+
+        Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
+        only loaded when a ``GraphStore`` is actually instantiated.
+        \"\"\"
+        cfg, command, ScriptDirectory, CommandError = self._get_alembic_config()
+
+        if self._handle_downgrade_request():
+            return
+
+        self._maybe_stamp_legacy_db(cfg, command)
+        self._maybe_take_backup_before_upgrade(cfg, ScriptDirectory)
+
+        try:
+            command.upgrade(cfg, "head")
+        except CommandError as exc:
+            self._handle_alembic_command_error(cfg, ScriptDirectory, exc)
+
+    def _get_alembic_config(self):
+        from alembic import command
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+        from alembic.util.exc import CommandError
+
+        migrations_dir = _resolve_migrations_dir()
+        cfg = Config()
+        cfg.set_main_option("script_location", str(migrations_dir))
+        cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
+        return cfg, command, ScriptDirectory, CommandError
+
+    def _handle_downgrade_request(self) -> bool:
+        if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
+            self._restore_pre_2_0_backup()
+            return True
+        return False
+
+    def _maybe_stamp_legacy_db(self, cfg, command) -> None:
+        existing = {
+            row[0]
+            for row in self._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        if "nodes" in existing:
+            needs_stamp = "alembic_version" not in existing
+            if not needs_stamp:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM alembic_version"
+                ).fetchone()
+                needs_stamp = row[0] == 0
+            if needs_stamp:
+                command.stamp(cfg, "002")
+
+    def _maybe_take_backup_before_upgrade(self, cfg, ScriptDirectory) -> None:
+        current_rev = self._read_alembic_version()
+        target_rev = ScriptDirectory.from_config(cfg).get_current_head()
+        if _crosses_breaking_boundary(current_rev, target_rev):
+            self._take_pre_2_0_backup()
+
+    def _handle_alembic_command_error(self, cfg, ScriptDirectory, exc) -> None:
+        import sqlite3
+        recorded: str | None
+        try:
+            row = self._conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()
+            recorded = row[0] if row else None
+        except sqlite3.Error:
+            recorded = None
+        head = ScriptDirectory.from_config(cfg).get_current_head()
+        raise RuntimeError(
+            f"Graph DB at {self.db_path} reports alembic revision "
+            f"{recorded!r} which is not shipped with this version of "
+            f"better-code-review-graph (head={head!r}). Either downgrade "
+            "the package or recreate the DB."
+        ) from exc
+
+    # ------------------------------------------------------------------
+    # Phase 3 Task 1 — backup / restore helpers
+    # ------------------------------------------------------------------
+
+"""
+    new_lines = new_methods.splitlines(keepends=True)
+
+    # Replace old method with new methods
+    lines[start_line:end_line] = new_lines
+
+    with open('src/better_code_review_graph/graph.py', 'w') as f:
+        f.writelines(lines)
+
+if __name__ == "__main__":
+    refactor()

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -280,6 +280,20 @@ class GraphStore:
         Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
         only loaded when a ``GraphStore`` is actually instantiated.
         """
+        cfg, command, ScriptDirectory, CommandError = self._get_alembic_config()
+
+        if self._handle_downgrade_request():
+            return
+
+        self._maybe_stamp_legacy_db(cfg, command)
+        self._maybe_take_backup_before_upgrade(cfg, ScriptDirectory)
+
+        try:
+            command.upgrade(cfg, "head")
+        except CommandError as exc:
+            self._handle_alembic_command_error(cfg, ScriptDirectory, exc)
+
+    def _get_alembic_config(self):
         from alembic import command
         from alembic.config import Config
         from alembic.script import ScriptDirectory
@@ -289,27 +303,15 @@ class GraphStore:
         cfg = Config()
         cfg.set_main_option("script_location", str(migrations_dir))
         cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
+        return cfg, command, ScriptDirectory, CommandError
 
-        # Phase 3 Task 1 — early-exit downgrade path.
-        #
-        # When the operator sets ``CRG_DOWNGRADE_TO_1_X=1`` we restore
-        # the pre-2.0 backup BEFORE any alembic activity (including
-        # the auto-stamp branch below — stamping a v1.x DB to "002"
-        # is the same idempotent outcome as the restored DB already
-        # being at "002", but we still skip it to avoid touching the
-        # restored file at all).
+    def _handle_downgrade_request(self) -> bool:
         if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
             self._restore_pre_2_0_backup()
-            return
+            return True
+        return False
 
-        # Detect "legacy DB": pre-existing structural tables but alembic
-        # has not yet recorded a head revision. Two sub-cases:
-        #   1. ``alembic_version`` table is missing entirely.
-        #   2. ``alembic_version`` exists but has no row (an interrupted
-        #      prior run, or a test fixture that touched the DB before
-        #      alembic was wired up).
-        # In both cases we stamp at ``002`` so the baseline ``CREATE
-        # TABLE`` is skipped on the subsequent ``upgrade("head")``.
+    def _maybe_stamp_legacy_db(self, cfg, command) -> None:
         existing = {
             row[0]
             for row in self._conn.execute(
@@ -326,42 +328,30 @@ class GraphStore:
             if needs_stamp:
                 command.stamp(cfg, "002")
 
-        # Phase 3 Task 1 — backup before BREAKING migration crosses the
-        # 005 boundary.  Read the current recorded revision (post-stamp)
-        # and the script-directory head; if the chain crosses 005,
-        # snapshot the SQLite file via ``shutil.copy2`` so the operator
-        # can roll back via ``CRG_DOWNGRADE_TO_1_X=1`` if the BREAKING
-        # migration produces a worse outcome than expected.  Idempotent:
-        # an existing backup is preserved (could be from an earlier
-        # partial run that aborted mid-upgrade — that copy is closer to
-        # the true v1.x state than anything we'd produce now).
+    def _maybe_take_backup_before_upgrade(self, cfg, ScriptDirectory) -> None:
         current_rev = self._read_alembic_version()
         target_rev = ScriptDirectory.from_config(cfg).get_current_head()
         if _crosses_breaking_boundary(current_rev, target_rev):
             self._take_pre_2_0_backup()
 
+    def _handle_alembic_command_error(self, cfg, ScriptDirectory, exc) -> None:
+        import sqlite3
+
+        recorded: str | None
         try:
-            command.upgrade(cfg, "head")
-        except CommandError as exc:
-            # Most likely cause: ``alembic_version`` references a revision
-            # this package does not ship.  Re-raise with the unknown
-            # revision and the local head spelt out so the operator knows
-            # whether to downgrade the package or recreate the DB.
-            recorded: str | None
-            try:
-                row = self._conn.execute(
-                    "SELECT version_num FROM alembic_version"
-                ).fetchone()
-                recorded = row[0] if row else None
-            except sqlite3.Error:
-                recorded = None
-            head = ScriptDirectory.from_config(cfg).get_current_head()
-            raise RuntimeError(
-                f"Graph DB at {self.db_path} reports alembic revision "
-                f"{recorded!r} which is not shipped with this version of "
-                f"better-code-review-graph (head={head!r}). Either downgrade "
-                "the package or recreate the DB."
-            ) from exc
+            row = self._conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()
+            recorded = row[0] if row else None
+        except sqlite3.Error:
+            recorded = None
+        head = ScriptDirectory.from_config(cfg).get_current_head()
+        raise RuntimeError(
+            f"Graph DB at {self.db_path} reports alembic revision "
+            f"{recorded!r} which is not shipped with this version of "
+            f"better-code-review-graph (head={head!r}). Either downgrade "
+            "the package or recreate the DB."
+        ) from exc
 
     # ------------------------------------------------------------------
     # Phase 3 Task 1 — backup / restore helpers

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR addresses the issue of the long `_run_alembic_upgrade` function in `src/better_code_review_graph/graph.py`.

### Changes:
- Extracted logic from `_run_alembic_upgrade` into five private helper methods:
  - `_get_alembic_config`: Handles lazy loading and setup of Alembic configuration.
  - `_handle_downgrade_request`: Handles the early-exit downgrade logic.
  - `_maybe_stamp_legacy_db`: Handles legacy DB detection and stamping.
  - `_maybe_take_backup_before_upgrade`: Handles pre-migration backups.
  - `_handle_alembic_command_error`: Provides detailed error reporting for Alembic failures.
- Simplified `_run_alembic_upgrade` to orchestrate these helpers.
- Preserved lazy loading of Alembic dependencies to maintain startup performance.
- Verified with `ruff`, `ty`, and the existing test suite (including `test_alembic_baseline.py` and `test_pre_2_0_backup.py`).

---
*PR created automatically by Jules for task [11170108445000184486](https://jules.google.com/task/11170108445000184486) started by @n24q02m*