### PR TITLE
fix: pin semgrep <1.162 in renovate to stop re-proposing the mcp-conflict bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,13 @@
       "allowedVersions": ">=10.0.0"
     },
     {
+      "description": "Pin semgrep <1.162 — semgrep >=1.162 pins mcp==1.23.3, which conflicts with the project's mcp floor and makes the [security] extra unresolvable (see pyproject.toml comment). Closed PR #684.",
+      "matchPackageNames": [
+        "semgrep"
+      ],
+      "allowedVersions": "<1.162"
+    },
+    {
       "description": "Pin Python runtime to 3.13.x",
       "matchPackageNames": [
         "python"


### PR DESCRIPTION
Durable fix for the recurring unmergeable semgrep bump (closed PR #684).

semgrep >=1.162 pins `mcp==1.23.3`, which conflicts with crg's mcp floor (`mcp>=1.27.1`) and makes the `[security]` extra unresolvable. pyproject.toml already caps `semgrep>=1.0,<1.162` with a comment, but Renovate kept proposing the bump anyway. This adds a renovate packageRule `allowedVersions: <1.162` for semgrep so Renovate stops re-opening the breaking PR until semgrep upstream relaxes its mcp pin.