### PR TITLE
[TEST] Missing error test for OSError in _get_review_context

### DIFF
--- a/tests/test_graph_stats_error_coverage.py
+++ b/tests/test_graph_stats_error_coverage.py
@@ -1,17 +1,22 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
-from better_code_review_graph.tools import _list_kinds_in_graph, _build_response_header
+
+from better_code_review_graph.tools import _build_response_header, _list_kinds_in_graph
+
 
 def test_list_kinds_in_graph_exception_handled():
     mock_store = MagicMock()
     mock_store._conn.execute.side_effect = Exception("DB error")
     assert _list_kinds_in_graph(mock_store) == []
 
+
 def test_build_response_header_embedding_exception_handled():
     with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
         mock_emb.side_effect = Exception("Embedding error")
-        header = _build_response_header(db_path="/tmp/fake", store=None)
+        header = _build_response_header(db_path=Path("/tmp/fake"), store=None)
         assert header["embeddings_count"] == 0
         assert header["keyword_only"] is True
+
 
 def test_build_response_header_metadata_exception_handled():
     mock_store = MagicMock()
@@ -19,6 +24,6 @@ def test_build_response_header_metadata_exception_handled():
     # emb_count will be 0 because we don't mock it to fail here, but let's just test metadata
     with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
         mock_emb.return_value.count.return_value = 10
-        header = _build_response_header(db_path="/tmp/fake", store=mock_store)
+        header = _build_response_header(db_path=Path("/tmp/fake"), store=mock_store)
         assert header["graph_last_updated"] is None
         assert header["embeddings_count"] == 10

--- a/tests/test_graph_stats_error_coverage.py
+++ b/tests/test_graph_stats_error_coverage.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, patch
+from better_code_review_graph.tools import _list_kinds_in_graph, _build_response_header
+
+def test_list_kinds_in_graph_exception_handled():
+    mock_store = MagicMock()
+    mock_store._conn.execute.side_effect = Exception("DB error")
+    assert _list_kinds_in_graph(mock_store) == []
+
+def test_build_response_header_embedding_exception_handled():
+    with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
+        mock_emb.side_effect = Exception("Embedding error")
+        header = _build_response_header(db_path="/tmp/fake", store=None)
+        assert header["embeddings_count"] == 0
+        assert header["keyword_only"] is True
+
+def test_build_response_header_metadata_exception_handled():
+    mock_store = MagicMock()
+    mock_store.get_metadata.side_effect = Exception("Metadata error")
+    # emb_count will be 0 because we don't mock it to fail here, but let's just test metadata
+    with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
+        mock_emb.return_value.count.return_value = 10
+        header = _build_response_header(db_path="/tmp/fake", store=mock_store)
+        assert header["graph_last_updated"] is None
+        assert header["embeddings_count"] == 10

--- a/tests/test_kinds_error_path.py
+++ b/tests/test_kinds_error_path.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
+
 from better_code_review_graph.tools import _list_kinds_in_graph
+
 
 def test_list_kinds_in_graph_error_path():
     """Cover the Exception branch in _list_kinds_in_graph (line 690)."""

--- a/tests/test_kinds_error_path.py
+++ b/tests/test_kinds_error_path.py
@@ -1,14 +1,10 @@
 from unittest.mock import MagicMock
-
 from better_code_review_graph.tools import _list_kinds_in_graph
 
+def test_list_kinds_in_graph_error_path():
+    """Cover the Exception branch in _list_kinds_in_graph (line 690)."""
+    mock_store = MagicMock()
+    mock_store._conn.execute.side_effect = Exception("DB Error")
 
-def test_list_kinds_in_graph_returns_empty_on_exception():
-    """Verify that _list_kinds_in_graph returns an empty list when an exception occurs."""
-    bad_store = MagicMock()
-    # Mocking the execute method to raise an exception
-    bad_store._conn.execute.side_effect = Exception("Database error")
-
-    result = _list_kinds_in_graph(bad_store)
-
-    assert result == []
+    kinds = _list_kinds_in_graph(mock_store)
+    assert kinds == []

