### PR TITLE
[FIX] Fix setup_status returning stale module-level state

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -565,19 +565,35 @@ async def config(
             from mcp_core.storage.per_plugin_store import PerPluginStore
 
             from . import credential_state as _cs
+            from .credential_state import resolve_credential_state
+
+            # Refresh module-level state so status is accurate and not stale.
+            resolve_credential_state()
 
             # Derive providers_configured from live PerPluginStore load + env
-            # so status is accurate even if module-level _state is stale.
+            # so status is accurate even if module-level _state was stale.
             _saved = PerPluginStore(_cs.PLUGIN_NAME).load() or {}
             _env_keys = [k for k in _cs.CLOUD_KEYS if os.environ.get(k)]
             _store_keys = [k for k in _cs.CLOUD_KEYS if _saved.get(k)]
             _providers = list(dict.fromkeys(_env_keys + _store_keys))
             if _providers:
                 _derived_state = "configured"
+                # Ensure module state matches derived state
+                if _cs.get_state() != _cs.CredentialState.CONFIGURED:
+                    _cs.set_state(_cs.CredentialState.CONFIGURED)
+                    # Load found keys into environment so they are actually usable
+                    for k in _cs.CLOUD_KEYS:
+                        _v = _saved.get(k)
+                        if _v and not os.environ.get(k):
+                            os.environ[k] = _v
             elif _cs.get_state() == _cs.CredentialState.LOCAL:
                 _derived_state = "local"
             else:
                 _derived_state = "awaiting_setup"
+                # Ensure module state matches derived state
+                if _cs.get_state() != _cs.CredentialState.AWAITING_SETUP:
+                    _cs.set_state(_cs.CredentialState.AWAITING_SETUP)
+
             return _json(
                 {
                     "state": _derived_state,

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.1"
+version = "3.17.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR fixes a bug where the `setup_status` action in the server returned an accurate derived state in its JSON response but failed to update the module-level `_state` in `credential_state.py`. This led to subsequent tool calls or internal checks seeing a stale credential state.

Changes:
- Imported and called `resolve_credential_state()` within the `setup_status` handler to refresh the global state.
- Explicitly synchronized the module-level state with the derived state calculated from the environment and `PerPluginStore`.
- Ensured that any credentials found in the store are applied to the process environment so they are immediately usable by other components.
- Verified the fix with a reproduction test ensuring `cs.get_state()` is updated correctly.

---
*PR created automatically by Jules for task [13054664406314472157](https://jules.google.com/task/13054664406314472157) started by @n24q02m*