### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Export Tool

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2485,7 +2485,7 @@ def export_graph_dispatch(
     """
     from .exporter import export_graph
 
-    store, _ = _get_store(repo_root)
+    store, root = _get_store(repo_root)
     try:
         payload = export_graph(store, format=format)
     except ValueError as e:
@@ -2495,7 +2495,13 @@ def export_graph_dispatch(
     byte_count = len(payload.encode("utf-8"))
 
     if output_path:
-        Path(output_path).write_text(payload, encoding="utf-8")
+        out_p = Path(output_path).resolve()
+        if not out_p.is_relative_to(root.resolve()):
+            return {
+                "status": "error",
+                "error": f"Output path {output_path} must be relative to repo root {root}",
+            }
+        out_p.write_text(payload, encoding="utf-8")
         return {
             "status": "ok",
             "format": fmt,

--- a/tests/test_export_graph_dispatch_path_traversal.py
+++ b/tests/test_export_graph_dispatch_path_traversal.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from better_code_review_graph.tools import export_graph_dispatch
+
+
+def test_export_graph_dispatch_path_traversal_blocked(
+    tmp_path, _allow_temporal_migration_without_git
+):
+    (tmp_path / ".code-review-graph").mkdir()
+    # Try to write outside the repo root
+    output_path = str(tmp_path / "../out.graphml")
+    result = export_graph_dispatch(
+        repo_root=str(tmp_path), format="graphml", output_path=output_path
+    )
+
+    assert result["status"] == "error"
+    assert "must be relative to repo root" in result["error"]
+
+
+def test_export_graph_dispatch_inside_repo_allowed(
+    tmp_path, _allow_temporal_migration_without_git
+):
+    (tmp_path / ".code-review-graph").mkdir()
+    # Write inside the repo root
+    output_path = str(tmp_path / "out.graphml")
+    result = export_graph_dispatch(
+        repo_root=str(tmp_path), format="graphml", output_path=output_path
+    )
+
+    assert result["status"] == "ok"
+    assert "bytes" in result
+    assert Path(output_path).exists()

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `export_graph_dispatch` tool allowed writing the entire code review graph payload to arbitrary locations on the filesystem (e.g., `~/.bashrc`, system directories) when a path-traversing `output_path` was specified.
🎯 Impact: Arbitrary file write, which can lead to remote code execution (RCE) or denial of service by overwriting critical system files or placing malicious scripts in execution paths.
🔧 Fix: Resolved the provided `output_path` using `pathlib.Path.resolve()` and validated that the resulting path `is_relative_to(root.resolve())`. If the check fails, the tool correctly rejects the export request with an error dictionary.
✅ Verification: `uv run pytest tests/test_export_graph_dispatch_path_traversal.py` executes successfully, proving that paths inside the repo are allowed, while traversing paths (like `../`) are rejected.

---
*PR created automatically by Jules for task [2256527318624319766](https://jules.google.com/task/2256527318624319766) started by @n24q02m*