### PR TITLE
[TEST] Missing tests for get_all_nodes

### DIFF
--- a/tests/test_graph_extra.py
+++ b/tests/test_graph_extra.py
@@ -317,6 +317,37 @@ class TestGraphStoreExtra:
         assert len(edges) == 2
         store.close()
 
+    def test_get_all_nodes(self, tmp_path):
+        store = GraphStore(str(tmp_path / "t.db"))
+        store.upsert_node(
+            NodeInfo(
+                kind="File",
+                name="/a.py",
+                file_path="/a.py",
+                line_start=1,
+                line_end=10,
+                language="python",
+            )
+        )
+        store.upsert_node(
+            NodeInfo(
+                kind="Function",
+                name="foo",
+                file_path="/a.py",
+                line_start=2,
+                line_end=5,
+                language="python",
+            )
+        )
+        store.commit()
+
+        nodes = store.get_all_nodes()
+        assert len(nodes) == 2
+        names = [n.name for n in nodes]
+        assert "/a.py" in names
+        assert "foo" in names
+        store.close()
+
     def test_get_edges_among_empty_set(self, tmp_path):
         store = GraphStore(str(tmp_path / "t.db"))
         assert store.get_edges_among(set()) == []

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.1"
+version = "3.17.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added unit test for `get_all_nodes` in `tests/test_graph_extra.py` to improve test coverage for `GraphStore`. The test verifies that all nodes upserted into the graph are correctly retrieved by the function.

---
*PR created automatically by Jules for task [4786087023841005236](https://jules.google.com/task/4786087023841005236) started by @n24q02m*