### PR TITLE
[CLEANUP] Unused Method: check_available

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -123,14 +123,6 @@ class EmbeddingBackend(Protocol):  # pragma: no cover
         """Embed a single text. Returns embedding vector."""
         ...
 
-    def check_available(self) -> int:
-        """Check if backend is available.
-
-        Returns:
-            Embedding dimensions if available, 0 if not.
-        """
-        ...
-
 
 # ---------------------------------------------------------------------------
 # Qwen3EmbedBackend (local ONNX)
@@ -204,17 +196,6 @@ class Qwen3EmbedBackend:
             kwargs["dim"] = dimensions
         result = list(model.query_embed(text, **kwargs))
         return result[0].tolist()
-
-    def check_available(self) -> int:
-        """Check if qwen3-embed is available."""
-        try:
-            model = self._get_model()
-            result = list(model.embed(["test"]))
-            if result:
-                return len(result[0])
-            return 0  # pragma: no cover
-        except Exception:
-            return 0
 
 
 # ---------------------------------------------------------------------------
@@ -443,16 +424,6 @@ class CloudEmbeddingBackend:
         """Embed a single text."""
         results = self.embed_texts([text], dimensions)
         return results[0]
-
-    def check_available(self) -> int:
-        """Check if the cloud model is available via test request."""
-        try:
-            embeddings = self._call_provider(["test"])
-            if embeddings:
-                return len(embeddings[0])
-            return 0  # pragma: no cover
-        except Exception:
-            return 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -17,7 +17,6 @@ import pytest
 from better_code_review_graph.embeddings import (
     CloudEmbeddingBackend,
     EmbeddingStore,
-    Qwen3EmbedBackend,
     _is_retryable,
 )
 from better_code_review_graph.graph import GraphNode, GraphStore
@@ -234,9 +233,7 @@ class TestSearchFallbackToEmbedSingle:
         """Cover line 636: fallback to embed_single when embed_single_query missing."""
         db = tmp_path / "graph.db"
         # Create a mock backend WITHOUT embed_single_query
-        mock_backend = MagicMock(
-            spec=["embed_texts", "embed_single", "check_available"]
-        )
+        mock_backend = MagicMock(spec=["embed_texts", "embed_single"])
         mock_backend.embed_texts.return_value = [[0.5] * 768]
         mock_backend.embed_single.return_value = [0.5] * 768
 
@@ -287,22 +284,6 @@ class TestProviderColumnMigration:
         columns = [row[1] for row in cursor.fetchall()]
         assert "provider" in columns
         store.close()
-
-
-# ---------------------------------------------------------------------------
-# embeddings.py: Qwen3 check_available failure (lines 216-217)
-# ---------------------------------------------------------------------------
-
-
-class TestQwen3CheckAvailableFailure:
-    def test_check_available_returns_zero_on_exception(self):
-        """Cover lines 216-217: check_available returns 0 on error."""
-        backend = Qwen3EmbedBackend(model_name="nonexistent/model")
-        with patch.object(
-            backend, "_get_model", side_effect=RuntimeError("model not found")
-        ):
-            dims = backend.check_available()
-            assert dims == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -224,11 +224,6 @@ class TestQwen3EmbedBackend:
         vectors = backend.embed_texts([])
         assert vectors == []
 
-    def test_check_available(self):
-        backend = Qwen3EmbedBackend()
-        dims = backend.check_available()
-        assert dims > 0
-
     def test_embed_single(self):
         backend = Qwen3EmbedBackend()
         vector = backend.embed_single("hello world", dimensions=768)


### PR DESCRIPTION
Removes the dead `check_available()` method from the embedding backends. It was declared on the `EmbeddingBackend` protocol and implemented on `Qwen3EmbedBackend` and `CloudEmbeddingBackend`, but has no caller anywhere in `src/` (verified via `git grep`). Removing it also lets us drop two tests that only exercised the dead method and a stale `MagicMock` spec entry + orphaned import.

This is a clean re-application of #674, which became un-mergeable after #670 restructured `test_embeddings.py`. Resolved by re-doing the change on current `main` rather than hand-merging the conflicted test file.

Changes:
- `embeddings.py`: remove 3 `check_available` definitions
- `test_embeddings.py`: remove `test_check_available` (also dropped a real HuggingFace download in CI)
- `test_coverage_gaps.py`: remove `TestQwen3CheckAvailableFailure`, drop `check_available` from a MagicMock spec, drop now-unused `Qwen3EmbedBackend` import

Local: ruff + ty + full pre-commit pytest gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)