### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in export_graph_dispatch

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2485,7 +2485,7 @@ def export_graph_dispatch(
     """
     from .exporter import export_graph
 
-    store, _ = _get_store(repo_root)
+    store, root = _get_store(repo_root)
     try:
         payload = export_graph(store, format=format)
     except ValueError as e:
@@ -2495,7 +2495,15 @@ def export_graph_dispatch(
     byte_count = len(payload.encode("utf-8"))
 
     if output_path:
-        Path(output_path).write_text(payload, encoding="utf-8")
+        out_p = Path(output_path).resolve()
+        # Security: Prevent path traversal by ensuring the output path stays within the repository
+        if not out_p.is_relative_to(root.resolve()):
+            return {
+                "status": "error",
+                "error": f"Invalid output path: {output_path} resolves outside repository root.",
+            }
+
+        out_p.write_text(payload, encoding="utf-8")
         return {
             "status": "ok",
             "format": fmt,

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in export_graph_dispatch

🚨 **Severity:** HIGH
💡 **Vulnerability:** The `export_graph_dispatch` function allowed saving graph exports to arbitrary locations via the user-controlled `output_path` parameter, leading to an arbitrary file write/path traversal vulnerability.
🎯 **Impact:** An attacker could overwrite critical files on the system or write new files outside of the repository boundary wherever the backend server has permissions.
🔧 **Fix:** Implemented a bounds check to ensure the resolved `output_path` is strictly relative to the target repository `root`. If an invalid path is detected, the MCP tool safely returns an error.
✅ **Verification:** A test exploit was created during development which attempted to write to `/tmp/exploit.txt` and verified that the operation was blocked securely. The pytest test suite remains green.

---
*PR created automatically by Jules for task [8554895416312072243](https://jules.google.com/task/8554895416312072243) started by @n24q02m*