### PR TITLE
[FIX] Fix correctness bug for bare suffix

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -960,6 +960,7 @@ class GraphStore:
         kind: str | tuple[str, ...] | None = None,
         *,
         as_of: str = "",
+        fallback: bool = True,
     ) -> list[GraphEdge]:
         frag, frag_params = self._temporal_filter(as_of)
         kind_frag, kind_params = self._kind_filter(kind)
@@ -974,7 +975,7 @@ class GraphStore:
         # enough to trigger the fallback — that would wrongly pull in edges
         # belonging to a different qualified target that happens to share the
         # bare name.
-        if not first_row and "::" in qualified_name:
+        if fallback and not first_row and "::" in qualified_name:
             if kind is not None:
                 exists = self._conn.execute(
                     f"SELECT 1 FROM edges WHERE target_qualified = ?{frag} LIMIT 1",  # noqa: S608

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1044,7 +1044,9 @@ def _handle_importers_of(
     *,
     as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_target(abs_target, kind="IMPORTS_FROM", as_of=as_of):
+    for e in store.get_edges_by_target(
+        abs_target, kind="IMPORTS_FROM", as_of=as_of, fallback=False
+    ):
         results.append({"importer": e.source_qualified, "file": e.file_path})
         edges_out.append(edge_to_dict(e))
 
@@ -1073,7 +1075,9 @@ def _handle_tests_for(
     as_of: str = "",
 ) -> None:
     qns = []
-    for e in store.get_edges_by_target(qn, kind="TESTED_BY", as_of=as_of):
+    for e in store.get_edges_by_target(
+        qn, kind="TESTED_BY", as_of=as_of, fallback=False
+    ):
         qns.append(e.source_qualified)
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
@@ -1101,7 +1105,7 @@ def _handle_inheritors_of(
 ) -> None:
     qns = []
     for e in store.get_edges_by_target(
-        qn, kind=("INHERITS", "IMPLEMENTS"), as_of=as_of
+        qn, kind=("INHERITS", "IMPLEMENTS"), as_of=as_of, fallback=False
     ):
         qns.append(e.source_qualified)
         edges_out.append(edge_to_dict(e))

--- a/tests/test_bare_suffix_correctness.py
+++ b/tests/test_bare_suffix_correctness.py
@@ -1,0 +1,132 @@
+import pytest
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+from better_code_review_graph.tools import (
+    _handle_importers_of,
+    _handle_inheritors_of,
+    _handle_tests_for,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "correctness.db"
+    s = GraphStore(str(db_path))
+    yield s
+    s.close()
+
+
+def test_inheritors_of_no_bare_fallback(store):
+    # Add a node that exists but has NO edges targeting it.
+    store.upsert_node(
+        NodeInfo(kind="Class", name="Base", file_path="a.py", line_start=1, line_end=10)
+    )
+
+    # Add another node that inherits from a BARE name "Base"
+    store.upsert_node(
+        NodeInfo(kind="Class", name="Sub", file_path="b.py", line_start=1, line_end=10)
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="INHERITS", source="b.py::Sub", target="Base", file_path="b.py", line=1
+        )
+    )
+
+    store.commit()
+
+    results = []
+    edges_out = []
+    _handle_inheritors_of(store, "a.py::Base", results, edges_out)
+
+    # It should NOT find b.py::Sub because we disabled fallback.
+    assert len(results) == 0
+    assert len(edges_out) == 0
+
+
+def test_tests_for_no_bare_fallback(store):
+    store.upsert_node(
+        NodeInfo(
+            kind="Function", name="target", file_path="a.py", line_start=1, line_end=10
+        )
+    )
+
+    # Test for bare name "target"
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="test_func",
+            file_path="test_a.py",
+            line_start=1,
+            line_end=10,
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="TESTED_BY",
+            source="test_a.py::test_func",
+            target="target",
+            file_path="test_a.py",
+            line=1,
+        )
+    )
+
+    store.commit()
+
+    results = []
+    # node argument is not used for TESTED_BY if qn is provided, but we pass it anyway
+    node = store.get_node("a.py::target")
+    _handle_tests_for(store, node, "target", "a.py::target", results)
+
+    assert len(results) == 0
+
+
+def test_importers_of_no_bare_fallback(store):
+    # importers_of for a file
+    # If we query importers of "app/a.py", it should not find someone importing bare "a.py"
+
+    store.upsert_node(
+        NodeInfo(
+            kind="File", name="a.py", file_path="app/a.py", line_start=0, line_end=0
+        )
+    )
+
+    store.upsert_node(
+        NodeInfo(
+            kind="File", name="b.py", file_path="app/b.py", line_start=0, line_end=0
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="IMPORTS_FROM",
+            source="app/b.py",
+            target="a.py",
+            file_path="app/b.py",
+            line=1,
+        )
+    )
+
+    store.commit()
+
+    results = []
+    edges_out = []
+    _handle_importers_of(store, "app/a.py", results, edges_out)
+
+    assert len(results) == 0
+
+
+def test_get_edges_by_target_explicit_fallback(store):
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS", source="b.py::bar", target="foo", file_path="b.py", line=1
+        )
+    )
+    store.commit()
+
+    # With fallback=True (default)
+    edges = store.get_edges_by_target("a.py::foo", kind="CALLS")
+    assert len(edges) == 1
+
+    # With fallback=False
+    edges = store.get_edges_by_target("a.py::foo", kind="CALLS", fallback=False)
+    assert len(edges) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `get_edges_by_target` method in `GraphStore` previously always fell back to bare-name matching if a qualified name had no edges. While useful for `callers_of` to resolve unqualified calls, this behavior caused correctness bugs for `inheritors_of`, `tests_for`, and `importers_of` by returning results that belonged to a different node sharing the same bare name.

This change:
1. Adds a `fallback` parameter to `get_edges_by_target` (defaulting to `True`).
2. Disables the fallback in `_handle_inheritors_of`, `_handle_tests_for`, and `_handle_importers_of`.
3. Adds a new test file `tests/test_bare_suffix_correctness.py` to verify the fix.

---
*PR created automatically by Jules for task [8955991070359445764](https://jules.google.com/task/8955991070359445764) started by @n24q02m*