### PR TITLE
[TEST] Missing test file for relay_schema.py

### DIFF
--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,4 +1,4 @@
-"""Tests for relay_schema, relay_setup, and credential_state modules."""
+"""Tests for relay_setup, and credential_state modules."""
 
 from __future__ import annotations
 
@@ -30,41 +30,6 @@ def _default_relay_url_env(monkeypatch):
     MCP_RELAY_URL" behavior can delenv it inside the test body.
     """
     monkeypatch.setenv("MCP_RELAY_URL", TEST_RELAY_URL)
-
-
-# ---------------------------------------------------------------------------
-# relay_schema
-# ---------------------------------------------------------------------------
-
-
-class TestRelaySchema:
-    def test_server_name(self):
-        assert RELAY_SCHEMA["server"] == "better-code-review-graph"
-
-    def test_display_name(self):
-        assert RELAY_SCHEMA["displayName"] == "Code Review Graph"
-
-    def test_has_fields(self):
-        fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 4
-
-    def test_field_keys(self):
-        keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
-        assert keys == [
-            "JINA_AI_API_KEY",
-            "GEMINI_API_KEY",
-            "OPENAI_API_KEY",
-            "COHERE_API_KEY",
-        ]
-
-    def test_all_fields_optional(self):
-        for field in RELAY_SCHEMA["fields"]:
-            assert field["required"] is False
-
-    def test_schema_is_valid_typed_dict(self):
-        assert "server" in RELAY_SCHEMA
-        assert "displayName" in RELAY_SCHEMA
-        assert "fields" in RELAY_SCHEMA
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,0 +1,66 @@
+"""Tests for the RELAY_SCHEMA configuration."""
+
+from __future__ import annotations
+
+from better_code_review_graph.relay_schema import RELAY_SCHEMA
+
+
+class TestRelaySchema:
+    def test_server_id(self):
+        """Must match the expected server ID for relay identification."""
+        assert RELAY_SCHEMA["server"] == "better-code-review-graph"
+
+    def test_display_name(self):
+        """Must match the expected display name for the relay UI."""
+        assert RELAY_SCHEMA["displayName"] == "Code Review Graph"
+
+    def test_description(self):
+        """Must have a descriptive string for users."""
+        assert isinstance(RELAY_SCHEMA["description"], str)
+        assert "API keys" in RELAY_SCHEMA["description"]
+
+    def test_fields_structure(self):
+        """Fields must be a list of configuration objects."""
+        fields = RELAY_SCHEMA["fields"]
+        assert isinstance(fields, list)
+        assert len(fields) == 4
+
+        expected_keys = [
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+        ]
+        actual_keys = [f["key"] for f in fields]
+        assert actual_keys == expected_keys
+
+    def test_fields_attributes(self):
+        """Each field must have the required relay attributes."""
+        for field in RELAY_SCHEMA["fields"]:
+            assert "key" in field
+            assert "label" in field
+            assert "type" in field
+            assert "required" in field
+            assert field["required"] is False
+            if "helpUrl" in field:
+                assert field["helpUrl"].startswith("https://")
+
+    def test_capability_info(self):
+        """Must define embedding and reranking capabilities for the relay UI."""
+        capabilities = RELAY_SCHEMA["capabilityInfo"]
+        assert isinstance(capabilities, list)
+        assert len(capabilities) == 2
+
+        labels = [c["label"] for c in capabilities]
+        assert "Embedding" in labels
+        assert "Reranking" in labels
+
+        for cap in capabilities:
+            assert "label" in cap
+            assert "priority" in cap
+            assert "description" in cap
+
+    def test_forward_compatibility_type(self):
+        """The schema must be a plain dict for forward compatibility."""
+        # The docstring in relay_schema.py notes this is intentional.
+        assert isinstance(RELAY_SCHEMA, dict)

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds a dedicated test file `tests/test_relay_schema.py` for `relay_schema.py` to ensure proper unit testing of the relay configuration. It also removes the redundant `TestRelaySchema` class from `tests/test_relay.py` to align with the project's testing structure of having one test file per source module. All tests passed, and type checks were successful.

---
*PR created automatically by Jules for task [2508863647411440434](https://jules.google.com/task/2508863647411440434) started by @n24q02m*