### PR TITLE
[FIX] Long function: semantic_search_nodes

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2179,6 +2179,143 @@ def _looks_like_literal_identifier(query: str) -> bool:
     return all(ch in allowed for ch in q)
 
 
+def _perform_semantic_search(
+    query: str,
+    kind: str | None,
+    limit: int,
+    repo: str,
+    as_of: str,
+    store: GraphStore,
+    emb_store: EmbeddingStore,
+    db_path: Path,
+) -> dict[str, Any] | None:
+    """Internal helper for semantic search path."""
+    # Phase 3 Task 9: an explicit ``as_of`` skips the vector path —
+    # the embedding store has no temporal column, so we cannot
+    # safely return historical snapshots through it.
+    if as_of != "" or not emb_store.available or emb_store.count() == 0:
+        return None
+
+    # Vector search
+    search_mode = "semantic"
+    raw = semantic_search(query, store, emb_store, limit=limit * 2)
+    if kind:
+        raw = [r for r in raw if r.get("kind") == kind]
+    if repo:
+        # The vector store has no repo_id column; cross-check
+        # each hit against the SQL row and drop misses. Batched
+        # via json_each so it stays O(1) queries regardless of
+        # how many hits the vector store returned.
+        repo_qns = [
+            r.get("qualified_name") for r in raw if r.get("qualified_name") is not None
+        ]
+        repo_map: dict[str, str] = {}
+        if repo_qns:
+            cursor = store._conn.execute(
+                "SELECT n.qualified_name, n.repo_id FROM nodes n "
+                "JOIN json_each(?) j ON n.qualified_name = j.value",
+                (json.dumps(repo_qns),),
+            )
+            repo_map = {row["qualified_name"]: row["repo_id"] for row in cursor}
+        filtered = []
+        for r in raw:
+            qn = r.get("qualified_name")
+            if qn is None:
+                continue
+            r_repo = repo_map.get(qn)
+            if r_repo is not None and (r_repo or "") == repo:
+                filtered.append(r)
+        raw = filtered
+
+    # Default-path filter: vector hits should also exclude
+    # rows that have been closed-out at a later commit. The
+    # vector store does not know about ``valid_to_sha`` so
+    # we cross-check via the SQL row — batched via json_each.
+    surv_qns = [
+        r.get("qualified_name") for r in raw if r.get("qualified_name") is not None
+    ]
+    surviving_set: set[str] = set()
+    if surv_qns:
+        cursor = store._conn.execute(
+            "SELECT n.qualified_name FROM nodes n "
+            "JOIN json_each(?) j ON n.qualified_name = j.value "
+            "WHERE n.valid_to_sha IS NULL",
+            (json.dumps(surv_qns),),
+        )
+        surviving_set = {row["qualified_name"] for row in cursor}
+    surviving: list[dict] = []
+    for r in raw:
+        qn = r.get("qualified_name")
+        if qn is None:
+            continue
+        if qn in surviving_set:
+            surviving.append(r)
+    raw = surviving
+    raw = raw[:limit]
+
+    return {
+        "status": "ok",
+        "query": query,
+        "search_mode": search_mode,
+        "summary": f"Found {len(raw)} node(s) matching '{query}' via semantic search"
+        + (f" (kind={kind})" if kind else ""),
+        "header": _build_response_header(store, db_path, keyword_only=False),
+        "results": raw,
+    }
+
+
+def _perform_keyword_search(
+    query: str,
+    kind: str | None,
+    limit: int,
+    repo: str,
+    as_of: str,
+    store: GraphStore,
+    db_path: Path,
+) -> dict[str, Any]:
+    """Internal helper for keyword fallback path."""
+    search_mode = "keyword"
+    results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
+
+    if kind:
+        results = [r for r in results if r.kind == kind]
+
+    def score(node):
+        name_lower = node.name.lower()
+        q_lower = query.lower()
+        if name_lower == q_lower:
+            return 0
+        if name_lower.startswith(q_lower):
+            return 1
+        return 2
+
+    results.sort(key=score)
+    results = results[:limit]
+
+    response: dict[str, Any] = {
+        "status": "ok",
+        "query": query,
+        "search_mode": search_mode,
+        "summary": f"Found {len(results)} node(s) matching '{query}'"
+        + (f" (kind={kind})" if kind else ""),
+        "header": _build_response_header(store, db_path, keyword_only=True),
+        "results": [node_to_dict(r) for r in results],
+    }
+
+    # #317: warn when running keyword fallback on a query that looks
+    # semantic. Users who pass single identifiers (`foo`, `foo_bar`,
+    # `Foo.bar`) are fine; users who pass phrases (`how does X work`,
+    # `firebase auth setup`) get garbage from keyword-substring match.
+    if not _looks_like_literal_identifier(query):
+        response["warning"] = (
+            "embeddings_count=0 - results are keyword-substring matches "
+            "only, not semantic similarity. Query shape suggests semantic "
+            "intent; rebuild with embeddings enabled "
+            "(graph action=embed) or reword as a literal identifier."
+        )
+    return response
+
+
 def semantic_search_nodes(
     query: str,
     kind: str | None = None,
@@ -2222,135 +2359,21 @@ def semantic_search_nodes(
         db_path = get_db_path(root)
         backend = init_backend()
         emb_store = EmbeddingStore(db_path, backend)
-        search_mode = "keyword"
-
         try:
-            # Phase 3 Task 9: an explicit ``as_of`` skips the vector path —
-            # the embedding store has no temporal column, so we cannot
-            # safely return historical snapshots through it. Fall through
-            # to the keyword path which threads ``as_of`` into the SQL.
-            if as_of == "" and emb_store.available and emb_store.count() > 0:
-                # Vector search
-                search_mode = "semantic"
-                raw = semantic_search(query, store, emb_store, limit=limit * 2)
-                if kind:
-                    raw = [r for r in raw if r.get("kind") == kind]
-                if repo:
-                    # The vector store has no repo_id column; cross-check
-                    # each hit against the SQL row and drop misses. Batched
-                    # via json_each so it stays O(1) queries regardless of
-                    # how many hits the vector store returned.
-                    repo_qns = [
-                        r.get("qualified_name")
-                        for r in raw
-                        if r.get("qualified_name") is not None
-                    ]
-                    repo_map: dict[str, str] = {}
-                    if repo_qns:
-                        cursor = store._conn.execute(
-                            "SELECT n.qualified_name, n.repo_id FROM nodes n "
-                            "JOIN json_each(?) j ON n.qualified_name = j.value",
-                            (json.dumps(repo_qns),),
-                        )
-                        repo_map = {
-                            row["qualified_name"]: row["repo_id"] for row in cursor
-                        }
-                    filtered = []
-                    for r in raw:
-                        qn = r.get("qualified_name")
-                        if qn is None:
-                            continue
-                        r_repo = repo_map.get(qn)
-                        if r_repo is not None and (r_repo or "") == repo:
-                            filtered.append(r)
-                    raw = filtered
-                # Default-path filter: vector hits should also exclude
-                # rows that have been closed-out at a later commit. The
-                # vector store does not know about ``valid_to_sha`` so
-                # we cross-check via the SQL row — batched via json_each.
-                surv_qns = [
-                    r.get("qualified_name")
-                    for r in raw
-                    if r.get("qualified_name") is not None
-                ]
-                surviving_set: set[str] = set()
-                if surv_qns:
-                    cursor = store._conn.execute(
-                        "SELECT n.qualified_name FROM nodes n "
-                        "JOIN json_each(?) j ON n.qualified_name = j.value "
-                        "WHERE n.valid_to_sha IS NULL",
-                        (json.dumps(surv_qns),),
-                    )
-                    surviving_set = {row["qualified_name"] for row in cursor}
-                surviving: list[dict] = []
-                for r in raw:
-                    qn = r.get("qualified_name")
-                    if qn is None:
-                        continue
-                    if qn in surviving_set:
-                        surviving.append(r)
-                raw = surviving
-                raw = raw[:limit]
-                return {
-                    "status": "ok",
-                    "query": query,
-                    "search_mode": search_mode,
-                    "summary": f"Found {len(raw)} node(s) matching '{query}' via semantic search"
-                    + (f" (kind={kind})" if kind else ""),
-                    "header": _build_response_header(
-                        store, db_path, keyword_only=False
-                    ),
-                    "results": raw,
-                }
+            res = _perform_semantic_search(
+                query, kind, limit, repo, as_of, store, emb_store, db_path
+            )
+            if res:
+                return res
         finally:
             emb_store.close()
 
         # Keyword fallback
-        results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
-
-        if kind:
-            results = [r for r in results if r.kind == kind]
-
-        def score(node):
-            name_lower = node.name.lower()
-            q_lower = query.lower()
-            if name_lower == q_lower:
-                return 0
-            if name_lower.startswith(q_lower):
-                return 1
-            return 2
-
-        results.sort(key=score)
-        results = results[:limit]
-
-        response: dict[str, Any] = {
-            "status": "ok",
-            "query": query,
-            "search_mode": search_mode,
-            "summary": f"Found {len(results)} node(s) matching '{query}'"
-            + (f" (kind={kind})" if kind else ""),
-            "header": _build_response_header(store, db_path, keyword_only=True),
-            "results": [node_to_dict(r) for r in results],
-        }
-
-        # #317: warn when running keyword fallback on a query that looks
-        # semantic. Users who pass single identifiers (`foo`, `foo_bar`,
-        # `Foo.bar`) are fine; users who pass phrases (`how does X work`,
-        # `firebase auth setup`) get garbage from keyword-substring match.
-        if not _looks_like_literal_identifier(query):
-            response["warning"] = (
-                "embeddings_count=0 - results are keyword-substring matches "
-                "only, not semantic similarity. Query shape suggests semantic "
-                "intent; rebuild with embeddings enabled "
-                "(graph action=embed) or reword as a literal identifier."
-            )
-        return response
+        return _perform_keyword_search(query, kind, limit, repo, as_of, store, db_path)
     finally:
         store.close()
 
 
-# ---------------------------------------------------------------------------
-# Tool 6: list_graph_stats
 # ---------------------------------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored the `semantic_search_nodes` tool into modular helper functions:
- `_perform_semantic_search`: Handles the vector search path, including repository and survival filtering.
- `_perform_keyword_search`: Handles the keyword fallback path, scoring, and response assembly.

This reduces the complexity of the main tool function while preserving all existing functionality and resource management (e.g., closing `store` and `emb_store`).

Verified with existing test suite and linting.

---
*PR created automatically by Jules for task [6299959679306306859](https://jules.google.com/task/6299959679306306859) started by @n24q02m*