### PR TITLE
[CLEANUP] Unused Function: _is_test_file

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -203,19 +203,6 @@ _TEST_PATTERNS = [
     re.compile(r"_spec$"),
 ]
 
-_TEST_FILE_PATTERNS = [
-    re.compile(r"test_.*\.py$"),
-    re.compile(r".*_test\.py$"),
-    re.compile(r".*\.test\.[jt]sx?$"),
-    re.compile(r".*\.spec\.[jt]sx?$"),
-    re.compile(r".*_test\.go$"),
-    re.compile(r"tests?/"),
-]
-
-
-def _is_test_file(path: str) -> bool:
-    return any(p.search(path) for p in _TEST_FILE_PATTERNS)
-
 
 def _is_test_function(name: str, file_path: str) -> bool:
     """A function is a test only if its name matches test patterns.

--- a/tests/test_parser_extra.py
+++ b/tests/test_parser_extra.py
@@ -6,18 +6,12 @@ from pathlib import Path
 
 from better_code_review_graph.parser import (
     CodeParser,
-    _is_test_file,
     _is_test_function,
     file_hash,
 )
 
 
 class TestParserUtils:
-    def test_is_test_file(self):
-        assert _is_test_file("tests/test_foo.py") is True
-        assert _is_test_file("test/test_bar.py") is True
-        assert _is_test_file("src/main.py") is False
-
     def test_is_test_function(self):
         assert _is_test_function("test_login", "test_auth.py") is True
         assert _is_test_function("login", "auth.py") is False

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR removes the unused internal function `_is_test_file` and the associated constant `_TEST_FILE_PATTERNS` from `src/better_code_review_graph/parser.py`.

Rationale:
- The function is internal (starts with `_`) and is not referenced anywhere in the source code.
- A regex search confirmed it was only used in tests.
- Test function identification remains correctly handled by `_is_test_function` using the `_TEST_PATTERNS` regex list.

Changes:
- Removed `_TEST_FILE_PATTERNS` from `src/better_code_review_graph/parser.py`.
- Removed `_is_test_file` from `src/better_code_review_graph/parser.py`.
- Removed corresponding tests and imports from `tests/test_parser_extra.py`.
- Verified changes by running the full test suite and code quality checks (ruff, ty).

---
*PR created automatically by Jules for task [16351380915562376585](https://jules.google.com/task/16351380915562376585) started by @n24q02m*