### PR TITLE
[FIX] Handle non-dict payload test setup bug

### DIFF
--- a/tests/test_full_live.py
+++ b/tests/test_full_live.py
@@ -113,19 +113,20 @@ export { Circle, Rectangle, totalArea };
 """
 
 
-def _parse_result_text(result) -> dict[str, Any]:
-    """Extract text from MCP call_tool result and parse as JSON.
+def _parse_result_text(result) -> Any:
+    """Extract text from MCP call_tool result and try to parse as JSON.
 
-    All tools in better-code-review-graph return JSON-encoded dicts; a
-    non-dict payload indicates a test setup bug, so we fail loudly here.
+    Most tools return JSON-encoded dicts, but some (like "help") may
+    return raw markdown strings.
     """
     text = result.content[0].text
-    payload = json.loads(text)
-    if not isinstance(payload, dict):
-        raise TypeError(
-            f"Expected JSON object from MCP tool, got {type(payload).__name__}: {text!r}"
-        )
-    return payload
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            return payload
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return text
 
 
 def _server_params() -> StdioServerParameters:
@@ -761,3 +762,24 @@ class TestFullCloudEmbed:
                     n in names for n in ("add", "multiply", "calculate", "Calculator")
                 )
                 assert found, f"Expected calculator nodes, got {names}"
+
+
+# ---------------------------------------------------------------------------
+# TestFullHelp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.full
+class TestFullHelp:
+    """Test help tool functionality."""
+
+    async def test_help_graph(self):
+        """help topic=graph returns markdown documentation."""
+        async with stdio_client(_server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool("help", {"topic": "graph"})
+                data = _parse_result_text(result)
+                # Should be a string (markdown), not a dict
+                assert isinstance(data, str)
+                assert "# Graph" in data or "graph" in data.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Updated `_parse_result_text` in `tests/test_full_live.py` to handle non-dict payloads by returning the raw text if JSON parsing fails or if the result is not a dictionary. This allows tools like 'help' that return raw markdown to be tested correctly.

---
*PR created automatically by Jules for task [8018943247059779526](https://jules.google.com/task/8018943247059779526) started by @n24q02m*