### PR TITLE
[FIX] N+1 Query in `_handle_importers_of`

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1038,15 +1038,24 @@ def _handle_imports_of(
 
 def _handle_importers_of(
     store: Any,
-    abs_target: str,
+    node: Any,
+    qn: str,
     results: list[dict],
     edges_out: list[dict],
     *,
     as_of: str = "",
 ) -> None:
-    for e in store.get_edges_by_target(
-        abs_target, kind="IMPORTS_FROM", as_of=as_of, fallback=False
-    ):
+    # Bolt: Use batched search to avoid N+1 queries when resolving importers (issue #342).
+    # We look for IMPORTS_FROM edges targeting either the qualified name or the node's QN.
+    search_targets = [qn]
+    if node and node.qualified_name and node.qualified_name != qn:
+        search_targets.append(node.qualified_name)
+
+    edges = store.search_edges_by_target_names(
+        search_targets, kind="IMPORTS_FROM", as_of=as_of
+    )
+
+    for e in edges:
         results.append({"importer": e.source_qualified, "file": e.file_path})
         edges_out.append(edge_to_dict(e))
 
@@ -1251,7 +1260,7 @@ def query_graph(
             )
         elif pattern == "importers_of":
             _handle_importers_of(
-                store, resolved_qn_or_path, results, edges_out, as_of=as_of
+                store, node, resolved_qn_or_path, results, edges_out, as_of=as_of
             )
         elif pattern == "children_of":
             _handle_children_of(store, resolved_qn_or_path, results, as_of=as_of)

--- a/tests/test_bare_suffix_correctness.py
+++ b/tests/test_bare_suffix_correctness.py
@@ -110,7 +110,7 @@ def test_importers_of_no_bare_fallback(store):
 
     results = []
     edges_out = []
-    _handle_importers_of(store, "app/a.py", results, edges_out)
+    _handle_importers_of(store, None, "app/a.py", results, edges_out)
 
     assert len(results) == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.1"
+version = "3.17.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `_handle_importers_of` function was previously using `store.get_edges_by_target` which could lead to N+1 queries if called repeatedly or if multiple targets were involved. This PR refactors it to use the batched `search_edges_by_target_names` method, similar to how `_handle_callers_of` is implemented.

Changes:
- Modified `_handle_importers_of` in `src/better_code_review_graph/tools.py` to accept `node` and use batched search.
- Updated `query_graph` in `src/better_code_review_graph/tools.py` to pass the `node` to `_handle_importers_of`.
- Updated `tests/test_bare_suffix_correctness.py` to match the new function signature.

---
*PR created automatically by Jules for task [7672738816126057485](https://jules.google.com/task/7672738816126057485) started by @n24q02m*