### PR TITLE
[FIX] Flaky wall-clock N+1 performance assertion

### DIFF
--- a/tests/test_performance_n1.py
+++ b/tests/test_performance_n1.py
@@ -1,4 +1,3 @@
-import time
 from unittest.mock import patch
 
 from better_code_review_graph.graph import GraphStore
@@ -46,22 +45,38 @@ def test_query_graph_n1_performance(tmp_path):
         store = GraphStore(db_path)
         mock_get_store.return_value = (store, tmp_path)
 
-        # Test children_of logic
-        start = time.time()
-        result = query_graph(
-            "children_of", "parent.py::parent", repo_root=str(tmp_path)
-        )
-        elapsed = time.time() - start
+        # Count actual SQL statements executed while resolving children_of.
+        # This is the deterministic, runner-independent signal for an N+1
+        # regression: the batched implementation runs a small constant number
+        # of queries regardless of result size, whereas an N+1 reimplementation
+        # would issue one query per child (500+). Wall-clock timing was flaky
+        # on loaded CI runners (e.g. 0.6s for the non-N+1 path), so we assert
+        # on query count instead of elapsed seconds.
+        query_count = 0
+
+        def _count_queries(statement: str) -> None:
+            nonlocal query_count
+            query_count += 1
+
+        store._conn.set_trace_callback(_count_queries)
+        try:
+            result = query_graph(
+                "children_of", "parent.py::parent", repo_root=str(tmp_path)
+            )
+        finally:
+            # query_graph may close the underlying connection; resetting the
+            # trace callback then raises ProgrammingError, which we ignore.
+            try:
+                store._conn.set_trace_callback(None)
+            except Exception:
+                pass
 
         assert result["status"] == "ok"
         assert len(result["results"]) == 500
-        # Check that it returns fast (should take single digit ms locally, well under
-        # 0.5s for 500 nodes; bumped from 0.2s to tolerate CI runner jitter while
-        # still catching true N+1 regressions which would be seconds-scale).
-        assert elapsed < 0.5
+        # Bounded query count proves no per-child round-trip. A true N+1 would
+        # scale with the 500 children; the batched path stays well under 50.
+        assert query_count < 50
 
         # Verify result order matches the edges
         for i in range(500):
             assert result["results"][i]["name"] == f"child{i}"
-
-        store.close()


### PR DESCRIPTION
`tests/test_performance_n1.py::test_query_graph_n1_performance` asserted `elapsed < 0.5` seconds. This wall-clock threshold flaked on loaded CI runners — the windows-latest run for the #667 merge observed `0.637s` for the correct, batched (non-N+1) code path, failing the build even though no regression existed.

Root-cause fix: assert on the number of SQL statements executed (via `sqlite3.Connection.set_trace_callback`) instead of elapsed time. The batched `children_of` path runs a small constant number of queries (`< 50`) regardless of the 500-child result size; a true N+1 reimplementation would issue one query per child (500+). This preserves exactly what the test guards against while being deterministic and immune to runner jitter.

The trace-callback reset is guarded with try/except because `query_graph` closes the underlying connection internally before the test's teardown.

Local: ruff + ty + full pre-commit pytest gate green; the hardened test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)