### PR TITLE
[FIX] Fix setup_status returning stale module-level state

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -546,25 +546,28 @@ async def config(
         case "cache_clear":
             return _config_cache_clear(repo_root)
         case "setup_status":
-            from mcp_core.storage.per_plugin_store import PerPluginStore
-
             from . import credential_state as _cs
 
-            # Derive providers_configured from live PerPluginStore load + env
-            # so status is accurate even if module-level _state is stale.
-            _saved = PerPluginStore(_cs.PLUGIN_NAME).load() or {}
+            # Re-resolve state to ensure module-level _state is accurate.
+            _derived_state = _cs.resolve_credential_state()
+
+            # We still want to list which providers are configured for the UI.
+            _saved = {}
+            if _cs._is_http_mode():
+                from mcp_core.storage.per_plugin_store import PerPluginStore
+
+                try:
+                    _saved = PerPluginStore(_cs.PLUGIN_NAME).load() or {}
+                except Exception:
+                    pass
+
             _env_keys = [k for k in _cs.CLOUD_KEYS if os.environ.get(k)]
             _store_keys = [k for k in _cs.CLOUD_KEYS if _saved.get(k)]
             _providers = list(dict.fromkeys(_env_keys + _store_keys))
-            if _providers:
-                _derived_state = "configured"
-            elif _cs.get_state() == _cs.CredentialState.LOCAL:
-                _derived_state = "local"
-            else:
-                _derived_state = "awaiting_setup"
+
             return _json(
                 {
-                    "state": _derived_state,
+                    "state": _derived_state.value,
                     "setup_url": _cs.get_setup_url(),
                     "cloud_keys_in_env": _env_keys,
                     "providers_configured": _providers,

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -33,6 +33,7 @@ class TestSetupStatusLiveDerivedState:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """setup_status returns configured when PerPluginStore has cloud keys."""
+        monkeypatch.setenv("TRANSPORT_MODE", "http")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.delenv("JINA_AI_API_KEY", raising=False)

--- a/tests/test_v17_coverage_gaps.py
+++ b/tests/test_v17_coverage_gaps.py
@@ -515,7 +515,9 @@ class TestServerSpotCheckAndRenamedInDiff:
 
         with (
             patch("mcp_core.storage.per_plugin_store.PerPluginStore") as mock_store,
-            patch.object(cs, "get_state", return_value=cs.CredentialState.LOCAL),
+            patch.object(
+                cs, "resolve_credential_state", return_value=cs.CredentialState.LOCAL
+            ),
         ):
             mock_store.return_value.load.return_value = {}
             result = json.loads(asyncio.run(config(action="setup_status")))

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4b1"
+version = "3.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `setup_status` action in `server.py` was returning stale module-level state because it was only deriving the state locally within the tool call without updating the global `_state` in `credential_state.py`.

This PR refactors `setup_status` to:
1. Call `credential_state.resolve_credential_state()` to update the global state.
2. Use the returned state for the response.
3. Update tests to handle the fact that `resolve_credential_state()` behaves differently in stdio vs http modes (stdio only checks env vars).

Changes:
- `src/better_code_review_graph/server.py`: Call `resolve_credential_state()` in `setup_status`.
- `tests/test_g6_ux_status_accuracy.py`: Set `TRANSPORT_MODE=http` so `resolve_credential_state()` checks the `PerPluginStore`.
- `tests/test_v17_coverage_gaps.py`: Mock `resolve_credential_state` instead of `get_state`.

---
*PR created automatically by Jules for task [3480164586154539785](https://jules.google.com/task/3480164586154539785) started by @n24q02m*