### PR TITLE
fix: correct docs drift (tool count, semgrep rules, help topics, dead links)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 ## Cau truc
 
 - `src/better_code_review_graph/` -- Package chinh (src layout)
-  - `server.py` -- FastMCP server, 6 tools: graph + query + review (3 main) + config + security + help
+  - `server.py` -- FastMCP server, 7 tools: graph + query + review (3 main) + config + security + help + config__open_relay (mcp-core relay helper)
   - `tools.py` -- MCP tool implementations (build, query, impact, review, search, embed, stats, docs, large functions)
   - `parser.py` -- Tree-sitter parsing (13 langs) + call target resolution
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
@@ -51,7 +51,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 6 tools (graph + query + review + config + security + help)
+                                     FastMCP server --> 7 tools (graph + query + review + config + security + help + config__open_relay)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -59,7 +59,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud multi-provider (Jina > Gemini > OpenAI > Cohere, auto-detected from env vars). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 6 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config, security, help. Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config, security, help, config__open_relay (mcp-core relay helper). Returns JSON strings.
 
 ## Embedding backends
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 ## Cau truc
 
 - `src/better_code_review_graph/` -- Package chinh (src layout)
-  - `server.py` -- FastMCP server, 6 tools: graph + query + review (3 main) + config (incl. setup_*) + security + help
+  - `server.py` -- FastMCP server, 7 tools: graph + query + review (3 main) + config (incl. setup_*) + security + help + config__open_relay (mcp-core relay helper)
   - `tools.py` -- MCP tool implementations (build, query, impact, review, search, embed, stats, docs, large functions)
   - `parser.py` -- Tree-sitter parsing (13 langs) + call target resolution
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
@@ -53,7 +53,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 6 tools (graph + query + review + config + security + help)
+                                     FastMCP server --> 7 tools (graph + query + review + config + security + help + config__open_relay)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -61,7 +61,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud multi-provider (Jina > Gemini > OpenAI > Cohere, auto-detected from env vars). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 6 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help. Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help, config__open_relay (mcp-core relay helper). Returns JSON strings.
 
 ## Embedding backends
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,23 +56,20 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ### Types
 
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-- `ci`: CI/CD changes
+Only two commit types are accepted; the `commit-msg` hook
+(`scripts/enforce-commit.sh`) rejects anything else:
+
+- `feat`: New feature (or any user-facing change)
+- `fix`: Bug fix (or any other non-feature change)
+
+Do not use a `!` breaking-change marker. Communicate breaking changes
+in the PR description and commit body instead.
 
 ### Examples
 
 ```text
 feat: add Ruby language support
 fix: resolve multi-word search AND logic edge case
-docs: update embedding configuration guide
-feat!: refactor tools to 3-tier architecture
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ What you get on v2.0+:
 - **Security scanning** -- `security(action="scan", ...)` runs a
   regex-based Tier-1 scanner (5 rules) by default; pass
   `engine="semgrep"` (after `uv add 'better-code-review-graph[security]'`)
-  for the ~120-rule Tier-2 overlay. Findings persist on
+  for the Tier-2 engine, which runs Semgrep's `p/auto` registry pack
+  plus a 3-rule curated overlay. Findings persist on
   `nodes.security_tags`; `report` re-emits the cache as JSON or
   SARIF v2.1.0. See `help(topic="security")`.
 
@@ -125,7 +126,7 @@ graph(action="embed")
 | callers_of/callees_of | Empty results (bare name targets) | Qualified name resolution + bare fallback |
 | Embedding | sentence-transformers + torch (1.1 GB) | qwen3-embed ONNX + cloud (200 MB), dual-mode |
 | Output size | Unbounded (500K+ chars) | Paginated (max_results, truncated flag) |
-| Tool design | 9 individual tools | 6 tools: graph + query + review + config + security + help |
+| Tool design | 9 individual tools | 7 tools: graph + query + review + config + security + help + config__open_relay |
 | Plugin hooks | Invalid PostEdit/PostGit | Valid PostToolUse |
 
 ## Status
@@ -149,7 +150,7 @@ graph(action="embed")
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/better-code-review-graph/](https://mcp.n24q02m.com/servers/better-code-review-graph/)**:
+Full docs at **[mcp.n24q02m.com/servers/better-code-review-graph/setup/](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -218,9 +219,13 @@ Actions: `scan` | `report` | `suppress` | `rule_list`
 
 ### `help` -- Full documentation
 
-Topics: `graph` | `query` | `review` | `config` | `recipes`
+Topics: `graph` | `query` | `review` | `config` | `security` | `recipes`
 
 Returns complete documentation for each tool. Use when the compressed descriptions above are insufficient.
+
+### `config__open_relay` -- Re-trigger the relay setup form
+
+Registered automatically from `mcp-core`. In HTTP mode it returns `<PUBLIC_URL>/authorize` so the agent can re-open the browser setup form (e.g. after credential expiry); in stdio mode it returns `status: 'stdio_unsupported'`.
 
 ## Security
 
@@ -242,7 +247,7 @@ uv run better-code-review-graph
 
 ## Trust Model
 
-This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-Local** (machine-bound, single trust principal). See the [mcp-core trust model](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/src/better_code_review_graph/docs/recipes.md
+++ b/src/better_code_review_graph/docs/recipes.md
@@ -128,8 +128,9 @@ SARIF for CI ingest:
 {"tool": "security", "action": "report", "format": "sarif"}
 ```
 
