### PR TITLE
fix: add Comparison section to README capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ mcp-name: io.github.n24q02m/better-code-review-graph
 - [Status](#status)
 - [Documentation](#documentation)
 - [Tools](#tools)
+- [Comparison](#comparison)
 - [Security](#security)
 - [Build from Source](#build-from-source)
 - [Trust Model](#trust-model)
@@ -226,6 +227,23 @@ Returns complete documentation for each tool. Use when the compressed descriptio
 ### `config__open_relay` -- Re-trigger the relay setup form
 
 Registered automatically from `mcp-core`. In HTTP mode it returns `<PUBLIC_URL>/authorize` so the agent can re-open the browser setup form (e.g. after credential expiry); in stdio mode it returns `status: 'stdio_unsupported'`.
+
+## Comparison
+
+How better-code-review-graph stacks up against direct competitors in each pillar:
+
+| Capability | better-code-review-graph | Greptile | Sourcegraph (Cody / MCP) | CodeGraph (colbymchenry) |
+|---|---|---|---|---|
+| Codebase knowledge graph | Yes (Tree-sitter, 14 langs, SQLite) | Yes (functions/classes/deps) | Yes (precise code indexing) | Yes (Tree-sitter, 20+ langs, SQLite) |
+| Persistent incremental updates | Yes (git-diff + file-hash re-parse) | ? | Yes (continuous indexing) | Yes (OS file-watcher debounced) |
+| Qualified call resolution (callers/callees) | Yes (same-file bare-call resolution + fallback) | ? | Yes (go-to-def / find-references) | Yes (callers / callees / impact) |
+| Semantic search / embeddings | Yes (qwen3 ONNX local + cloud Jina/Gemini/OpenAI/Cohere) | ? | Yes (semantic + keyword + regex) | No (FTS5 full-text only) |
+| Token-optimized review context | Yes (`review` tool, git-diff scoped) | Yes (PR review comments) | No (code-context assistant) | No (context layer, not review) |
+| Security scanning | Yes (Semgrep `p/auto` + 3-rule overlay, SARIF) | ? | ? | No |
+| Self-hostable | Yes (stdio default, machine-bound) | Yes (Docker / K8s / air-gapped) | Yes (self-hosted instance) | Yes (100% local, no API keys) |
+| Free / open source | Yes (MIT) | No (proprietary SaaS; free OSS tier) | No (Enterprise license, source private) | Yes (MIT) |
+
+Sources: [Greptile](https://www.greptile.com/docs/introduction) · [Greptile pricing](https://www.greptile.com/pricing) · [Sourcegraph MCP](https://sourcegraph.com/mcp) · [CodeGraph](https://github.com/colbymchenry/codegraph). Cells marked `?` are capabilities the competitor does not publicly document, not confirmed absences.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Adds a Tier-1 house-style `## Comparison` section to the README, matching the capability-matrix format used by `wet-mcp` and `mnemo-mcp` (`vs <named real competitors>`). CRG previously lacked this section.

Placement follows sibling section order: inserted after `## Tools` (right after the `config__open_relay` subsection) and before `## Security`, with a matching `[Comparison](#comparison)` Table-of-contents entry.

## Competitors chosen (all verified real, genuinely comparable)

| Competitor | Why comparable | Source |
|---|---|---|
| **Greptile** | AI code reviewer built on a codebase graph (functions/classes/deps); ships an MCP server (v3) | https://www.greptile.com/docs/introduction , https://www.greptile.com/pricing |
| **Sourcegraph (Cody / MCP)** | Code graph with precise go-to-def / find-references + semantic search; exposes an MCP server; self-hostable | https://sourcegraph.com/mcp |
| **CodeGraph (colbymchenry/codegraph)** | Closest OSS architectural peer: local-first Tree-sitter + SQLite/FTS5 code knowledge graph MCP server with callers/callees/impact | https://github.com/colbymchenry/codegraph |

## Per-competitor verification notes

**Greptile** — Codebase graph: Yes (docs: "complete graph of your codebase - every function, class, and dependency"). PR review: Yes (posts PR comments). Self-host: Yes (Docker/K8s/air-gapped). Free/OSS: No — proprietary SaaS, $30/seat/mo; free tier only for qualifying OSS projects (MIT/Apache/GPL). Incremental updates, qualified-call resolution, embeddings, security scanning: not publicly documented -> marked `?`.

**Sourcegraph (Cody / MCP)** — Code graph: Yes (precise go-to-definition / find-references). Semantic search: Yes (semantic + keyword + regex). MCP server: Yes. Self-host: Yes (self-hosted/air-gapped instances). Token-optimized *PR review*: No — it is a code-context assistant, not a PR reviewer. Free/OSS: No — relicensed to non-OSS Sourcegraph Enterprise license (2023-06-13), source moved private (2024-08-22); Cody now Enterprise-only ($59/user/mo). Security scanning: not a documented feature -> `?`.

**CodeGraph (colbymchenry)** — Local-first OSS (MIT): Yes ("100% Local", no API keys). Incremental updates: Yes (native OS file-watcher with debounce). Callers/callees/impact: Yes. Embeddings/semantic search: No — FTS5 full-text only. Security scanning: No. Token-optimized review context: No — context layer, not a review tool. Tree-sitter + SQLite, 20+ langs.

**our (better-code-review-graph) cells** — derived only from this repo's README/CLAUDE.md/src: 7-tool surface (graph/query/review/config/security/help/config__open_relay), persistent incremental SQLite graph (git-diff + file-hash), qualified same-file call resolution, dual-mode embeddings (qwen3 ONNX local + cloud Jina/Gemini/OpenAI/Cohere), Semgrep `p/auto` + 3-rule overlay (SARIF v2.1.0), stdio/machine-bound self-host, MIT.

## Anti-fabrication

- Every competitor cell reflects publicly documented capability only; un-documented capabilities are marked `?` (explicitly noted as "not confirmed absences", not "No").
- No invented features or metrics.
- README is not linted (ruff/ty/pytest hooks target Python only); commit-msg conventional-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)