### PR TITLE
[FIX] Fix historical bug in Alembic baseline

### DIFF
--- a/src/better_code_review_graph/security/heuristic.py
+++ b/src/better_code_review_graph/security/heuristic.py
@@ -155,10 +155,12 @@ def _default_rules_dir() -> Path:
     """
 
     try:
-        ref = files("better_code_review_graph_security_rules") / "heuristic"
-        path = Path(str(ref))
-        if path.is_dir():
-            return path
+        ref = files("better_code_review_graph_security_rules")
+        # Robust path resolution pattern: avoid Path(str(ref)) because some
+        # importlib.resources versions return the repr in __str__.
+        probe = ref.joinpath("heuristic", "hardcoded-secret.yaml")
+        if isinstance(probe, Path) and probe.is_file():
+            return probe.parent
     except (ModuleNotFoundError, OSError):
         pass
     return Path(__file__).resolve().parent.parent.parent.parent / "rules" / "heuristic"

--- a/src/better_code_review_graph/security/semgrep_engine.py
+++ b/src/better_code_review_graph/security/semgrep_engine.py
@@ -74,10 +74,12 @@ def _resolve_overlay_rules_dir() -> Path | None:
     """
 
     try:
-        ref = files("better_code_review_graph_security_rules") / "semgrep"
-        path = Path(str(ref))
-        if path.is_dir():
-            return path
+        ref = files("better_code_review_graph_security_rules")
+        # Robust path resolution pattern: avoid Path(str(ref)) because some
+        # importlib.resources versions return the repr in __str__.
+        probe = ref.joinpath("semgrep", "curated.yaml")
+        if isinstance(probe, Path) and probe.is_file():
+            return probe.parent
     except (ModuleNotFoundError, OSError):
         pass
     fallback = (

--- a/tests/test_alembic_baseline.py
+++ b/tests/test_alembic_baseline.py
@@ -576,6 +576,11 @@ def test_resolve_migrations_dir_handles_multiplexed_path_repr(
 
     monkeypatch.setattr(_resources, "files", _files)
 
+    # Verify the mock correctly simulates the historical bug.
+    obj = _files("better_code_review_graph_migrations")
+    expected_repr = f"MultiplexedPath('{fake_dir}')"
+    assert str(obj) == expected_repr
+
     # Falls through installed-wheel branch (joinpath result not a Path)
     # → resolves via source-checkout fallback. Both paths exist in the
     # checkout, so we should get a working migrations dir back.

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR fixes a historical bug in the Alembic baseline and security rule resolution.
Some versions of `importlib.resources` (MultiplexedPath) have a `__str__` that returns the `repr`, which breaks `Path(str(ref))`.
The fix standardizes path resolution by using `ref.joinpath("probe_file")` and checking if the result is a `pathlib.Path`.

Changes:
- Added explicit verification of the historical bug in `tests/test_alembic_baseline.py`.
- Updated `src/better_code_review_graph/security/semgrep_engine.py` to use robust path resolution.
- Updated `src/better_code_review_graph/security/heuristic.py` to use robust path resolution.

---
*PR created automatically by Jules for task [3344586142806655419](https://jules.google.com/task/3344586142806655419) started by @n24q02m*