### PR TITLE
⚡ Bolt: Replace SQLite fetchall() with direct cursor iteration

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -623,12 +623,12 @@ class EmbeddingStore:
         # Batch fetch existing metadata to prevent N+1 queries
         qns = [n.qualified_name for n in nodes if n.kind != "File"]
         existing_map: dict[str, dict[str, Any]] = {}
-        rows = self._conn.execute(
+        cursor = self._conn.execute(
             "SELECT qualified_name, text_hash, provider FROM embeddings "
             "WHERE qualified_name IN (SELECT value FROM json_each(?))",
             (json.dumps(qns),),
-        ).fetchall()
-        for r in rows:
+        )
+        for r in cursor:
             existing_map[r["qualified_name"]] = r
 
         for node in nodes:

--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -90,11 +90,11 @@ class RepoRegistry:
 
     def _load_from_store(self) -> None:
         """Populate the in-memory caches from the ``repos`` table."""
-        rows = self._store._conn.execute(
+        cursor = self._store._conn.execute(
             "SELECT repo_id, path, remote_url, last_indexed_sha, "
             "first_indexed_at, last_indexed_at FROM repos"
-        ).fetchall()
-        for row in rows:
+        )
+        for row in cursor:
             entry = RepoEntry(
                 repo_id=row["repo_id"],
                 path=Path(row["path"]),

--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -271,17 +271,17 @@ def batch_summarize(
         )
     provider, api_key = resolved
 
-    rows = store._conn.execute(
+    cursor = store._conn.execute(
         "SELECT id, source_text, source_hash, summary, summary_provider FROM nodes "
         "WHERE kind='Function' AND source_text IS NOT NULL LIMIT ?",
         (max_nodes,),
-    ).fetchall()
+    )
 
     generated = 0
     cached = 0
     errors = 0
 
-    for row in rows:
+    for row in cursor:
         row_id = row[0]
         src = row[1]
         stored_hash = row[2]

--- a/src/better_code_review_graph/temporal.py
+++ b/src/better_code_review_graph/temporal.py
@@ -446,6 +446,7 @@ class TemporalIndex:
         Returns:
             Number of nodes whose ``valid_to_sha`` was set in this call.
         """
+        # We need fetchall() here because we are modifying the DB inside the loop
         rows = self._store._conn.execute(
             "SELECT id, qualified_name FROM nodes "
             "WHERE file_path = ? AND valid_to_sha IS NULL",

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.16.4"
+version = "3.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
⚡ Bolt: Replace SQLite fetchall() with direct cursor iteration

Replaces `cursor.fetchall()` with direct cursor iteration (`for row in cursor`) in `embeddings.py`, `federation.py`, and `summarizer.py`.

💡 What: Removed `.fetchall()` from SQLite `execute()` calls when the loop strictly reads from the database. A comment was added to `temporal.py` to explain why `.fetchall()` was retained there (because it modifies the database during iteration).
🎯 Why: Calling `.fetchall()` materializes the entire result set in memory as a Python list. Direct cursor iteration yields rows one by one, which significantly reduces the peak memory footprint, especially for large queries or queries containing large text blobs.
📊 Impact: Reduces memory overhead and peak allocation during batch metadata fetches, repository loading, and summarization retrieval.
🔬 Measurement: Verify by executing database operations on a very large repository and observing the peak RSS memory footprint. Tests and typing remain passing.

---
*PR created automatically by Jules for task [5115373071346685543](https://jules.google.com/task/5115373071346685543) started by @n24q02m*