### PR TITLE
[TEST] Missing exception coverage for parse_bytes

### DIFF
--- a/tests/test_v17_coverage_gaps.py
+++ b/tests/test_v17_coverage_gaps.py
@@ -359,6 +359,29 @@ class TestRenamedInDiffFilters:
         # Removed functions are out of scope -> not reported.
         assert "removed_fn" not in symbols
 
+    def test_parse_exception_skipped(self, tmp_path):
+        """If parse_bytes raises an Exception, the file is skipped."""
+        repo = _make_minimal_repo(tmp_path)
+        _run_git(repo, "init", "--initial-branch=main")
+        _run_git(repo, "config", "user.email", "t@t.com")
+        _run_git(repo, "config", "user.name", "t")
+        src = repo / "broken.py"
+        src.write_text("def boom():\n    pass\n")
+        _run_git(repo, "add", "broken.py")
+        _run_git(repo, "commit", "-m", "feat: initial")
+        src.write_text("def boom():\n    return 1\n")
+        _run_git(repo, "add", "broken.py")
+        _run_git(repo, "commit", "-m", "fix: change")
+
+        with patch(
+            "better_code_review_graph.parser.CodeParser.parse_bytes",
+            side_effect=RuntimeError("parse boom"),
+        ):
+            result = renamed_in_diff(base="HEAD~1", repo_root=str(repo))
+
+        assert result["status"] == "ok"
+        assert result["shifts"] == []
+
 
 # ---------------------------------------------------------------------------
 # _looks_like_literal_identifier (#317)

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `renamed_in_diff` function in `src/better_code_review_graph/tools.py` had a `try...except Exception` block around calls to `parser.parse_bytes` that was not being exercised by existing tests.

This PR adds `test_parse_exception_skipped` to `TestRenamedInDiffFilters` in `tests/test_v17_coverage_gaps.py`. This test specifically mocks `CodeParser.parse_bytes` to raise a `RuntimeError` and asserts that the function continues processing other files (or returns successfully with empty shifts if all files fail), thus providing the missing coverage.

Verification:
- Run `uv run pytest tests/test_v17_coverage_gaps.py` - PASSED
- Run `uv run pytest` (full suite) - PASSED
- Run `uv run ruff check . --fix && uv run ruff format .` - PASSED

---
*PR created automatically by Jules for task [15980766642043032560](https://jules.google.com/task/15980766642043032560) started by @n24q02m*