-Tier 1 (heuristic, default) needs no extra deps. Tier 2 (Semgrep,
-~120 rules) is opt-in via `uv add 'better-code-review-graph[security]'`
+Tier 1 (heuristic, default) needs no extra deps. Tier 2 (Semgrep's
+`p/auto` registry pack + a 3-rule curated overlay) is opt-in via
+`uv add 'better-code-review-graph[security]'`
 and `engine="semgrep"`. Suppress noisy rules persistently with
 `security(action="suppress", rule_id=...)`. See `security.md` for the
 bundled ruleset, SARIF envelope shape, and the Semgrep install recipe.

--- a/src/better_code_review_graph/docs/security.md
+++ b/src/better_code_review_graph/docs/security.md
@@ -9,8 +9,9 @@ The `security` tool surfaces vulnerability findings on `Function` /
   dependencies; bundled rule files live under
   `better_code_review_graph_security_rules/heuristic/*.yaml`.
 - **Tier 2 (semgrep)** -- opt-in via the `[security]` extra; wraps
-  the [Semgrep](https://semgrep.dev/) CLI for ~120 curated rules
-  drawn from the project's overlay set.
+  the [Semgrep](https://semgrep.dev/) CLI. By default the scanner runs
+  Semgrep's `p/auto` registry pack (auto-selected community rules) plus
+  the bundled 3-rule curated overlay (`rules/semgrep/curated.yaml`).
 
 Findings are persisted to `nodes.security_tags` as a JSON array of
 `<rule_id>:<severity>` strings so subsequent queries (or the

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -1,6 +1,7 @@
 """MCP server entry point for Better Code Review Graph.
 
-5-tool architecture: graph + query + review (3 main) + config + help.
+7-tool architecture: graph + query + review (3 main) + config + security
++ help + config__open_relay (mcp-core relay helper).
 Run as: better-code-review-graph serve
 """
 
@@ -81,9 +82,10 @@ mcp = FastMCP(
     version=_pkg_version,
     instructions=(
         "Persistent incremental knowledge graph for token-efficient, "
-        "context-aware code reviews. 5 tools: graph (build/embed/stats), "
+        "context-aware code reviews. 7 tools: graph (build/embed/stats), "
         "query (search/impact/patterns), review (code review context), "
-        "config (status/set/setup_*), help (full docs)."
+        "config (status/set/setup_*), security (scan/report/rule_list), "
+        "help (full docs), config__open_relay (re-trigger relay form)."
     ),
 )
 
@@ -793,7 +795,7 @@ def _config_cache_clear(repo_root: str | None) -> str:
 @mcp.tool(
     description=(
         "Get full documentation for any tool. "
-        "Topics: graph | query | review | config. "
+        "Topics: graph | query | review | config | security | recipes. "
         "Use when compressed descriptions are insufficient."
     ),
     annotations=ToolAnnotations(
@@ -812,8 +814,9 @@ def help(topic: str = "graph") -> str:
     - query: Query operations (query, search, impact, large_functions)
     - review: Code review context generation
     - config: Server configuration (status, set, cache_clear)
+    - security: Security scanning (scan, report, suppress, rule_list)
     - recipes: Common operational recipes (#319) -- workflow patterns
-      that combine the 5 tools (freshness check, blast radius, scope
+      that combine the core tools (freshness check, blast radius, scope
       completeness, pre-merge review, etc.)
     """
     valid_topics = {
@@ -821,6 +824,7 @@ def help(topic: str = "graph") -> str:
         "query": "query.md",
         "review": "review.md",
         "config": "config.md",
+        "security": "security.md",
         "recipes": "recipes.md",
     }
     filename = valid_topics.get(topic)


### PR DESCRIPTION
Documentation/config drift fixes from a multi-repo docs audit. All findings verified against source/runtime before editing; no merge.

## Findings

1. **Semgrep rule count overstated** — Docs claimed "~120 rules". Verified: `SemgrepScanner` defaults to `config="p/auto"` (Semgrep registry meta-pack), and the only bundled overlay (`rules/semgrep/curated.yaml`) has exactly **3** explicit rules. Corrected README, `docs/security.md`, `docs/recipes.md` to describe it accurately (p/auto pack + 3-rule curated overlay).

2. **security.md unreachable via help tool** — `security.md` shipped in the docs package but was missing from the `help` tool's `valid_topics`, so `help(topic="security")` returned an error. Registered `security` -> `security.md` (the security tool exists and the doc is real). Verified end-to-end: `help(topic="security")` now returns the markdown doc, not an error payload. Also updated the help description/docstring.

3. **Tool-count drift (6/5 -> 7)** — Runtime `_list_tools()` returns 7: `graph, query, review, config, help, security, config__open_relay`. Updated README feature table, CLAUDE.md, AGENTS.md, server module docstring, and the FastMCP `instructions` string. Added a `config__open_relay` entry to the README tool-surface section.

4. **Dead links** — `mcp-core/docs/TRUST-MODEL.md` (404) repointed to `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (verified 200 via sitemap). Bare server-root docs link `/servers/better-code-review-graph/` (404 — all bare server-roots 404) repointed to the working `/setup/` leaf (verified 200). Confirmed no other bare-root/TRUST-MODEL refs remain.

5. **CONTRIBUTING.md commit-type list** — Listed docs/style/refactor/perf/test/chore/ci and a `feat!:` example, contradicting the enforced `commit-msg` hook (`scripts/enforce-commit.sh` accepts `feat:`/`fix:` only, plus bot `chore(release):`). Aligned the Types list to feat/fix only and removed the breaking-change marker example.

## Verification

- `uv run ruff check .` -> All checks passed
- `uv run ruff format --check .` -> 146 files already formatted
- `uv run ty check` -> All checks passed
- `scripts/preserve-diacritics.py` on all edited files -> exit 0
- `pytest` for help/server/semgrep/registration tests -> all pass
- `help(topic="security")` returns the doc (Finding 2 confirmed live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)