### PR TITLE
[TEST] Untested function _estimate_payload_bytes

### DIFF
--- a/tests/test_payload_estimation.py
+++ b/tests/test_payload_estimation.py
@@ -1,0 +1,44 @@
+import json
+
+from better_code_review_graph.tools import _estimate_payload_bytes
+
+
+def test_estimate_payload_bytes_empty():
+    assert _estimate_payload_bytes() == 0
+
+
+def test_estimate_payload_bytes_single_dict():
+    d = {"key": "value", "int": 123, "bool": True, "none": None}
+    estimate = _estimate_payload_bytes(d)
+    actual_json_len = len(json.dumps(d))
+    # repr uses ' while json uses "
+    # repr uses True while json uses true
+    # repr uses None while json uses null
+    assert estimate >= actual_json_len
+    assert isinstance(estimate, int)
+
+
+def test_estimate_payload_bytes_list_of_dicts():
+    payload = [{"a": 1}, {"b": 2}]
+    estimate = _estimate_payload_bytes(payload)
+    actual_json_len = len(json.dumps(payload))
+    assert estimate >= actual_json_len
+
+
+def test_estimate_payload_bytes_multiple_args():
+    d1 = {"a": 1}
+    d2 = {"b": 2}
+    l1 = [{"c": 3}]
+    # sum(len(repr(d1)), len(repr(d2)), len(repr(l1)))
+    expected = len(repr(d1)) + len(repr(d2)) + len(repr(l1))
+    assert _estimate_payload_bytes(d1, d2, l1) == expected
+
+
+def test_estimate_payload_bytes_overestimation():
+    # Example where repr is definitely longer than JSON
+    d = {"key": "it's a string with single quote"}
+    # repr(d) -> "{'key': \"it's a string with single quote\"}"
+    # json.dumps(d) -> '{"key": "it\'s a string with single quote"}'
+    estimate = _estimate_payload_bytes(d)
+    actual_json_len = len(json.dumps(d))
+    assert estimate >= actual_json_len

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added unit tests for the `_estimate_payload_bytes` function in `src/better_code_review_graph/tools.py` to ensure its reliability as an upper-bound estimator for JSON payload sizes. Created a new test file `tests/test_payload_estimation.py` with comprehensive test cases covering various input types including empty dicts, populated dicts, lists of dicts, and multiple arguments. Verified that the estimate is always greater than or equal to the actual JSON serialized size.

---
*PR created automatically by Jules for task [15753088622168531437](https://jules.google.com/task/15753088622168531437) started by @n24q02m*