### PR TITLE
🛡️ Sentinel: [HIGH] Fix Argument Injection in Semgrep Wrapper

### DIFF
--- a/src/better_code_review_graph/security/semgrep_engine.py
+++ b/src/better_code_review_graph/security/semgrep_engine.py
@@ -126,6 +126,10 @@ class SemgrepScanner:
                 "semgrep CLI not found on PATH. Install with: "
                 "uv add 'better-code-review-graph[security]'"
             )
+        if resolved.startswith("-"):
+            raise ValueError(
+                f"Semgrep executable cannot start with a hyphen: {resolved}"
+            )
         self._executable: str = resolved
         if require_python_module and not _semgrep_python_module_available():
             raise SemgrepNotAvailable(
@@ -160,8 +164,7 @@ class SemgrepScanner:
 
         cmd = [
             self._executable,
-            "--config",
-            self._config,
+            f"--config={self._config}",
             "--json",
             "--quiet",
             "--",

--- a/tests/test_semgrep_engine.py
+++ b/tests/test_semgrep_engine.py
@@ -314,7 +314,7 @@ def test_scan_path_returns_tags_on_findings(tmp_path):
     assert json.loads(result.raw_output) == payload
     cmd = run_mock.call_args[0][0]
     assert cmd[0] == "/fake/semgrep"
-    assert "--config" in cmd and "p/auto" in cmd
+    assert "--config=p/auto" in cmd
     assert "--json" in cmd
     assert str(target) in cmd
 
@@ -434,9 +434,7 @@ def test_scan_path_with_registry_config(tmp_path):
 
     cmd = run_mock.call_args[0][0]
     # Verify --config <config> is still correct
-    assert "--config" in cmd
-    idx = cmd.index("--config")
-    assert cmd[idx + 1] == "p/python"
+    assert "--config=p/python" in cmd
     # Verify -- is still before target
     assert "--" in cmd
     assert cmd.index("--") == cmd.index(str(target)) - 1

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.2b1"
+version = "3.17.2b2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixes argument injection vulnerability in the `SemgrepScanner` where the `executable` path was not validated for leading hyphens and the `--config` flag was separated from its value in the command array.

---
*PR created automatically by Jules for task [10487828506506934332](https://jules.google.com/task/10487828506506934332) started by @n24q02m*