### PR TITLE
[FIX] Long function: _run_alembic_upgrade

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -280,6 +280,21 @@ class GraphStore:
         Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
         only loaded when a ``GraphStore`` is actually instantiated.
         """
+        cfg, command, script_dir_cls, cmd_err_cls = self._get_alembic_config()
+
+        if self._handle_downgrade_request():
+            return
+
+        self._maybe_stamp_legacy_db(cfg, command)
+        self._maybe_take_backup_before_upgrade(cfg, script_dir_cls)
+
+        try:
+            command.upgrade(cfg, "head")
+        except cmd_err_cls as exc:
+            self._handle_alembic_command_error(exc, cfg, script_dir_cls)
+
+    def _get_alembic_config(self) -> tuple:
+        """Lazy-load alembic and return (config, command, ScriptDirectory, CommandError)."""
         from alembic import command
         from alembic.config import Config
         from alembic.script import ScriptDirectory
@@ -289,27 +304,25 @@ class GraphStore:
         cfg = Config()
         cfg.set_main_option("script_location", str(migrations_dir))
         cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
+        return cfg, command, ScriptDirectory, CommandError
 
-        # Phase 3 Task 1 — early-exit downgrade path.
-        #
-        # When the operator sets ``CRG_DOWNGRADE_TO_1_X=1`` we restore
-        # the pre-2.0 backup BEFORE any alembic activity (including
-        # the auto-stamp branch below — stamping a v1.x DB to "002"
-        # is the same idempotent outcome as the restored DB already
-        # being at "002", but we still skip it to avoid touching the
-        # restored file at all).
+    def _handle_downgrade_request(self) -> bool:
+        """Check for downgrade environment variable and restore backup if set.
+
+        Returns:
+            True if a downgrade was handled (caller should exit), False otherwise.
+        """
         if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
             self._restore_pre_2_0_backup()
-            return
+            return True
+        return False
 
-        # Detect "legacy DB": pre-existing structural tables but alembic
-        # has not yet recorded a head revision. Two sub-cases:
-        #   1. ``alembic_version`` table is missing entirely.
-        #   2. ``alembic_version`` exists but has no row (an interrupted
-        #      prior run, or a test fixture that touched the DB before
-        #      alembic was wired up).
-        # In both cases we stamp at ``002`` so the baseline ``CREATE
-        # TABLE`` is skipped on the subsequent ``upgrade("head")``.
+    def _maybe_stamp_legacy_db(self, cfg, command) -> None:
+        """Detect and stamp legacy DBs (missing alembic_version) at revision 002.
+
+        In both cases (missing table or empty table) we stamp at ``002`` so the
+        baseline ``CREATE TABLE`` is skipped on the subsequent ``upgrade("head")``.
+        """
         existing = {
             row[0]
             for row in self._conn.execute(
@@ -326,46 +339,41 @@ class GraphStore:
             if needs_stamp:
                 command.stamp(cfg, "002")
 
-        # Phase 3 Task 1 — backup before BREAKING migration crosses the
-        # 005 boundary.  Read the current recorded revision (post-stamp)
-        # and the script-directory head; if the chain crosses 005,
-        # snapshot the SQLite file via ``shutil.copy2`` so the operator
-        # can roll back via ``CRG_DOWNGRADE_TO_1_X=1`` if the BREAKING
-        # migration produces a worse outcome than expected.  Idempotent:
-        # an existing backup is preserved (could be from an earlier
-        # partial run that aborted mid-upgrade — that copy is closer to
-        # the true v1.x state than anything we'd produce now).
+    def _maybe_take_backup_before_upgrade(self, cfg, script_dir_cls) -> None:
+        """Check for breaking boundary and snapshot the SQLite file if crossed.
+
+        Read the current recorded revision (post-stamp) and the script-directory
+        head; if the chain crosses 005, snapshot the SQLite file via
+        ``shutil.copy2`` so the operator can roll back via
+        ``CRG_DOWNGRADE_TO_1_X=1``.
+        """
         current_rev = self._read_alembic_version()
-        target_rev = ScriptDirectory.from_config(cfg).get_current_head()
+        target_rev = script_dir_cls.from_config(cfg).get_current_head()
         if _crosses_breaking_boundary(current_rev, target_rev):
             self._take_pre_2_0_backup()
 
-        try:
-            command.upgrade(cfg, "head")
-        except CommandError as exc:
-            # Most likely cause: ``alembic_version`` references a revision
-            # this package does not ship.  Re-raise with the unknown
-            # revision and the local head spelt out so the operator knows
-            # whether to downgrade the package or recreate the DB.
-            recorded: str | None
-            try:
-                row = self._conn.execute(
-                    "SELECT version_num FROM alembic_version"
-                ).fetchone()
-                recorded = row[0] if row else None
-            except sqlite3.Error:
-                recorded = None
-            head = ScriptDirectory.from_config(cfg).get_current_head()
-            raise RuntimeError(
-                f"Graph DB at {self.db_path} reports alembic revision "
-                f"{recorded!r} which is not shipped with this version of "
-                f"better-code-review-graph (head={head!r}). Either downgrade "
-                "the package or recreate the DB."
-            ) from exc
+    def _handle_alembic_command_error(self, exc, cfg, script_dir_cls) -> None:
+        """Re-raise CommandError as RuntimeError with a recovery hint.
 
-    # ------------------------------------------------------------------
-    # Phase 3 Task 1 — backup / restore helpers
-    # ------------------------------------------------------------------
+        Most likely cause: ``alembic_version`` references a revision this
+        package does not ship. Re-raise with the unknown revision and the
+        local head spelt out.
+        """
+        recorded = None
+        try:
+            row = self._conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()
+            recorded = row[0] if row else None
+        except sqlite3.Error:
+            recorded = None
+        head = script_dir_cls.from_config(cfg).get_current_head()
+        raise RuntimeError(
+            f"Graph DB at {self.db_path} reports alembic revision "
+            f"{recorded!r} which is not shipped with this version of "
+            f"better-code-review-graph (head={head!r}). Either downgrade "
+            "the package or recreate the DB."
+        ) from exc
 
     def _read_alembic_version(self) -> str | None:
         """Return the revision recorded in ``alembic_version`` (or ``None``).

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored the `_run_alembic_upgrade` method in `GraphStore` into several private helper methods to improve readability and maintainability.

The following helpers were extracted:
- `_get_alembic_config`: Handles lazy loading and setup of Alembic Config.
- `_handle_downgrade_request`: Manages the early-exit downgrade path.
- `_maybe_stamp_legacy_db`: Detects and stamps legacy databases.
- `_maybe_take_backup_before_upgrade`: Handles breaking boundary backups.
- `_handle_alembic_command_error`: Provides descriptive errors for failed upgrades.

Functionality and lazy-loading of Alembic dependencies are preserved.

---
*PR created automatically by Jules for task [6722732837689314980](https://jules.google.com/task/6722732837689314980) started by @n24q02m*