### PR TITLE
[TEST] Untested function _handle_not_found

### DIFF
--- a/tests/test_handle_not_found_coverage.py
+++ b/tests/test_handle_not_found_coverage.py
@@ -1,0 +1,60 @@
+from better_code_review_graph.parser import NodeInfo
+from better_code_review_graph.tools import _handle_not_found
+
+
+def test_handle_not_found_with_data(tmp_graph_store):
+    """Test _handle_not_found with nodes present in the graph."""
+    # Seed some data to have kinds in the graph
+    tmp_graph_store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="my_func",
+            file_path="test.py",
+            line_start=1,
+            line_end=10,
+            language="python",
+        )
+    )
+    tmp_graph_store.upsert_node(
+        NodeInfo(
+            kind="Class",
+            name="MyClass",
+            file_path="test.py",
+            line_start=11,
+            line_end=20,
+            language="python",
+        )
+    )
+
+    target = "missing_symbol"
+    result = _handle_not_found(tmp_graph_store, target)
+
+    assert result["status"] == "not_found"
+    assert result["reason"] == "no_such_symbol"
+    assert f"No node found matching {target!r}." in result["summary"]
+    assert "Function" in result["indexed_kinds"]
+    assert "Class" in result["indexed_kinds"]
+    assert target in result["hint"]
+    assert "file_path::Class.method" in result["hint"]
+
+
+def test_handle_not_found_empty_graph(tmp_graph_store):
+    """Test _handle_not_found with an empty graph."""
+    target = "another_missing_symbol"
+    result = _handle_not_found(tmp_graph_store, target)
+
+    assert result["status"] == "not_found"
+    assert result["indexed_kinds"] == []
+    assert f"No node found matching {target!r}." in result["summary"]
+
+
+def test_handle_not_found_store_error(tmp_graph_store):
+    """Test _handle_not_found when store results in an error (e.g. closed connection)."""
+    target = "error_symbol"
+    tmp_graph_store.close()
+
+    # _list_kinds_in_graph should catch the exception and return []
+    result = _handle_not_found(tmp_graph_store, target)
+
+    assert result["status"] == "not_found"
+    assert result["indexed_kinds"] == []

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added tests/test_handle_not_found_coverage.py to verify the
_handle_not_found function in tools.py. Tested various scenarios:
- Graph with existing data (verified indexed_kinds and hint content).
- Empty graph.
- Store error handling (closed database connection).

---
*PR created automatically by Jules for task [788067421165776294](https://jules.google.com/task/788067421165776294) started by @n24q02m*