### PR TITLE
[FIX] Handle non-dict payload test setup bug

### DIFF
--- a/tests/test_full_live.py
+++ b/tests/test_full_live.py
@@ -113,19 +113,16 @@ export { Circle, Rectangle, totalArea };
 """
 
 
-def _parse_result_text(result) -> dict[str, Any]:
-    """Extract text from MCP call_tool result and parse as JSON.
-
-    All tools in better-code-review-graph return JSON-encoded dicts; a
-    non-dict payload indicates a test setup bug, so we fail loudly here.
-    """
+def _parse_result_text(result) -> Any:
+    """Extract text from MCP call_tool result and try to parse as JSON."""
     text = result.content[0].text
-    payload = json.loads(text)
-    if not isinstance(payload, dict):
-        raise TypeError(
-            f"Expected JSON object from MCP tool, got {type(payload).__name__}: {text!r}"
-        )
-    return payload
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            return payload
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return text
 
 
 def _server_params() -> StdioServerParameters:
@@ -692,6 +689,30 @@ class TestFullMultiLang:
                 assert "Circle" in names or "totalArea" in names, (
                     f"Expected TypeScript nodes in file summary, got {names}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# TestFullHelp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.full
+class TestFullHelp:
+    """Test the help tool returns raw Markdown."""
+
+    async def test_help_returns_markdown(self):
+        """help(topic="graph") should return raw Markdown content."""
+        async with stdio_client(_server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                result = await session.call_tool("help", {"topic": "graph"})
+                data = _parse_result_text(result)
+
+                # Should be a string starting with Markdown content
+                assert isinstance(data, str)
+                assert "graph" in data.lower()
+                assert "build" in data.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `_parse_result_text` helper in `tests/test_full_live.py` was too strict, assuming all MCP tool results are JSON-encoded dictionaries. This caused tests to fail when calling tools like `help`, which return raw Markdown strings.

This PR:
1. Fixes `_parse_result_text` to return raw text if JSON parsing fails or if the result is not a dictionary.
2. Updates the type hint of `_parse_result_text` to `Any` to satisfy `ty` type checking across all call sites (which previously expected `dict`).
3. Adds a new `TestFullHelp` class to `tests/test_full_live.py` to ensure the `help` tool is properly tested and handled by the fixed helper.

---
*PR created automatically by Jules for task [6684371078338221917](https://jules.google.com/task/6684371078338221917) started by @n24q02m*