### PR TITLE
[FIX] Long function: get_impact_radius

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -507,6 +507,69 @@ def _estimate_payload_bytes(*payloads: list[dict] | dict) -> int:
     return sum(len(repr(p)) for p in payloads)
 
 
+def _resolve_impact_radius_files(
+    root: Path, changed_files: list[str] | None, base: str
+) -> tuple[list[str], list[str]]:
+    """Resolve and validate changed files for impact radius analysis."""
+    if changed_files is None:
+        changed_files = get_changed_files(root, base)
+        if not changed_files:
+            changed_files = get_staged_and_unstaged(root)
+
+    if not changed_files:
+        return [], []
+
+    abs_files = []
+    root_resolved = root.resolve()
+    for f in changed_files:
+        full_path_raw = root / f
+        full_path = full_path_raw.resolve()
+        if not full_path.is_relative_to(root_resolved):
+            continue
+        if full_path_raw.is_symlink() or full_path.is_symlink():
+            continue
+        abs_files.append(str(full_path))
+    return changed_files, abs_files
+
+
+def _truncate_impact_radius_payload(
+    changed_dicts: list[dict],
+    impacted_dicts: list[dict],
+    edge_dicts: list[dict],
+    max_payload_bytes: int,
+) -> tuple[list[dict], list[dict], bool, str | None, int, int]:
+    """Iteratively truncate impacted nodes/edges to stay under payload cap."""
+    results_truncated = False
+    results_truncated_reason: str | None = None
+    original_impacted_count = len(impacted_dicts)
+    original_edges_count = len(edge_dicts)
+
+    if max_payload_bytes and max_payload_bytes > 0:
+        estimated = _estimate_payload_bytes(changed_dicts, impacted_dicts, edge_dicts)
+        if estimated > max_payload_bytes:
+            results_truncated = True
+            # Halve until we fit (or down to a minimum sample of 10 each).
+            while _estimate_payload_bytes(
+                changed_dicts, impacted_dicts, edge_dicts
+            ) > max_payload_bytes and (
+                len(impacted_dicts) > 10 or len(edge_dicts) > 10
+            ):
+                impacted_dicts = impacted_dicts[: max(10, len(impacted_dicts) // 2)]
+                edge_dicts = edge_dicts[: max(10, len(edge_dicts) // 2)]
+            results_truncated_reason = (
+                f"impact payload exceeded {max_payload_bytes} bytes "
+                f"(was approximately {estimated})"
+            )
+    return (
+        impacted_dicts,
+        edge_dicts,
+        results_truncated,
+        results_truncated_reason,
+        original_impacted_count,
+        original_edges_count,
+    )
+
+
 def get_impact_radius(
     changed_files: list[str] | None = None,
     max_depth: int = 2,
@@ -550,11 +613,9 @@ def get_impact_radius(
     """
     store, root = _get_store(repo_root)
     try:
-        if changed_files is None:
-            changed_files = get_changed_files(root, base)
-            if not changed_files:
-                changed_files = get_staged_and_unstaged(root)
-
+        changed_files, abs_files = _resolve_impact_radius_files(
+            root, changed_files, base
+        )
         if not changed_files:
             return {
                 "status": "ok",
@@ -565,18 +626,6 @@ def get_impact_radius(
                 "truncated": False,
                 "total_impacted": 0,
             }
-
-        # Convert to absolute paths for graph lookup
-        abs_files = []
-        root_resolved = root.resolve()
-        for f in changed_files:
-            full_path_raw = root / f
-            full_path = full_path_raw.resolve()
-            if not full_path.is_relative_to(root_resolved):
-                continue
-            if full_path_raw.is_symlink() or full_path.is_symlink():
-                continue
-            abs_files.append(str(full_path))
 
         result = store.get_impact_radius(
             abs_files,
@@ -592,6 +641,17 @@ def get_impact_radius(
         truncated = result["truncated"]
         total_impacted = result["total_impacted"]
 
+        (
+            impacted_dicts,
+            edge_dicts,
+            res_truncated,
+            res_reason,
+            orig_impacted_count,
+            orig_edges_count,
+        ) = _truncate_impact_radius_payload(
+            changed_dicts, impacted_dicts, edge_dicts, max_payload_bytes
+        )
+
         summary_parts = [
             f"Blast radius for {len(changed_files)} changed file(s):",
             f"  - {len(changed_dicts)} nodes directly changed",
@@ -603,38 +663,12 @@ def get_impact_radius(
                 f"  - TRUNCATED: results capped at {max_results} nodes"
                 f" ({total_impacted} total impacted)"
             )
-
-        # #315: payload-size auto-truncation. Even with max_results=500 the
-        # impacted_nodes + edges arrays can blow past the conversation
-        # token budget for shared utils (observed: 7.6MB, 12MB). Trim
-        # iteratively until the rough JSON size fits under the soft cap.
-        results_truncated = False
-        results_truncated_reason: str | None = None
-        original_impacted_count = len(impacted_dicts)
-        original_edges_count = len(edge_dicts)
-        if max_payload_bytes and max_payload_bytes > 0:
-            estimated = _estimate_payload_bytes(
-                changed_dicts, impacted_dicts, edge_dicts
+        if res_truncated:
+            summary_parts.append(
+                f"  - PAYLOAD TRUNCATED: kept {len(impacted_dicts)} of "
+                f"{orig_impacted_count} impacted nodes / "
+                f"{len(edge_dicts)} of {orig_edges_count} edges"
             )
-            if estimated > max_payload_bytes:
-                results_truncated = True
-                # Halve until we fit (or down to a minimum sample of 10 each).
-                while _estimate_payload_bytes(
-                    changed_dicts, impacted_dicts, edge_dicts
-                ) > max_payload_bytes and (
-                    len(impacted_dicts) > 10 or len(edge_dicts) > 10
-                ):
-                    impacted_dicts = impacted_dicts[: max(10, len(impacted_dicts) // 2)]
-                    edge_dicts = edge_dicts[: max(10, len(edge_dicts) // 2)]
-                results_truncated_reason = (
-                    f"impact payload exceeded {max_payload_bytes} bytes "
-                    f"(was approximately {estimated})"
-                )
-                summary_parts.append(
-                    f"  - PAYLOAD TRUNCATED: kept {len(impacted_dicts)} of "
-                    f"{original_impacted_count} impacted nodes / "
-                    f"{len(edge_dicts)} of {original_edges_count} edges"
-                )
 
         response: dict[str, Any] = {
             "status": "ok",
@@ -647,15 +681,15 @@ def get_impact_radius(
             "truncated": truncated,
             "total_impacted": total_impacted,
         }
-        if results_truncated:
+        if res_truncated:
             response["results_truncated"] = True
-            response["reason"] = results_truncated_reason
+            response["reason"] = res_reason
             response["hint"] = (
                 "rerun with max_depth=1, narrow changed_files scope, or "
                 "raise max_payload_bytes if you can handle a larger response"
             )
-            response["original_impacted_count"] = original_impacted_count
-            response["original_edges_count"] = original_edges_count
+            response["original_impacted_count"] = orig_impacted_count
+            response["original_edges_count"] = orig_edges_count
         return response
     finally:
         store.close()

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR refactors the `get_impact_radius` function in `src/better_code_review_graph/tools.py`, which was identified as being too long and complex. 

Key changes:
- Extracted file detection and absolute path resolution (including symlink and path traversal checks) into `_resolve_impact_radius_files`.
- Extracted iterative payload truncation logic into `_truncate_impact_radius_payload`.
- Simplified the main `get_impact_radius` function to coordinate these helpers, resulting in a much cleaner and more maintainable implementation.
- Functional parity is preserved, as verified by existing unit tests.
- Code style and linting updated via Ruff.

---
*PR created automatically by Jules for task [16478745015784056452](https://jules.google.com/task/16478745015784056452) started by @n24q02m*