### PR TITLE
[SECURITY] Fix Command Injection vulnerability in git show

### DIFF
--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -285,6 +285,7 @@ def backfill_commits_for_repo(
                 "log",
                 "--first-parent",
                 f"--format={_GIT_LOG_FORMAT}",
+                "--",
             ],
             cwd=str(repo_root),
             capture_output=True,

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -185,7 +185,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
 
     try:
         result = subprocess.run(
-            [git_bin, "diff", "--name-only", base],
+            [git_bin, "diff", "--name-only", "--end-of-options", base],
             capture_output=True,
             text=True,
             cwd=str(repo_root),

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1738,7 +1738,7 @@ def renamed_in_diff(
             # Fetch base-ref content via git.
             try:
                 proc = subprocess.run(
-                    ["git", "show", f"{base}:{rel_path}"],
+                    ["git", "show", "--end-of-options", f"{base}:{rel_path}"],
                     cwd=str(root),
                     capture_output=True,
                     timeout=15,

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR fixes a command injection (argument injection) vulnerability in the `git show` call within `src/better_code_review_graph/tools.py`.

The issue was that the `base` and `rel_path` variables were being passed to `git show` without a separator, allowing an attacker who controls the `base` ref (e.g., setting it to `-h` or `--version`) to inject command-line arguments.

Fixes:
- Added `--end-of-options` to `git show` in `src/better_code_review_graph/tools.py`.
- Added `--end-of-options` to `git diff` in `src/better_code_review_graph/incremental.py` as a defense-in-depth measure.
- Added `--` separator to `git log` in `src/better_code_review_graph/federation.py` for standard argument separation.

Verification:
- Created a reproduction script that demonstrated `git show` executing flags when `base` started with `-`.
- Verified that with `--end-of-options`, Git correctly rejects these as invalid revisions instead of interpreting them as flags.
- Ran `uv run pytest` and confirmed that all relevant tests (including federation and tool tests) pass.
- Ran `ruff` and `ty check` to ensure code quality.

---
*PR created automatically by Jules for task [12048825398555245413](https://jules.google.com/task/12048825398555245413) started by @n24q02m*