### PR TITLE
⚡ Bolt: optimize database fetchall() memory footprint

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -623,12 +623,14 @@ class EmbeddingStore:
         # Batch fetch existing metadata to prevent N+1 queries
         qns = [n.qualified_name for n in nodes if n.kind != "File"]
         existing_map: dict[str, dict[str, Any]] = {}
-        rows = self._conn.execute(
+        # Performance: Replaced fetchall() with direct cursor iteration to avoid
+        # materializing large intermediate lists in memory, reducing peak memory usage.
+        cursor = self._conn.execute(
             "SELECT qualified_name, text_hash, provider FROM embeddings "
             "WHERE qualified_name IN (SELECT value FROM json_each(?))",
             (json.dumps(qns),),
-        ).fetchall()
-        for r in rows:
+        )
+        for r in cursor:
             existing_map[r["qualified_name"]] = r
 
         for node in nodes:

--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -90,11 +90,13 @@ class RepoRegistry:
 
     def _load_from_store(self) -> None:
         """Populate the in-memory caches from the ``repos`` table."""
-        rows = self._store._conn.execute(
+        # Performance: Replaced fetchall() with direct cursor iteration to avoid
+        # materializing large intermediate lists in memory, reducing peak memory usage.
+        cursor = self._store._conn.execute(
             "SELECT repo_id, path, remote_url, last_indexed_sha, "
             "first_indexed_at, last_indexed_at FROM repos"
-        ).fetchall()
-        for row in rows:
+        )
+        for row in cursor:
             entry = RepoEntry(
                 repo_id=row["repo_id"],
                 path=Path(row["path"]),

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 What: Replaced `.fetchall()` with direct cursor iteration in `_load_from_store` (`federation.py`) and metadata batch fetch (`embeddings.py`).
🎯 Why: `.fetchall()` materializes the entire query result set into a large list in memory. By iterating directly over the cursor, we stream the rows.
📊 Impact: Reduces peak memory consumption during repository loading and embedding synchronization by avoiding the creation of large intermediate Python lists.
🔬 Measurement: Verify tests still pass (`uv run pytest`) and observe reduced memory footprint during `_load_from_store` for repositories with thousands of files or large embedding histories.

---
*PR created automatically by Jules for task [10983803914529443935](https://jules.google.com/task/10983803914529443935) started by @n24q02m*