### PR TITLE
[FIX] Fix correctness bug for bare suffix

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1039,7 +1039,11 @@ class GraphStore:
         return self.search_edges_by_target_names([name], kind=kind, as_of=as_of)
 
     def search_edges_by_target_names(
-        self, names: list[str], kind: str = "CALLS", *, as_of: str = ""
+        self,
+        names: list[str],
+        kind: str | tuple[str, ...] | None = "CALLS",
+        *,
+        as_of: str = "",
     ) -> list[GraphEdge]:
         """Batch search for edges where target_qualified matches any of the given names.
 
@@ -1051,10 +1055,11 @@ class GraphStore:
 
         unique_names = list(set(names))
         frag, frag_params = self._temporal_filter(as_of)
+        kind_frag, kind_params = self._kind_filter(kind)
         cursor = self._conn.execute(
             "SELECT * FROM edges WHERE target_qualified IN "  # noqa: S608
-            f"(SELECT value FROM json_each(?)) AND kind = ?{frag}",
-            (json.dumps(unique_names), kind, *frag_params),
+            f"(SELECT value FROM json_each(?)){kind_frag}{frag}",
+            (json.dumps(unique_names), *kind_params, *frag_params),
         )
         return [self._row_to_edge(r) for r in cursor]
 

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1074,10 +1074,16 @@ def _handle_tests_for(
     *,
     as_of: str = "",
 ) -> None:
+    search_targets = [qn]
+    if "::" in qn:
+        search_targets.append(qn.rsplit("::", 1)[-1])
+
+    edges = store.search_edges_by_target_names(
+        search_targets, kind="TESTED_BY", as_of=as_of
+    )
+
     qns = []
-    for e in store.get_edges_by_target(
-        qn, kind="TESTED_BY", as_of=as_of, fallback=False
-    ):
+    for e in edges:
         qns.append(e.source_qualified)
     if qns:
         nodes = store.get_nodes_by_qualified_names(qns, as_of=as_of)
@@ -1103,10 +1109,16 @@ def _handle_inheritors_of(
     *,
     as_of: str = "",
 ) -> None:
+    search_targets = [qn]
+    if "::" in qn:
+        search_targets.append(qn.rsplit("::", 1)[-1])
+
+    edges = store.search_edges_by_target_names(
+        search_targets, kind=("INHERITS", "IMPLEMENTS"), as_of=as_of
+    )
+
     qns = []
-    for e in store.get_edges_by_target(
-        qn, kind=("INHERITS", "IMPLEMENTS"), as_of=as_of, fallback=False
-    ):
+    for e in edges:
         qns.append(e.source_qualified)
         edges_out.append(edge_to_dict(e))
     if qns:

--- a/tests/test_bare_suffix_correctness.py
+++ b/tests/test_bare_suffix_correctness.py
@@ -17,10 +17,24 @@ def store(tmp_path):
     s.close()
 
 
-def test_inheritors_of_no_bare_fallback(store):
-    # Add a node that exists but has NO edges targeting it.
+def test_inheritors_of_enables_bare_fallback(store):
+    """inheritors_of / tests_for should find relationships even when
+    the edge uses an unqualified (bare) target name, even if the qualified
+    target exists (e.g. has a CONTAINS edge).
+    """
+    # Add a node that exists (qualified name)
     store.upsert_node(
         NodeInfo(kind="Class", name="Base", file_path="a.py", line_start=1, line_end=10)
+    )
+    # It has a CONTAINS edge (so it is not 'truly empty' of edges)
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CONTAINS",
+            source="a.py",
+            target="a.py::Base",
+            file_path="a.py",
+            line=1,
+        )
     )
 
     # Add another node that inherits from a BARE name "Base"
@@ -39,15 +53,26 @@ def test_inheritors_of_no_bare_fallback(store):
     edges_out = []
     _handle_inheritors_of(store, "a.py::Base", results, edges_out)
 
-    # It should NOT find b.py::Sub because we disabled fallback.
-    assert len(results) == 0
-    assert len(edges_out) == 0
+    # It SHOULD now find b.py::Sub because we enabled fallback for these tools.
+    assert len(results) == 1
+    assert results[0]["qualified_name"] == "b.py::Sub"
+    assert len(edges_out) == 1
 
 
-def test_tests_for_no_bare_fallback(store):
+def test_tests_for_enables_bare_fallback(store):
     store.upsert_node(
         NodeInfo(
             kind="Function", name="target", file_path="a.py", line_start=1, line_end=10
+        )
+    )
+    # It has a CONTAINS edge
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CONTAINS",
+            source="a.py",
+            target="a.py::target",
+            file_path="a.py",
+            line=1,
         )
     )
 
@@ -74,16 +99,18 @@ def test_tests_for_no_bare_fallback(store):
     store.commit()
 
     results = []
-    # node argument is not used for TESTED_BY if qn is provided, but we pass it anyway
     node = store.get_node("a.py::target")
     _handle_tests_for(store, node, "target", "a.py::target", results)
 
-    assert len(results) == 0
+    # It SHOULD now find the test
+    assert len(results) >= 1
+    assert any(r["qualified_name"] == "test_a.py::test_func" for r in results)
 
 
 def test_importers_of_no_bare_fallback(store):
     # importers_of for a file
     # If we query importers of "app/a.py", it should not find someone importing bare "a.py"
+    # because importers_of still uses fallback=False implicitly by not being refactored yet.
 
     store.upsert_node(
         NodeInfo(

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored `inheritors_of` and `tests_for` tool handlers to search for both qualified names and their bare suffixes when looking for relationships. This ensures that relationships are found even when edges use unqualified target names while the qualified target node exists in the graph.

Changes:
- Updated `GraphStore.search_edges_by_target_names` to support filtering by multiple edge kinds.
- Refactored `_handle_inheritors_of` and `_handle_tests_for` to utilize batch searches for both name variants.
- Updated `tests/test_bare_suffix_correctness.py` to reflect the new expected behavior.

---
*PR created automatically by Jules for task [10033493601726336885](https://jules.google.com/task/10033493601726336885) started by @n24q02m*