### PR TITLE
fix: correct summarize docstring, embedding-only manifest, and 3-pillar desc

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,31 +3,43 @@
   "description": "Persistent incremental knowledge graph for token-efficient code reviews",
   "version": "3.18.0-beta.3",
   "userConfig": {
+    "EMBEDDING_MODELS": {
+      "type": "string",
+      "title": "Embedding model chain (optional)",
+      "description": "CSV 'provider/model,provider/model' (order = litellm fallback); provider inferred from prefix. Empty = local ONNX (qwen3-embed). Example: jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+      "required": false
+    },
+    "SUMMARY_MODELS": {
+      "type": "string",
+      "title": "Summarizer model chain (optional)",
+      "description": "CSV 'provider/model,...' for the graph summarize action; provider inferred from prefix. Empty = summaries disabled. Chat-completion providers only (gemini/openai). Example: gemini/gemini-3-flash-preview",
+      "required": false
+    },
     "JINA_AI_API_KEY": {
       "type": "string",
       "title": "Jina AI API key (optional)",
-      "description": "Optional cloud reranker. Without it, server uses local ONNX. https://jina.ai/api-dashboard/",
+      "description": "Enables jina_ai/ embedding models referenced in EMBEDDING_MODELS. Without any cloud key the server uses local ONNX. https://jina.ai/api-dashboard/",
       "sensitive": true,
       "required": false
     },
     "GEMINI_API_KEY": {
       "type": "string",
       "title": "Gemini API key (optional)",
-      "description": "Optional cloud embedding fallback. Free tier available. https://aistudio.google.com/apikey",
+      "description": "Enables gemini/ models referenced in EMBEDDING_MODELS / SUMMARY_MODELS. Free tier available. https://aistudio.google.com/apikey",
       "sensitive": true,
       "required": false
     },
     "OPENAI_API_KEY": {
       "type": "string",
       "title": "OpenAI API key (optional)",
-      "description": "Optional cloud embedding fallback. https://platform.openai.com/api-keys",
+      "description": "Enables openai/ models referenced in EMBEDDING_MODELS / SUMMARY_MODELS. https://platform.openai.com/api-keys",
       "sensitive": true,
       "required": false
     },
     "COHERE_API_KEY": {
       "type": "string",
       "title": "Cohere API key (optional)",
-      "description": "Optional cloud embedding + reranking fallback. https://dashboard.cohere.com/api-keys",
+      "description": "Enables cohere/ embedding models referenced in EMBEDDING_MODELS. https://dashboard.cohere.com/api-keys",
       "sensitive": true,
       "required": false
     }
@@ -47,6 +59,8 @@
       ],
       "env": {
         "MCP_TRANSPORT": "stdio",
+        "EMBEDDING_MODELS": "${user_config.EMBEDDING_MODELS}",
+        "SUMMARY_MODELS": "${user_config.SUMMARY_MODELS}",
         "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}",
         "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}",
         "OPENAI_API_KEY": "${user_config.OPENAI_API_KEY}",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-code-review-graph",
-  "description": "Knowledge graph for token-efficient code reviews with fixed search and configurable embeddings",
+  "description": "Knowledge graph for token-efficient code reviews with fixed search, configurable embeddings, and qualified call resolution",
   "repository": {
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -138,8 +138,9 @@ def graph(
         in graphml | json-ld | dot | cypher format. Writes to output_path when
         provided, otherwise returns payload inline.
     - summarize (-> max_nodes=500, repo_root): Generate LLM summaries for
-        Function nodes. Provider auto-detected from env (GEMINI_API_KEY >
-        GOOGLE_API_KEY > OPENAI_API_KEY); no-op when no provider configured.
+        Function nodes. Models come from the SUMMARY_MODELS chain (provider
+        inferred from the model prefix); when unset a key-gated default
+        (gemini or openai) is used. No-op when no provider key is configured.
         Cost-capped via max_nodes (default 500 LLM calls per invocation).
     """
     match action:


### PR DESCRIPTION
## Vấn đề (di sản priority-router + capability sai)
- `server.py` graph `summarize` docstring: mô tả "Provider auto-detected (GEMINI_API_KEY > GOOGLE_API_KEY > OPENAI_API_KEY)" — ship tới LLM client. Thực tế dùng `SUMMARY_MODELS` chain (verified `summarizer.py`).
- `.claude-plugin/plugin.json`: gọi JINA/COHERE là "reranker"/"reranking" — crg KHÔNG có reranker (verified: grep `rerank` src rỗng; chúng là embedding provider). Thiếu `EMBEDDING_MODELS`/`SUMMARY_MODELS` chain fields.
- `server.json` desc: thiếu pillar "qualified call resolution" (README/GitHub desc có 3-pillar).

## Fix
Sync docstring → SUMMARY_MODELS chain + key-gated default; plugin.json embedding-only + 2 chain field + env; server.json 3-pillar. Khớp CLAUDE.md (nguồn sạch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)