### PR TITLE
[CLEANUP] Unused Method: check_available

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -123,14 +123,6 @@ class EmbeddingBackend(Protocol):  # pragma: no cover
         """Embed a single text. Returns embedding vector."""
         ...
 
-    def check_available(self) -> int:
-        """Check if backend is available.
-
-        Returns:
-            Embedding dimensions if available, 0 if not.
-        """
-        ...
-
 
 # ---------------------------------------------------------------------------
 # Qwen3EmbedBackend (local ONNX)
@@ -204,17 +196,6 @@ class Qwen3EmbedBackend:
             kwargs["dim"] = dimensions
         result = list(model.query_embed(text, **kwargs))
         return result[0].tolist()
-
-    def check_available(self) -> int:
-        """Check if qwen3-embed is available."""
-        try:
-            model = self._get_model()
-            result = list(model.embed(["test"]))
-            if result:
-                return len(result[0])
-            return 0  # pragma: no cover
-        except Exception:
-            return 0
 
 
 # ---------------------------------------------------------------------------
@@ -443,16 +424,6 @@ class CloudEmbeddingBackend:
         """Embed a single text."""
         results = self.embed_texts([text], dimensions)
         return results[0]
-
-    def check_available(self) -> int:
-        """Check if the cloud model is available via test request."""
-        try:
-            embeddings = self._call_provider(["test"])
-            if embeddings:
-                return len(embeddings[0])
-            return 0  # pragma: no cover
-        except Exception:
-            return 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -17,7 +17,6 @@ import pytest
 from better_code_review_graph.embeddings import (
     CloudEmbeddingBackend,
     EmbeddingStore,
-    Qwen3EmbedBackend,
     _is_retryable,
 )
 from better_code_review_graph.graph import GraphNode, GraphStore
@@ -234,9 +233,7 @@ class TestSearchFallbackToEmbedSingle:
         """Cover line 636: fallback to embed_single when embed_single_query missing."""
         db = tmp_path / "graph.db"
         # Create a mock backend WITHOUT embed_single_query
-        mock_backend = MagicMock(
-            spec=["embed_texts", "embed_single", "check_available"]
-        )
+        mock_backend = MagicMock(spec=["embed_texts", "embed_single"])
         mock_backend.embed_texts.return_value = [[0.5] * 768]
         mock_backend.embed_single.return_value = [0.5] * 768
 
@@ -287,22 +284,6 @@ class TestProviderColumnMigration:
         columns = [row[1] for row in cursor.fetchall()]
         assert "provider" in columns
         store.close()
-
-
-# ---------------------------------------------------------------------------
-# embeddings.py: Qwen3 check_available failure (lines 216-217)
-# ---------------------------------------------------------------------------
-
-
-class TestQwen3CheckAvailableFailure:
-    def test_check_available_returns_zero_on_exception(self):
-        """Cover lines 216-217: check_available returns 0 on error."""
-        backend = Qwen3EmbedBackend(model_name="nonexistent/model")
-        with patch.object(
-            backend, "_get_model", side_effect=RuntimeError("model not found")
-        ):
-            dims = backend.check_available()
-            assert dims == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -238,11 +238,6 @@ class TestQwen3EmbedBackend:
         vectors = backend.embed_texts([])
         assert vectors == []
 
-    def test_check_available(self):
-        backend = Qwen3EmbedBackend()
-        dims = backend.check_available()
-        assert dims > 0
-
     def test_embed_single(self):
         backend = Qwen3EmbedBackend()
         vector = backend.embed_single("hello world", dimensions=768)
@@ -423,24 +418,6 @@ class TestCloudEmbeddingBackend:
             mock_client.embed.return_value = self._mock_cohere_response(["test"])
             vector = backend.embed_single("test", dimensions=768)
             assert len(vector) == 768
-
-    def test_check_available_success(self):
-        backend = CloudEmbeddingBackend(api_key="test-key")
-        with patch("cohere.ClientV2") as mock_cls:
-            mock_client = MagicMock()
-            mock_cls.return_value = mock_client
-            mock_client.embed.return_value = self._mock_cohere_response(["test"])
-            dims = backend.check_available()
-            assert dims == 768
-
-    def test_check_available_failure(self):
-        backend = CloudEmbeddingBackend(api_key="test-key")
-        with patch("cohere.ClientV2") as mock_cls:
-            mock_client = MagicMock()
-            mock_cls.return_value = mock_client
-            mock_client.embed.side_effect = Exception("connection error")
-            dims = backend.check_available()
-            assert dims == 0
 
     def test_retry_on_transient_error(self):
         backend = CloudEmbeddingBackend(api_key="test-key")

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.1"
+version = "3.17.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Removed the unused `check_available` method from `EmbeddingBackend`, `Qwen3EmbedBackend`, and `CloudEmbeddingBackend` as it was dead code. 

Also performed the following cleanup in the test suite:
- Removed `test_check_available`, `test_check_available_success`, and `test_check_available_failure` from `tests/test_embeddings.py`.
- Removed `TestQwen3CheckAvailableFailure` from `tests/test_coverage_gaps.py`.
- Updated mock specifications in `tests/test_coverage_gaps.py` to remove `check_available`.

Verified changes with `ruff check`, `ruff format`, and `ty check`. Ran existing tests (noting some timeouts in Qwen3 tests due to external rate limits which are unrelated to these changes).

---
*PR created automatically by Jules for task [6851699513764527991](https://jules.google.com/task/6851699513764527991) started by @n24q02m*