### PR TITLE
fix: report package version in serverInfo instead of fastmcp version

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from importlib.resources import files
 
 from fastmcp import FastMCP
@@ -63,8 +65,15 @@ def _maybe_include_setup_hint(result: dict) -> dict:
     return result
 
 
+try:
+    _pkg_version = pkg_version("better-code-review-graph")
+except PackageNotFoundError:
+    _pkg_version = "dev"
+
+
 mcp = FastMCP(
     "better-code-review-graph",
+    version=_pkg_version,
     instructions=(
         "Persistent incremental knowledge graph for token-efficient, "
         "context-aware code reviews. 5 tools: graph (build/embed/stats), "
@@ -669,14 +678,9 @@ async def config(
 
 def _config_status(repo_root: str | None) -> str:
     """Return server status as JSON."""
-    from importlib.metadata import version as pkg_version
-
     from .tools import _get_store
 
-    try:
-        version = pkg_version("better-code-review-graph")
-    except Exception:
-        version = "dev"
+    version = _pkg_version
 
     try:
         store, root = _get_store(repo_root)

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -65,10 +65,15 @@ def _maybe_include_setup_hint(result: dict) -> dict:
     return result
 
 
-try:
-    _pkg_version = pkg_version("better-code-review-graph")
-except PackageNotFoundError:
-    _pkg_version = "dev"
+def _resolve_version() -> str:
+    """Resolve the installed package version, falling back to 'dev'."""
+    try:
+        return pkg_version("better-code-review-graph")
+    except PackageNotFoundError:
+        return "dev"
+
+
+_pkg_version = _resolve_version()
 
 
 mcp = FastMCP(

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -338,12 +338,10 @@ class TestConfigStatusVersionFallback:
             assert result["version"] == "dev"
 
     def test_version_fallback_direct(self):
-        """Test _config_status directly with mocked version."""
+        """Test _config_status reports the module-level resolved version."""
         from better_code_review_graph.server import _config_status
 
-        with patch(
-            "importlib.metadata.version", side_effect=Exception("not installed")
-        ):
+        with patch("better_code_review_graph.server._pkg_version", "dev"):
             result = json.loads(_config_status(repo_root=None))
             assert result["version"] == "dev"
 

--- a/tests/test_serverinfo_version.py
+++ b/tests/test_serverinfo_version.py
@@ -1,0 +1,24 @@
+"""Regression test: server reports its own package version in serverInfo.
+
+Previously the FastMCP constructor was called without ``version=``, so the
+reported version defaulted to the fastmcp framework version (e.g. "3.4.2")
+instead of the better-code-review-graph package version.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+
+from better_code_review_graph.server import mcp
+
+
+def test_serverinfo_reports_package_version():
+    expected = pkg_version("better-code-review-graph")
+    reported = mcp._mcp_server.create_initialization_options().server_version
+    assert reported == expected
+
+
+def test_serverinfo_not_fastmcp_version():
+    reported = mcp._mcp_server.create_initialization_options().server_version
+    fastmcp_version = pkg_version("fastmcp")
+    assert reported != fastmcp_version

--- a/tests/test_serverinfo_version.py
+++ b/tests/test_serverinfo_version.py
@@ -7,9 +7,11 @@ instead of the better-code-review-graph package version.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
+from unittest.mock import patch
 
-from better_code_review_graph.server import mcp
+from better_code_review_graph.server import _resolve_version, mcp
 
 
 def test_serverinfo_reports_package_version():
@@ -22,3 +24,11 @@ def test_serverinfo_not_fastmcp_version():
     reported = mcp._mcp_server.create_initialization_options().server_version
     fastmcp_version = pkg_version("fastmcp")
     assert reported != fastmcp_version
+
+
+def test_resolve_version_fallback_when_not_installed():
+    with patch(
+        "better_code_review_graph.server.pkg_version",
+        side_effect=PackageNotFoundError("better-code-review-graph"),
+    ):
+        assert _resolve_version() == "dev"


### PR DESCRIPTION
## Problem

The server reported the fastmcp framework version (`3.4.2`) in `serverInfo.version` instead of its own package version.

## Root cause

`src/better_code_review_graph/server.py` built `FastMCP("better-code-review-graph", ...)` without passing the `version=` kwarg, so it defaulted to the fastmcp package version.

## Fix

- Resolve package version via `importlib.metadata.version("better-code-review-graph")` at module level (fallback `"dev"` on `PackageNotFoundError`).
- Pass it as `version=` to the `FastMCP` constructor.
- Reuse the module-level value in `_config_status` (removes the duplicated local import).

## Test

Added `tests/test_serverinfo_version.py`:
- asserts `create_initialization_options().server_version` equals the package version
- asserts it is NOT the fastmcp version

🤖 Generated with [Claude Code](https://claude.com/claude-code)