### PR TITLE
[TEST] Missing test file for temporal.py

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock
+
+from better_code_review_graph.temporal import (
+    TemporalIndex,
+    TemporalUpsertResult,
+    _hash_source,
+)
+
+
+def test_hash_source_handles_none() -> None:
+    """None input collapses to empty string hash."""
+    assert _hash_source(None) == ""
+
+
+def test_hash_source_handles_empty_string() -> None:
+    """Empty string input collapses to empty string hash."""
+    assert _hash_source("") == ""
+
+
+def test_hash_source_returns_sha256_for_content() -> None:
+    """Valid string returns hex-encoded SHA-256."""
+    text = "def foo(): pass"
+    expected = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    assert _hash_source(text) == expected
+
+
+def test_temporal_upsert_result_fields() -> None:
+    """TemporalUpsertResult holds the expected fields."""
+    res = TemporalUpsertResult(action="inserted", closed_out_count=0)
+    assert res.action == "inserted"
+    assert res.closed_out_count == 0
+
+
+def test_temporal_index_instantiation() -> None:
+    """TemporalIndex can be instantiated with a store and sha."""
+    mock_store = MagicMock()
+    idx = TemporalIndex(mock_store, current_sha="abc")
+    assert idx._store == mock_store
+    assert idx._current_sha == "abc"

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds a dedicated unit test file tests/test_temporal.py for the core functions and dataclasses in src/better_code_review_graph/temporal.py.

Changes:
- Created tests/test_temporal.py covering:
    - _hash_source utility with None, empty string, and standard string inputs.
    - TemporalUpsertResult dataclass.
    - Basic TemporalIndex instantiation.
- Verified that these tests, along with existing temporal tests, pass successfully.
- Ensured code quality with ruff and type checking with ty.

This addresses the missing direct test coverage for the temporal.py module.

---
*PR created automatically by Jules for task [4473144166778233277](https://jules.google.com/task/4473144166778233277) started by @n24q02m*