### PR TITLE
[TEST] Missing tests for get_all_nodes

### DIFF
--- a/tests/test_graph_extra.py
+++ b/tests/test_graph_extra.py
@@ -317,6 +317,37 @@ class TestGraphStoreExtra:
         assert len(edges) == 2
         store.close()
 
+    def test_get_all_nodes(self, tmp_path):
+        store = GraphStore(str(tmp_path / "t.db"))
+        store.upsert_node(
+            NodeInfo(
+                kind="Function",
+                name="func1",
+                file_path="/file1.py",
+                line_start=1,
+                line_end=10,
+                language="python",
+            )
+        )
+        store.upsert_node(
+            NodeInfo(
+                kind="Class",
+                name="Class1",
+                file_path="/file2.py",
+                line_start=1,
+                line_end=20,
+                language="python",
+            )
+        )
+        store.commit()
+
+        nodes = store.get_all_nodes()
+        assert len(nodes) == 2
+        qualified_names = [n.qualified_name for n in nodes]
+        assert "/file1.py::func1" in qualified_names
+        assert "/file2.py::Class1" in qualified_names
+        store.close()
+
     def test_get_edges_among_empty_set(self, tmp_path):
         store = GraphStore(str(tmp_path / "t.db"))
         assert store.get_edges_among(set()) == []

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds missing unit tests for the `get_all_nodes` method in `GraphStore`. The test ensures that nodes are correctly retrieved from the SQLite database and mapped to `GraphNode` objects. Verified with `pytest` and linter checks.

---
*PR created automatically by Jules for task [15456279562471636452](https://jules.google.com/task/15456279562471636452) started by @n24q02m*