### PR TITLE
[SECURITY] Potential Command Injection in Semgrep Engine

### DIFF
--- a/src/better_code_review_graph/security/semgrep_engine.py
+++ b/src/better_code_review_graph/security/semgrep_engine.py
@@ -117,7 +117,10 @@ class SemgrepScanner:
         executable: str | None = None,
         require_python_module: bool = False,
     ) -> None:
-        self._config = str(config)
+        config_str = str(config)
+        if config_str.startswith("-"):
+            raise ValueError(f"Semgrep config cannot start with a hyphen: {config_str}")
+        self._config = config_str
         resolved = executable or _semgrep_executable()
         if resolved is None:
             raise SemgrepNotAvailable(
@@ -162,6 +165,7 @@ class SemgrepScanner:
             self._config,
             "--json",
             "--quiet",
+            "--",
             str(target),
         ]
         proc = subprocess.run(

--- a/tests/test_semgrep_engine.py
+++ b/tests/test_semgrep_engine.py
@@ -419,3 +419,24 @@ def test_scan_path_uses_double_dash_separator(tmp_path):
 def test_init_raises_on_config_starting_with_hyphen():
     with pytest.raises(ValueError, match="Semgrep config cannot start with a hyphen"):
         SemgrepScanner(config="--some-flag", executable="/fake/semgrep")
+
+
+def test_scan_path_with_registry_config(tmp_path):
+    target = tmp_path / "src.py"
+    target.write_text("print(1)")
+    # Using a registry-like config string
+    scanner = SemgrepScanner(config="p/python", executable="/fake/semgrep")
+    with patch(
+        "better_code_review_graph.security.semgrep_engine.subprocess.run",
+        return_value=_mock_completed(0, stdout='{"results": []}'),
+    ) as run_mock:
+        scanner.scan_path(target)
+
+    cmd = run_mock.call_args[0][0]
+    # Verify --config <config> is still correct
+    assert "--config" in cmd
+    idx = cmd.index("--config")
+    assert cmd[idx + 1] == "p/python"
+    # Verify -- is still before target
+    assert "--" in cmd
+    assert cmd.index("--") == cmd.index(str(target)) - 1

--- a/tests/test_semgrep_engine.py
+++ b/tests/test_semgrep_engine.py
@@ -394,3 +394,28 @@ def test_security_module_reexports_semgrep_symbols():
     assert "SemgrepScanner" in security.__all__
     assert "SemgrepResult" in security.__all__
     assert "SemgrepNotAvailable" in security.__all__
+
+
+# ---------------------------------------------------------------------------
+# Security: Argument Injection
+# ---------------------------------------------------------------------------
+
+
+def test_scan_path_uses_double_dash_separator(tmp_path):
+    target = tmp_path / "--version"
+    target.write_text("print(1)")
+    scanner = SemgrepScanner(executable="/fake/semgrep")
+    with patch(
+        "better_code_review_graph.security.semgrep_engine.subprocess.run",
+        return_value=_mock_completed(0, stdout='{"results": []}'),
+    ) as run_mock:
+        scanner.scan_path(target)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--" in cmd
+    assert cmd.index("--") == cmd.index(str(target)) - 1
+
+
+def test_init_raises_on_config_starting_with_hyphen():
+    with pytest.raises(ValueError, match="Semgrep config cannot start with a hyphen"):
+        SemgrepScanner(config="--some-flag", executable="/fake/semgrep")

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR addresses a potential command injection vulnerability in the Semgrep engine. 
While subprocess.run uses a list format which prevents shell injection, it was still vulnerable to argument injection if 'target' or 'config' started with a hyphen.

Changes:
- Added a validation check in SemgrepScanner.__init__ to raise ValueError if the config starts with '-'.
- Added the '--' separator in scan_path to ensure the target is treated as a positional argument.
- Added regression tests in tests/test_semgrep_engine.py.
- Recorded security learnings in .jules/sentinel.md.

---
*PR created automatically by Jules for task [8693555031358725743](https://jules.google.com/task/8693555031358725743) started by @n24q02m*