### PR TITLE
feat: model-chain selection (crg)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "qwen3-embed>=1.10.0",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # litellm security floor (transitive via mcp-core[llm]). 1.83.x-1.87.x carry 4
     # advisories in litellm's PROXY server: GHSA-r75f-5x8p-qvmc (SQLi in proxy key
     # verify), GHSA-xqmj-j6mv-4862 (SSTI /prompts/test), GHSA-v4p8-mg3p-g94g (cmd-exec

--- a/server.json
+++ b/server.json
@@ -22,7 +22,19 @@
       },
       "environmentVariables": [
         {
-          "description": "Embedding backend override: 'local' (qwen3-embed ONNX) or 'cloud' ('litellm' is an accepted alias). Auto-detected from provider API keys if omitted.",
+          "description": "Ordered embedding model chain 'provider/model,...'; empty = local ONNX",
+          "isRequired": false,
+          "isSecret": false,
+          "name": "EMBEDDING_MODELS"
+        },
+        {
+          "description": "Ordered summarizer model chain; empty = summaries disabled",
+          "isRequired": false,
+          "isSecret": false,
+          "name": "SUMMARY_MODELS"
+        },
+        {
+          "description": "DEPRECATED (honored one release): embedding backend override 'local' or 'cloud'. Use EMBEDDING_MODELS instead.",
           "isRequired": false,
           "isSecret": false,
           "name": "EMBEDDING_BACKEND"
@@ -40,7 +52,7 @@
           "name": "LLM_API_BASE"
         },
         {
-          "description": "Override the summarizer model as a litellm 'provider/model' string (e.g. 'gemini/gemini-2.5-flash'). Defaults per detected provider when omitted.",
+          "description": "DEPRECATED (honored one release): single summarizer model as a litellm 'provider/model' string. Use SUMMARY_MODELS instead.",
           "isRequired": false,
           "isSecret": false,
           "name": "SUMMARY_MODEL"

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -5,13 +5,15 @@ Supports two backends:
   download on first use. Default backend.
 - **cloud**: Cloud embedding via ``mcp_core.llm`` (litellm passthrough).
   Supports Jina, Gemini, OpenAI, Cohere, or any litellm ``provider/model``.
-  Provider auto-detected from API key env vars with priority:
-  jina > gemini > openai > cohere.
+  Models come from the ``EMBEDDING_MODELS`` chain (ordered ``provider/model``
+  list, first entry is the active model).
 
-Backend selection (always returns a valid backend):
-1. Explicit EMBEDDING_BACKEND env var ('litellm' is an alias for 'cloud')
-2. 'cloud' if any provider API key is set
-3. 'local' (default, always available)
+Backend selection:
+- ``EMBEDDING_MODELS`` non-empty -> 'cloud' (first entry is the model).
+- Empty -> 'local' (default ONNX, always available).
+- Default chain keeps only models whose provider key is configured.
+- Legacy ``EMBEDDING_BACKEND`` / ``EMBEDDING_MODEL`` honored one release
+  (with a deprecation warning).
 
 All embeddings are stored at fixed 768 dimensions (MRL truncation).
 Switching backend does NOT invalidate existing vectors.
@@ -21,6 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import math
 import os
 import sqlite3
@@ -30,6 +33,8 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from .graph import GraphNode, GraphStore, node_to_dict
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -204,32 +209,43 @@ class Qwen3EmbedBackend:
 # ---------------------------------------------------------------------------
 
 
-# Priority-ordered mapping: first provider whose key is present in env wins.
-# Mirrors wet-mcp + mnemo-mcp _EMBEDDING_PROVIDERS (MCP config parity).
-_DEFAULT_CLOUD_MODELS: tuple[tuple[str, str], ...] = (
-    ("JINA_AI_API_KEY", "jina_ai/jina-embeddings-v5-text-small"),
-    ("GEMINI_API_KEY", "gemini/gemini-embedding-001"),
-    ("GOOGLE_API_KEY", "gemini/gemini-embedding-001"),
-    ("OPENAI_API_KEY", "text-embedding-3-large"),
-    ("COHERE_API_KEY", "embed-multilingual-v3.0"),
-    ("CO_API_KEY", "embed-multilingual-v3.0"),
+# Explicit provider prefixes -> unambiguous key detection + litellm routing.
+_DEFAULT_EMBEDDING_CHAIN = (
+    "jina_ai/jina-embeddings-v5-text-small",
+    "gemini/gemini-embedding-001",
+    "openai/text-embedding-3-large",
+    "cohere/embed-multilingual-v3.0",
 )
+_KEY_ALIASES = {"GEMINI_API_KEY": "GOOGLE_API_KEY", "COHERE_API_KEY": "CO_API_KEY"}
 
 
-def _auto_select_cloud_model() -> str:
-    """Pick the first cloud model whose API key is available in env.
+def _key_available(env_var: str) -> bool:
+    if os.getenv(env_var):
+        return True
+    alias = _KEY_ALIASES.get(env_var)
+    return bool(alias and os.getenv(alias))
 
-    Default is ``embed-multilingual-v3.0`` (Cohere) only when no cloud key is
-    set -- that keeps behaviour stable in pure-local mode where this value is
-    never used. When cloud keys are present, we must pick a model whose
-    provider key is non-empty; otherwise the provider SDK builds an empty
-    ``Bearer`` header and fails with ``LocalProtocolError`` before the
-    request leaves the machine.
+
+def resolve_embedding_chain() -> list[str]:
+    """Ordered embedding chain from EMBEDDING_MODELS (fallback order).
+
+    Empty -> local ONNX. Legacy EMBEDDING_MODEL honored one release (warning).
+    Default keeps ONLY models whose provider key is configured; none -> empty
+    -> local. Not "any key" (that would keep keyless cloud models).
     """
-    for env_var, model in _DEFAULT_CLOUD_MODELS:
-        if os.getenv(env_var):
-            return model
-    return "embed-multilingual-v3.0"
+    from mcp_core.llm.providers import key_env_for_model
+
+    explicit = os.getenv("EMBEDDING_MODELS", "").strip()
+    if explicit:
+        return [m.strip() for m in explicit.split(",") if m.strip()]
+    legacy = os.getenv("EMBEDDING_MODEL", "").strip()
+    if legacy:
+        logger.warning(
+            "Deprecated EMBEDDING_MODEL honored; migrate to EMBEDDING_MODELS "
+            "(removed next release)."
+        )
+        return [legacy]
+    return [m for m in _DEFAULT_EMBEDDING_CHAIN if _key_available(key_env_for_model(m))]
 
 
 class CloudEmbeddingBackend:
@@ -247,7 +263,10 @@ class CloudEmbeddingBackend:
         model: str | None = None,
         api_key: str | None = None,
     ):
-        self.model = model or os.getenv("EMBEDDING_MODEL") or _auto_select_cloud_model()
+        self.model = (
+            model
+            or (resolve_embedding_chain() or ["cohere/embed-multilingual-v3.0"])[0]
+        )
         self.api_key = api_key
         self._provider = _detect_embedding_provider(self.model)
 
@@ -386,31 +405,19 @@ class CloudEmbeddingBackend:
 
 
 def resolve_backend() -> str:
-    """Auto-detect backend from env vars.
+    """Resolve the embedding backend ('cloud' or 'local').
 
-    Priority:
-    1. Explicit EMBEDDING_BACKEND env var
-    2. 'cloud' if any provider API key is set
-    3. 'local' (default, always available)
+    Legacy ``EMBEDDING_BACKEND`` is honored one release (warning); otherwise
+    inferred from the resolved embedding chain: a non-empty chain -> 'cloud',
+    empty -> 'local'.
     """
-    explicit = os.getenv("EMBEDDING_BACKEND")
-    if explicit:
-        if explicit == "litellm":
-            return "cloud"
-        return explicit
-    if any(
-        os.getenv(k)
-        for k in (
-            "JINA_AI_API_KEY",
-            "GEMINI_API_KEY",
-            "GOOGLE_API_KEY",
-            "OPENAI_API_KEY",
-            "COHERE_API_KEY",
-            "CO_API_KEY",
+    legacy = os.getenv("EMBEDDING_BACKEND")
+    if legacy:
+        logger.warning(
+            "Deprecated EMBEDDING_BACKEND honored; inferred from EMBEDDING_MODELS now."
         )
-    ):
-        return "cloud"
-    return "local"
+        return "cloud" if legacy in ("cloud", "litellm") else legacy
+    return "cloud" if resolve_embedding_chain() else "local"
 
 
 def init_backend(mode: str | None = None) -> EmbeddingBackend:

--- a/src/better_code_review_graph/relay_schema.py
+++ b/src/better_code_review_graph/relay_schema.py
@@ -1,4 +1,9 @@
-"""Config schema for relay page setup.
+"""Config schema for relay page setup (model-chain widget).
+
+The relay form uses per-task ``model-chain`` widgets: the user picks an
+ordered list of ``provider/model`` strings per task (order = fallback). The
+relay page derives the required API-key fields from the providers referenced
+by the chosen models (``derived: True``) and renders them automatically.
 
 The literal `dict[str, Any]` type is intentional: this schema includes
 `description` and `capabilityInfo` fields that the relay page renders at
@@ -10,58 +15,89 @@ mcp-core catches up; see tracker: see docs/migration-from-mcp-relay-core.md.
 
 from typing import Any
 
+_EMBEDDING_SUGGESTED = [
+    "jina_ai/jina-embeddings-v5-text-small",
+    "gemini/gemini-embedding-001",
+    "openai/text-embedding-3-large",
+    "cohere/embed-multilingual-v3.0",
+]
+_SUMMARY_SUGGESTED = [
+    "gemini/gemini-2.5-flash",
+    "openai/gpt-4o-mini",
+]
+
+
+def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "type": "password",
+        "placeholder": ph,
+        "helpUrl": url,
+        "derived": True,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "better-code-review-graph",
     "displayName": "Code Review Graph",
-    "description": "Enter API keys for cloud embeddings. Leave all empty for local ONNX mode.",
+    "description": (
+        "Pick models per task (order = fallback). Leave embedding empty for "
+        "local ONNX; leave summary empty to disable LLM summaries. Key fields "
+        "appear automatically for the providers your models use."
+    ),
     "fields": [
         {
-            "key": "JINA_AI_API_KEY",
-            "label": "Jina AI API Key",
-            "type": "password",
-            "placeholder": "jina_...",
-            "helpUrl": "https://jina.ai/api-key",
-            "helpText": "Embedding + Reranking (highest priority for both).",
-            "required": False,
+            "key": "EMBEDDING_MODELS",
+            "label": "Embedding models",
+            "type": "model-chain",
+            "task": "embedding",
+            "suggestedModels": _EMBEDDING_SUGGESTED,
+            "hasLocal": True,
+            "placeholder": "add embedding model…",
         },
         {
-            "key": "GEMINI_API_KEY",
-            "label": "Gemini API Key",
-            "type": "password",
-            "placeholder": "AIza...",
-            "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "Embedding. Free tier available.",
-            "required": False,
+            "key": "SUMMARY_MODELS",
+            "label": "Summary models",
+            "type": "model-chain",
+            "task": "summary",
+            "suggestedModels": _SUMMARY_SUGGESTED,
+            "hasLocal": False,
+            "placeholder": "add summary model…",
         },
-        {
-            "key": "OPENAI_API_KEY",
-            "label": "OpenAI API Key",
-            "type": "password",
-            "placeholder": "sk-...",
-            "helpUrl": "https://platform.openai.com/api-keys",
-            "helpText": "Embedding.",
-            "required": False,
-        },
-        {
-            "key": "COHERE_API_KEY",
-            "label": "Cohere API Key",
-            "type": "password",
-            "placeholder": "co-...",
-            "helpUrl": "https://dashboard.cohere.com/api-keys",
-            "helpText": "Embedding + Reranking.",
-            "required": False,
-        },
+        _key_field(
+            "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
+        ),
+        _key_field(
+            "GEMINI_API_KEY",
+            "Gemini API Key",
+            "AIza...",
+            "https://aistudio.google.com/apikey",
+        ),
+        _key_field(
+            "OPENAI_API_KEY",
+            "OpenAI API Key",
+            "sk-...",
+            "https://platform.openai.com/api-keys",
+        ),
+        _key_field(
+            "COHERE_API_KEY",
+            "Cohere API Key",
+            "co-...",
+            "https://dashboard.cohere.com/api-keys",
+        ),
     ],
     "capabilityInfo": [
         {
             "label": "Embedding",
-            "priority": "Jina > Gemini > OpenAI > Cohere > Local ONNX",
-            "description": "Vector embeddings for code graph search. Local mode uses Qwen3-Embedding (0.6B ONNX).",
+            "priority": "configurable",
+            "description": "Vector embeddings for code graph search. Empty = local Qwen3-Embedding (0.6B ONNX).",
         },
         {
-            "label": "Reranking",
-            "priority": "Jina > Cohere > Local ONNX",
-            "description": "Re-ranks graph query results. Local mode uses Qwen3-Reranker (0.6B ONNX).",
+            "label": "Summary",
+            "priority": "configurable",
+            "description": "LLM docstring summaries for graph nodes. Empty = summaries disabled.",
         },
     ],
 }

--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -13,12 +13,13 @@ when persisting ``nodes.source_hash`` -- recomputing here is wasteful and
 also gives subtle "rehash drift" bugs if the caller passes a normalised
 form of the source).
 
-Provider priority: Gemini wins over OpenAI when both keys are set, and
-``GOOGLE_API_KEY`` is treated as a Gemini alias. This matches the
-embedding backend's Gemini-over-OpenAI sub-ordering in
-``embeddings.py`` (full embedding order: jina > gemini > openai >
-cohere). Jina + Cohere are intentionally excluded here because they
-don't expose chat-completion APIs.
+Model selection: the ``SUMMARY_MODELS`` chain (ordered ``provider/model``
+list, fallback order) drives which model runs; the first entry is the
+active model and its provider prefix is the cache tag. The default chain
+(Gemini then OpenAI) is key-gated — a model is kept only when its provider
+key is configured, with ``GOOGLE_API_KEY`` accepted as a ``GEMINI_API_KEY``
+alias. An empty chain disables summaries. Jina + Cohere are excluded from
+the default because they don't expose chat-completion APIs.
 
 LLM dispatch goes through ``mcp_core.llm.completion`` (litellm
 passthrough). The litellm import is deferred into ``summarize_node`` so
@@ -33,6 +34,8 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import Any
+
+from mcp_core.llm.providers import provider_of_model
 
 logger = logging.getLogger(__name__)
 
@@ -78,30 +81,40 @@ def compute_summary_cache_key(node: NodeNeedingSummary, provider: str) -> str:
     return f"{hash_value}:{provider}"
 
 
-def resolve_summary_provider() -> tuple[str, str] | None:
-    """Detect the active LLM summary provider from environment variables.
+# Default summary chain (fallback order). Key-gated: a model is kept only when
+# its provider key is configured. Explicit provider prefixes everywhere.
+_DEFAULT_SUMMARY_CHAIN = ("gemini/gemini-2.5-flash", "openai/gpt-4o-mini")
 
-    Returns ``(provider, api_key)`` tuple, or ``None`` if no provider key
-    is configured. Empty-string values are treated as "not set" so that
-    ``GEMINI_API_KEY=""`` does not yield a broken ``("gemini", "")``
-    tuple.
 
-    Priority:
-    1. ``GEMINI_API_KEY`` (Gemini, primary)
-    2. ``GOOGLE_API_KEY`` (Gemini, alias)
-    3. ``OPENAI_API_KEY`` (OpenAI)
+def resolve_summary_chain() -> list[str]:
+    """Ordered summary model chain from SUMMARY_MODELS (fallback order).
 
-    Mirrors the Gemini-over-OpenAI sub-ordering used by
-    ``embeddings.py``. Jina + Cohere are intentionally excluded because
-    those providers don't expose chat-completion APIs.
+    Empty -> summaries disabled. Legacy ``SUMMARY_MODEL`` honored one release
+    (warning). Default keeps ONLY models whose provider key is configured;
+    none -> empty -> disabled.
     """
-    gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if gemini_key:
-        return ("gemini", gemini_key)
-    openai_key = os.environ.get("OPENAI_API_KEY")
-    if openai_key:
-        return ("openai", openai_key)
-    return None
+    explicit = os.getenv("SUMMARY_MODELS", "").strip()
+    if explicit:
+        return [m.strip() for m in explicit.split(",") if m.strip()]
+    legacy = os.getenv("SUMMARY_MODEL", "").strip()
+    if legacy:
+        logger.warning(
+            "Deprecated SUMMARY_MODEL honored; migrate to SUMMARY_MODELS "
+            "(removed next release)."
+        )
+        return [legacy]
+    # Key-gated default: keep only models whose provider key is set
+    # (GOOGLE_API_KEY is an accepted alias for GEMINI_API_KEY).
+    from mcp_core.llm.providers import key_env_for_model
+
+    keyed = []
+    for m in _DEFAULT_SUMMARY_CHAIN:
+        env_var = key_env_for_model(m)
+        if os.getenv(env_var) or (
+            env_var == "GEMINI_API_KEY" and os.getenv("GOOGLE_API_KEY")
+        ):
+            keyed.append(m)
+    return keyed
 
 
 # ---------------------------------------------------------------------------
@@ -114,31 +127,12 @@ _PROMPT_PREFIX = (
     "Source:\n"
 )
 
-# Default litellm ``provider/model`` per summary provider. Overridable via the
-# ``SUMMARY_MODEL`` env var (used verbatim when set).
+# Default litellm ``provider/model`` per summary provider, used by the
+# ``summarize_node`` default-model path (provider label -> model).
 _DEFAULT_SUMMARY_MODELS: dict[str, str] = {
     "gemini": "gemini/gemini-2.5-flash",
     "openai": "gpt-4o-mini",
 }
-
-
-def _provider_from_model(model: str) -> str:
-    """Derive the cache-key provider tag from a litellm model string.
-
-    Used so a ``SUMMARY_MODEL`` override still produces a stable
-    ``{hash}:{provider}`` cache key. The provider prefix (text before the
-    first ``/``) is matched first; bare OpenAI-style names (e.g.
-    ``gpt-4o-mini``) default to ``openai``.
-    """
-    if "/" in model:
-        prefix = model.split("/", 1)[0].lower()
-        if prefix in ("gemini", "google"):
-            return "gemini"
-        if prefix == "openai":
-            return "openai"
-        return prefix
-    # Bare names with no provider prefix are OpenAI-style (e.g. gpt-4o-mini).
-    return "openai"
 
 
 def summarize_node(
@@ -164,9 +158,8 @@ def summarize_node(
     Args:
         node: NodeNeedingSummary with source_text to summarize.
         provider: lowercase provider label. In the default-model path it
-            selects the model and must be "gemini" or "openai" (matches
-            ``resolve_summary_provider()``); in the explicit-``model`` path
-            it is purely a label for error messages.
+            selects the model and must be "gemini" or "openai"; in the
+            explicit-``model`` path it is purely a label for error messages.
         api_key: API credential for the provider, or ``None`` to let
             litellm resolve the provider's key from the environment.
         model: optional explicit litellm ``provider/model`` override. When
@@ -273,8 +266,8 @@ def batch_summarize(
     if max_nodes < 1:
         raise ValueError(f"max_nodes must be >= 1, got {max_nodes}")
 
-    resolved = resolve_summary_provider()
-    if resolved is None:
+    chain = resolve_summary_chain()
+    if not chain:
         return BatchSummarizeResult(
             generated=0,
             cached=0,
@@ -282,22 +275,13 @@ def batch_summarize(
             provider=None,
             errors=0,
         )
-    provider, api_key = resolved
 
-    # SUMMARY_MODEL override: the model string carries litellm routing, so it
-    # may target a different provider than the env-resolved one. In that case
-    # (a) the cache tag is derived from the model prefix (so switching models
-    # invalidates stale summaries), and (b) the env-resolved api_key is dropped
-    # to None — it belongs to ``provider``, not the override's provider, and
-    # forwarding it would 401. ``api_key=None`` lets litellm resolve the
-    # correct key from the environment for the override's provider.
-    override_model = os.environ.get("SUMMARY_MODEL")
-    if override_model:
-        cache_provider = _provider_from_model(override_model)
-        effective_api_key: str | None = None
-    else:
-        cache_provider = provider
-        effective_api_key = api_key
+    # The chain carries explicit ``provider/model`` routing. Use the primary
+    # (first) model and derive the cache-key provider tag from its prefix so a
+    # model swap invalidates stale summaries. ``api_key=None`` lets litellm
+    # resolve the provider's key from the environment for the chosen model.
+    model = chain[0]
+    cache_provider = provider_of_model(model)
 
     rows = store._conn.execute(
         "SELECT id, source_text, source_hash, summary, summary_provider FROM nodes "
@@ -334,8 +318,8 @@ def batch_summarize(
                     source_hash=live_hash,
                 ),
                 provider=cache_provider,
-                api_key=effective_api_key,
-                model=override_model,
+                api_key=None,
+                model=model,
             )
         except Exception as exc:
             logger.warning("summarize_node failed for id=%d: %s", row_id, exc)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -20,6 +20,7 @@ from better_code_review_graph.embeddings import (
     embed_all_nodes,
     init_backend,
     resolve_backend,
+    resolve_embedding_chain,
     semantic_search,
 )
 from better_code_review_graph.graph import GraphNode, GraphStore
@@ -177,6 +178,145 @@ class TestResolveBackend:
     def test_default_local(self):
         with patch.dict(os.environ, {}, clear=True):
             assert resolve_backend() == "local"
+
+
+# ---------------------------------------------------------------------------
+# Embedding model chain (per-task model-chain redesign)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEmbeddingChain:
+    def test_explicit_models_from_env(self, monkeypatch):
+        monkeypatch.delenv("EMBEDDING_BACKEND", raising=False)
+        monkeypatch.setenv(
+            "EMBEDDING_MODELS",
+            "jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+        )
+        chain = resolve_embedding_chain()
+        assert chain == [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+        ]
+        assert resolve_backend() == "cloud"
+
+    def test_explicit_models_strip_and_skip_empties(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_MODELS", " openai/text-embedding-3-large , , ")
+        assert resolve_embedding_chain() == ["openai/text-embedding-3-large"]
+
+    def test_empty_no_keys_is_local(self, monkeypatch):
+        for k in (
+            "EMBEDDING_MODELS",
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        assert resolve_embedding_chain() == []
+        assert resolve_backend() == "local"
+
+    def test_default_chain_key_gated(self, monkeypatch):
+        """Default keeps only models whose provider key is configured."""
+        for k in (
+            "EMBEDDING_BACKEND",
+            "EMBEDDING_MODELS",
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Only the openai model survives key-gating.
+        assert resolve_embedding_chain() == ["openai/text-embedding-3-large"]
+        assert resolve_backend() == "cloud"
+
+    def test_default_chain_gemini_alias(self, monkeypatch):
+        """GOOGLE_API_KEY satisfies the gemini model's key requirement."""
+        for k in (
+            "EMBEDDING_MODELS",
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "g-test")
+        assert resolve_embedding_chain() == ["gemini/gemini-embedding-001"]
+
+    def test_default_chain_cohere_alias(self, monkeypatch):
+        """CO_API_KEY satisfies the cohere model's key requirement."""
+        for k in (
+            "EMBEDDING_MODELS",
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("CO_API_KEY", "co-test")
+        assert resolve_embedding_chain() == ["cohere/embed-multilingual-v3.0"]
+
+    def test_legacy_embedding_model_honored(self, monkeypatch):
+        for k in (
+            "EMBEDDING_BACKEND",
+            "EMBEDDING_MODELS",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("EMBEDDING_MODEL", "gemini/gemini-embedding-001")
+        assert resolve_embedding_chain() == ["gemini/gemini-embedding-001"]
+        assert resolve_backend() == "cloud"
+
+    def test_explicit_models_wins_over_legacy(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_MODELS", "openai/text-embedding-3-large")
+        monkeypatch.setenv("EMBEDDING_MODEL", "gemini/gemini-embedding-001")
+        assert resolve_embedding_chain() == ["openai/text-embedding-3-large"]
+
+    def test_legacy_backend_env_honored(self, monkeypatch):
+        for k in (
+            "EMBEDDING_MODELS",
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("EMBEDDING_BACKEND", "cloud")
+        assert resolve_backend() == "cloud"
+        monkeypatch.setenv("EMBEDDING_BACKEND", "litellm")
+        assert resolve_backend() == "cloud"
+        monkeypatch.setenv("EMBEDDING_BACKEND", "local")
+        assert resolve_backend() == "local"
+
+    def test_cloud_backend_uses_first_chain_model(self, monkeypatch):
+        for k in (
+            "EMBEDDING_MODEL",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "CO_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("EMBEDDING_MODELS", "gemini/gemini-embedding-001")
+        backend = CloudEmbeddingBackend()
+        assert backend.model == "gemini/gemini-embedding-001"
 
 
 class TestInitBackend:

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,8 +1,12 @@
-"""Tests for relay_schema module."""
+"""Tests for relay_schema module (model-chain widget)."""
 
 from __future__ import annotations
 
 from better_code_review_graph.relay_schema import RELAY_SCHEMA
+
+
+def _fields_by_key() -> dict:
+    return {f["key"]: f for f in RELAY_SCHEMA["fields"]}
 
 
 class TestRelaySchema:
@@ -12,6 +16,35 @@ class TestRelaySchema:
     def test_display_name(self):
         assert RELAY_SCHEMA["displayName"] == "Code Review Graph"
 
-    def test_has_fields(self):
-        fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 4
+    def test_model_chain_tasks_are_embedding_and_summary(self):
+        tasks = {
+            f["task"] for f in RELAY_SCHEMA["fields"] if f.get("type") == "model-chain"
+        }
+        assert tasks == {"embedding", "summary"}
+
+    def test_embedding_has_local_summary_does_not(self):
+        fields = _fields_by_key()
+        assert fields["EMBEDDING_MODELS"]["hasLocal"] is True
+        assert fields["SUMMARY_MODELS"]["hasLocal"] is False
+
+    def test_suggested_models_all_have_provider_prefix(self):
+        for f in RELAY_SCHEMA["fields"]:
+            if f.get("type") == "model-chain":
+                for model in f["suggestedModels"]:
+                    assert "/" in model, f"{model} missing provider prefix"
+
+    def test_derived_key_fields_present_and_marked(self):
+        fields = _fields_by_key()
+        for key in (
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            assert key in fields
+            assert fields[key]["derived"] is True
+
+    def test_no_priority_arrows_in_capability_info(self):
+        for cap in RELAY_SCHEMA["capabilityInfo"]:
+            assert ">" not in cap["priority"], cap
+            assert cap["priority"] == "configurable"

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -22,7 +22,7 @@ from better_code_review_graph.summarizer import (
     NodeNeedingSummary,
     compute_source_hash,
     compute_summary_cache_key,
-    resolve_summary_provider,
+    resolve_summary_chain,
     summarize_node,
 )
 
@@ -115,66 +115,65 @@ def test_cache_key_uses_precomputed_hash_when_provided():
 
 
 # ---------------------------------------------------------------------------
-# Provider resolution
+# Summary model chain (per-task model-chain redesign)
 # ---------------------------------------------------------------------------
 
 
 def _clear_provider_env(monkeypatch):
-    for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY"):
+    for key in (
+        "SUMMARY_MODELS",
+        "SUMMARY_MODEL",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
-def test_resolve_provider_prefers_gemini(monkeypatch):
+def test_summary_chain_from_env(monkeypatch):
+    monkeypatch.setenv("SUMMARY_MODELS", "gemini/gemini-2.5-flash,openai/gpt-4o-mini")
+    chain = resolve_summary_chain()
+    assert chain == ["gemini/gemini-2.5-flash", "openai/gpt-4o-mini"]
+
+
+def test_summary_chain_strips_and_skips_empties(monkeypatch):
+    monkeypatch.setenv("SUMMARY_MODELS", " openai/gpt-4o-mini , , ")
+    assert resolve_summary_chain() == ["openai/gpt-4o-mini"]
+
+
+def test_summary_chain_legacy_model_honored(monkeypatch):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("SUMMARY_MODEL", "openai/gpt-4o-mini")
+    assert resolve_summary_chain() == ["openai/gpt-4o-mini"]
+
+
+def test_summary_chain_explicit_wins_over_legacy(monkeypatch):
+    monkeypatch.setenv("SUMMARY_MODELS", "gemini/gemini-2.5-flash")
+    monkeypatch.setenv("SUMMARY_MODEL", "openai/gpt-4o-mini")
+    assert resolve_summary_chain() == ["gemini/gemini-2.5-flash"]
+
+
+def test_summary_chain_default_key_gated_gemini(monkeypatch):
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-
-    result = resolve_summary_provider()
-
-    assert result == ("gemini", "g-key")
+    assert resolve_summary_chain() == ["gemini/gemini-2.5-flash"]
 
 
-def test_resolve_provider_falls_back_to_openai(monkeypatch):
+def test_summary_chain_default_key_gated_google_alias(monkeypatch):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_API_KEY", "g-key")
+    assert resolve_summary_chain() == ["gemini/gemini-2.5-flash"]
+
+
+def test_summary_chain_default_key_gated_openai_only(monkeypatch):
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-
-    result = resolve_summary_provider()
-
-    assert result == ("openai", "o-key")
+    assert resolve_summary_chain() == ["openai/gpt-4o-mini"]
 
 
-def test_resolve_provider_handles_google_api_key_alias(monkeypatch):
+def test_summary_chain_default_empty_when_no_keys(monkeypatch):
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
-
-    result = resolve_summary_provider()
-
-    assert result == ("gemini", "google-key")
-
-
-def test_resolve_provider_returns_none_when_no_key(monkeypatch):
-    _clear_provider_env(monkeypatch)
-
-    result = resolve_summary_provider()
-
-    assert result is None
-
-
-def test_resolve_provider_empty_gemini_falls_through_to_google(monkeypatch):
-    """Empty GEMINI_API_KEY should fall through to GOOGLE_API_KEY (per docstring contract)."""
-    _clear_provider_env(monkeypatch)
-    monkeypatch.setenv("GEMINI_API_KEY", "")
-    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
-    assert resolve_summary_provider() == ("gemini", "google-key")
-
-
-def test_resolve_provider_all_empty_returns_none(monkeypatch):
-    """All env vars set to empty strings should be treated as unset."""
-    _clear_provider_env(monkeypatch)
-    monkeypatch.setenv("GEMINI_API_KEY", "")
-    monkeypatch.setenv("GOOGLE_API_KEY", "")
-    monkeypatch.setenv("OPENAI_API_KEY", "")
-    assert resolve_summary_provider() is None
+    assert resolve_summary_chain() == []
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +308,7 @@ def test_summarize_node_none_content_raises(monkeypatch):
 
 
 def test_summarize_node_provider_is_case_sensitive():
-    """provider arg must match the lowercase canonical form returned by resolve_summary_provider."""
+    """provider arg must match the lowercase canonical provider form (default-model path)."""
     node = NodeNeedingSummary(node_id="x", source_text="y", source_hash=None)
     with pytest.raises(ValueError, match="Unsupported provider: 'Gemini'"):
         summarize_node(node, provider="Gemini", api_key="k")
@@ -328,24 +327,6 @@ def test_summarize_node_handles_braces_in_source(monkeypatch):
     assert result == "Returns a dict."
     # Verify the source went verbatim into the prompt
     assert src in mock_completion.call_args.kwargs["messages"][0]["content"]
-
-
-# ---------------------------------------------------------------------------
-# _provider_from_model (cache-key provider derivation)
-# ---------------------------------------------------------------------------
-
-
-def test_provider_from_model_derives_prefix():
-    from better_code_review_graph.summarizer import _provider_from_model
-
-    assert _provider_from_model("gemini/gemini-2.5-flash") == "gemini"
-    assert _provider_from_model("google/gemini-pro") == "gemini"
-    assert _provider_from_model("openai/gpt-4o-mini") == "openai"
-    # Bare OpenAI-style name (no provider prefix) -> openai default.
-    assert _provider_from_model("gpt-4o-mini") == "openai"
-    # Unknown / non-canonical prefixes are passed through verbatim.
-    assert _provider_from_model("cohere/command-r") == "cohere"
-    assert _provider_from_model("anthropic/claude-haiku") == "anthropic"
 
 
 # ---------------------------------------------------------------------------
@@ -770,16 +751,17 @@ def test_batch_summarize_cache_provider_from_summary_model(tmp_path, monkeypatch
         store.close()
 
 
-def test_batch_summarize_no_override_forwards_env_key(monkeypatch, tmp_path):
-    """Without SUMMARY_MODEL, the env-resolved api_key + provider are forwarded.
+def test_batch_summarize_default_chain_passes_prefixed_model(monkeypatch, tmp_path):
+    """Default chain (key-gated) passes chain[0] as an explicit prefixed model.
 
-    Locks the non-override branch: api_key is the env key (not None) and no
-    explicit model override is passed (summarize_node picks the default).
+    api_key is always None (litellm resolves the provider's env key from the
+    model prefix) and the cache provider is derived from the model prefix.
     """
     from better_code_review_graph.graph import GraphStore
     from better_code_review_graph.parser import NodeInfo
     from better_code_review_graph.summarizer import batch_summarize
 
+    monkeypatch.delenv("SUMMARY_MODELS", raising=False)
     monkeypatch.delenv("SUMMARY_MODEL", raising=False)
     for k in ("GOOGLE_API_KEY", "OPENAI_API_KEY"):
         monkeypatch.delenv(k, raising=False)
@@ -811,9 +793,9 @@ def test_batch_summarize_no_override_forwards_env_key(monkeypatch, tmp_path):
         assert result.generated == 1
         assert result.provider == "gemini"
         call_kwargs = mock_sum.call_args.kwargs
-        assert call_kwargs["api_key"] == "g-key"
+        assert call_kwargs["api_key"] is None
         assert call_kwargs["provider"] == "gemini"
-        assert call_kwargs["model"] is None
+        assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
     finally:
         store.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.17.2b2"
+version = "3.18.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -195,7 +195,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.88.0" },
     { name = "mcp", specifier = ">=1.27.1,<2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b1"
+version = "1.18.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1176,9 +1176,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Phase 2 selection redesign. Inline `EMBEDDING_MODELS`/`SUMMARY_MODELS` chain resolvers (key-gated default), relay model-chain widget, server.json env, keep {hash}:{provider} cache-key + litellm>=1.88.0 floor. Pin mcp-core[llm]>=1.18.0b2. 1202 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)