### PR TITLE
[FIX] Repeated Queries in Loop in `_lookup_node_directly`

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -194,6 +194,7 @@ class GraphNode:
     return_type: str | None
     is_test: bool
     file_hash: str | None
+    repo_id: str
     extra: dict
 
 
@@ -1432,6 +1433,7 @@ class GraphStore:
             return_type=row["return_type"],
             is_test=bool(row["is_test"]),
             file_hash=row["file_hash"],
+            repo_id=row["repo_id"] or "",
             extra=json.loads(row["extra"]) if row["extra"] else {},
         )
 

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -11,7 +11,7 @@ import shutil
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -194,8 +194,8 @@ class GraphNode:
     return_type: str | None
     is_test: bool
     file_hash: str | None
-    repo_id: str
-    extra: dict
+    repo_id: str = ""
+    extra: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -206,7 +206,7 @@ class GraphEdge:
     target_qualified: str
     file_path: str
     line: int
-    extra: dict
+    extra: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -852,11 +852,7 @@ def _resolve_query_target(
     # requested repo so the search-by-name fallback below can pick a
     # repo-scoped candidate instead of returning the cross-repo match.
     if node is not None and repo:
-        row = store._conn.execute(
-            "SELECT repo_id FROM nodes WHERE qualified_name = ?",
-            (node.qualified_name,),
-        ).fetchone()
-        if row is None or (row["repo_id"] or "") != repo:
+        if (node.repo_id or "") != repo:
             node = None
 
     # 2. Search by name if not found directly

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -48,6 +48,7 @@ def _make_graph_node(**kwargs) -> GraphNode:
         "is_test": False,
         "file_hash": None,
         "extra": {},
+        "repo_id": "",
     }
     defaults.update(kwargs)
     return GraphNode(**defaults)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -45,6 +45,7 @@ def _make_node(**kwargs) -> GraphNode:
         "is_test": False,
         "file_hash": None,
         "extra": {},
+        "repo_id": "",
     }
     defaults.update(kwargs)
     return GraphNode(**defaults)

--- a/tests/test_embeddings_extra.py
+++ b/tests/test_embeddings_extra.py
@@ -22,6 +22,7 @@ def _make_node(**kwargs) -> GraphNode:
         "is_test": False,
         "file_hash": None,
         "extra": {},
+        "repo_id": "",
     }
     defaults.update(kwargs)
     return GraphNode(**defaults)

--- a/tests/test_resolve_search_candidates.py
+++ b/tests/test_resolve_search_candidates.py
@@ -19,6 +19,7 @@ def make_node(kind, name, qualified_name):
         return_type=None,
         is_test=False,
         file_hash=None,
+        repo_id="",
         extra={},
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Optimized `_resolve_query_target` by eliminating a redundant database query.
The `repo_id` is now retrieved once during the initial node lookup and
stored in the `GraphNode` dataclass.

Changes:
- Added `repo_id: str` to `GraphNode` dataclass in `graph.py`.
- Updated `GraphStore._row_to_node` to populate `repo_id` from the DB row.
- Refactored `_resolve_query_target` in `tools.py` to use `node.repo_id`.
- Updated test helpers in several test files to support the new `repo_id` field.

---
*PR created automatically by Jules for task [6595383736951363395](https://jules.google.com/task/6595383736951363395) started by @n24q02m*