--- a/tests/test_oserror_coverage.py
+++ b/tests/test_oserror_coverage.py
@@ -9,6 +9,7 @@ from better_code_review_graph.tools import (
     _LAST_CALLERS_RESULT,
     get_review_context,
     spot_check_last_callers,
+    _get_source_snippets,
 )
 
 
@@ -21,9 +22,6 @@ def repo_with_cache(tmp_path):
 
     file_path = tmp_path / "test.py"
     file_path.write_text("def hello(): pass")
-
-    # Ensure _get_store won't trigger heavy logic if we can help it,
-    # but here it's fine as long as we don't mock read_text too early.
 
     _LAST_CALLERS_RESULT[str(tmp_path.resolve())] = {
         "pattern": "callers_of",
@@ -88,7 +86,6 @@ def test_get_review_context_source_snippets_handles_oserror(tmp_path):
     original_read_text = Path.read_text
 
     def side_effect(self, *args, **kwargs):
-        # We check if the path ends with changed.py because of how resolve() might work
         if str(self).endswith("changed.py"):
             raise OSError("Read error")
         return original_read_text(self, *args, **kwargs)
@@ -104,3 +101,38 @@ def test_get_review_context_source_snippets_handles_oserror(tmp_path):
     snippets = result["context"].get("source_snippets", {})
     assert "changed.py" in snippets
     assert snippets["changed.py"] == "(could not read file)"
+
+
+def test_get_source_snippets_handles_resolve_oserror(tmp_path):
+    """Cover the OSError/ValueError branch in _get_source_snippets loop."""
+    repo = tmp_path
+    (repo / ".git").mkdir()
+
+    file_path = repo / "bad_resolve.py"
+    file_path.write_text("print(1)")
+
+    original_resolve = Path.resolve
+
+    # Track calls to resolve()
+    calls = []
+
+    def side_effect(self, *args, **kwargs):
+        calls.append(str(self))
+        # Initial root.resolve() must pass
+        if self == repo and len(calls) == 1:
+            return original_resolve(self, *args, **kwargs)
+
+        # parent_raw.resolve(strict=True) on line 1882 should fail to put None in cache
+        if self == repo: # parent_raw
+             raise OSError("Parent resolve error")
+
+        # full_path_raw.resolve() on line 1890 should fail
+        if str(self).endswith("bad_resolve.py"):
+             raise OSError("Resolve error")
+
+        return original_resolve(self, *args, **kwargs)
+
+    with patch("better_code_review_graph.tools.Path.resolve", side_effect):
+        snippets = _get_source_snippets(repo, ["bad_resolve.py"], [], 100)
+
+    assert snippets == {}

--- a/tests/test_oserror_coverage.py
+++ b/tests/test_oserror_coverage.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import NodeInfo
+from better_code_review_graph.tools import (
+    _LAST_CALLERS_RESULT,
+    get_review_context,
+    spot_check_last_callers,
+)
+
+
+@pytest.fixture
+def repo_with_cache(tmp_path):
+    """Setup a repo and populate _LAST_CALLERS_RESULT cache."""
+    (tmp_path / ".git").mkdir()
+    crg = tmp_path / ".code-review-graph"
+    crg.mkdir()
+
+    file_path = tmp_path / "test.py"
+    file_path.write_text("def hello(): pass")
+
+    # Ensure _get_store won't trigger heavy logic if we can help it,
+    # but here it's fine as long as we don't mock read_text too early.
+
+    _LAST_CALLERS_RESULT[str(tmp_path.resolve())] = {
+        "pattern": "callers_of",
+        "target": "test.py::hello",
+        "edges": [
+            {
+                "file_path": str(file_path),
+                "line": 1,
+                "source_qualified": "other.py::main",
+                "target_qualified": "test.py::hello",
+            }
+        ],
+    }
+    return tmp_path, file_path
+
+
+def test_spot_check_handles_oserror(repo_with_cache):
+    repo, file_path = repo_with_cache
+
+    original_read_text = Path.read_text
+
+    def side_effect(self, *args, **kwargs):
+        if str(self) == str(file_path):
+            raise OSError("Read error")
+        return original_read_text(self, *args, **kwargs)
+
+    with patch("better_code_review_graph.tools.Path.read_text", side_effect):
+        result = spot_check_last_callers(n=1, repo_root=str(repo))
+
+    assert result["status"] == "ok"
+    assert len(result["samples"]) == 1
+    assert result["samples"][0]["snippet"] == "(could not read file)"
+
+
+def test_get_review_context_source_snippets_handles_oserror(tmp_path):
+    """Test that _get_source_snippets handles OSError (via get_review_context)."""
+    repo = tmp_path
+    (repo / ".git").mkdir()
+    crg = repo / ".code-review-graph"
+    crg.mkdir()
+
+    # Create a dummy database
+    db_path = crg / "graph.db"
+    store = GraphStore(str(db_path))
+
+    file_path = repo / "changed.py"
+    file_path.write_text("print('hello')")
+
+    # Upsert a node so it's picked up by impact radius
+    node = NodeInfo(
+        kind="File",
+        name=str(file_path),
+        file_path=str(file_path),
+        line_start=1,
+        line_end=1,
+        language="python",
+    )
+    store.upsert_node(node)
+    store.commit()
+    store.close()
+
+    original_read_text = Path.read_text
+
+    def side_effect(self, *args, **kwargs):
+        # We check if the path ends with changed.py because of how resolve() might work
+        if str(self).endswith("changed.py"):
+            raise OSError("Read error")
+        return original_read_text(self, *args, **kwargs)
+
+    # Mock git changed files
+    with patch(
+        "better_code_review_graph.tools.get_changed_files", return_value=["changed.py"]
+    ):
+        with patch("better_code_review_graph.tools.Path.read_text", side_effect):
+            result = get_review_context(repo_root=str(repo))
+
+    assert result["status"] == "ok"
+    snippets = result["context"].get("source_snippets", {})
+    assert "changed.py" in snippets
+    assert snippets["changed.py"] == "(could not read file)"

--- a/tests/test_oserror_coverage.py
+++ b/tests/test_oserror_coverage.py
@@ -7,9 +7,9 @@ from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.parser import NodeInfo
 from better_code_review_graph.tools import (
     _LAST_CALLERS_RESULT,
+    _get_source_snippets,
     get_review_context,
     spot_check_last_callers,
-    _get_source_snippets,
 )
 
 
@@ -123,12 +123,12 @@ def test_get_source_snippets_handles_resolve_oserror(tmp_path):
             return original_resolve(self, *args, **kwargs)
 
         # parent_raw.resolve(strict=True) on line 1882 should fail to put None in cache
-        if self == repo: # parent_raw
-             raise OSError("Parent resolve error")
+        if self == repo:  # parent_raw
+            raise OSError("Parent resolve error")
 
         # full_path_raw.resolve() on line 1890 should fail
         if str(self).endswith("bad_resolve.py"):
-             raise OSError("Resolve error")
+            raise OSError("Resolve error")
 
         return original_resolve(self, *args, **kwargs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.16.4b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Adds tests/test_oserror_coverage.py to cover the OSError exception handlers in spot_check_last_callers and _get_source_snippets (used by get_review_context) in src/better_code_review_graph/tools.py. These tests utilize a selective mocking strategy for Path.read_text to ensure internal library operations (e.g., alembic, importlib) are not disrupted during tool initialization.

---
*PR created automatically by Jules for task [12105035450229945318](https://jules.google.com/task/12105035450229945318) started by @n24q02m*