### PR TITLE
fix: filter vector search by provider + correct rerank metadata (BYO)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tree-sitter-language-pack>=0.13.0,<1",
     "networkx>=3.6.1,<4",
     "watchdog>=4.0.2,<6",
-    "qwen3-embed>=1.10.0",
+    "qwen3-embed>=1.12.0b1",
     "httpx",
     "pydantic-settings",
     "n24q02m-mcp-core[llm]>=1.18.0b2,<2",

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -615,8 +615,16 @@ class EmbeddingStore:
         if not self.backend:
             return []
 
-        # Count embeddings first
-        count = self._conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+        # Restrict the scan to the active provider. Vectors from different
+        # embedding models are not comparable, so mixing them in one cosine
+        # ranking silently corrupts results when the user switches providers.
+        provider_name = self._get_backend_name()
+
+        # Count embeddings for the active provider first
+        count = self._conn.execute(
+            "SELECT COUNT(*) FROM embeddings WHERE provider = ?",
+            (provider_name,),
+        ).fetchone()[0]
         if count == 0:
             return []
 
@@ -630,7 +638,10 @@ class EmbeddingStore:
         # Brute-force cosine similarity scan with precalculated query norm
         scored: list[tuple[str, float]] = []
         query_norm = math.hypot(*query_vec)
-        cursor = self._conn.execute("SELECT qualified_name, vector FROM embeddings")
+        cursor = self._conn.execute(
+            "SELECT qualified_name, vector FROM embeddings WHERE provider = ?",
+            (provider_name,),
+        )
         chunk_size = 500
         while True:
             rows = cursor.fetchmany(chunk_size)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -146,13 +146,15 @@ class TestSearchFallbackToEmbedSingle:
         """Cover line 636: fallback to embed_single when embed_single_query missing."""
         db = tmp_path / "graph.db"
         # Create a mock backend WITHOUT embed_single_query
-        mock_backend = MagicMock(spec=["embed_texts", "embed_single"])
+        mock_backend = MagicMock(spec=["name", "embed_texts", "embed_single"])
+        mock_backend.name = "mock"
         mock_backend.embed_texts.return_value = [[0.5] * 768]
         mock_backend.embed_single.return_value = [0.5] * 768
 
         store = EmbeddingStore(db, mock_backend)
 
-        # Directly insert into DB to skip the actual embedding
+        # Directly insert into DB to skip the actual embedding. Provider must
+        # match the active backend name so the row is in-scope for search().
         import struct
 
         blob = struct.pack(f"{768}f", *([0.5] * 768))

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from better_code_review_graph.embeddings import (
+    _DEFAULT_DIMS,
     CloudEmbeddingBackend,
     EmbeddingStore,
     Qwen3EmbedBackend,
@@ -686,6 +687,45 @@ class TestEmbeddingStore:
             assert row is not None
             vec = _decode_vector(row["vector"])
             assert len(vec) == 768
+        finally:
+            store.close()
+
+    def test_search_filters_by_active_provider(self, tmp_path):
+        """search() must only score rows of the active provider.
+
+        Switching embedding providers must NOT mix vectors from different
+        models in one cosine ranking. Rows stored under a different provider
+        than the active backend must be excluded from the scan.
+        """
+        db = tmp_path / "graph.db"
+        # No embed_single_query attr -> search() uses embed_single fallback.
+        backend = MagicMock(spec=["name", "embed_single", "embed_texts"])
+        backend.name = "cloud:openai:openai/text-embedding-3-large"
+        # Deterministic query vector so cosine is well-defined.
+        backend.embed_single.return_value = [1.0] * _DEFAULT_DIMS
+
+        store = EmbeddingStore(db, backend)
+        try:
+            # Two rows under DIFFERENT providers, identical vectors.
+            vec_blob = _encode_vector([1.0] * _DEFAULT_DIMS)
+            store._conn.execute(
+                "INSERT INTO embeddings "
+                "(qualified_name, vector, text_hash, provider) "
+                "VALUES (?, ?, ?, ?)",
+                ("active.py::keep", vec_blob, "h1", backend.name),
+            )
+            store._conn.execute(
+                "INSERT INTO embeddings "
+                "(qualified_name, vector, text_hash, provider) "
+                "VALUES (?, ?, ?, ?)",
+                ("other.py::drop", vec_blob, "h2", "cloud:cohere:cohere/embed-v3"),
+            )
+            store._conn.commit()
+
+            results = store.search("anything", limit=10)
+            names = [qn for qn, _score in results]
+            assert "active.py::keep" in names
+            assert "other.py::drop" not in names
         finally:
             store.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
-    { name = "qwen3-embed", specifier = ">=1.10.0" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
     { name = "semgrep", marker = "extra == 'security'", specifier = ">=1.0,<1.162" },
     { name = "tree-sitter", specifier = ">=0.25.2,<1" },
     { name = "tree-sitter-language-pack", specifier = ">=0.13.0,<1" },
@@ -1626,7 +1626,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.11.1"
+version = "1.12.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1637,9 +1637,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/0d/8877e7e9c19daae9c7b97cc5d18c706df02c22d73c2d11c880a72023daad/qwen3_embed-1.11.1.tar.gz", hash = "sha256:b86adf71b3fa158dbcd51b72db624352cb9a9b410de0c2e1b6d78144d7e8f256", size = 187826, upload-time = "2026-06-09T02:53:40.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/80/fbbd7adf445a547fd4119e58b2c352b8c921df2028727453aba81c57bd0b/qwen3_embed-1.12.0b1.tar.gz", hash = "sha256:b3949f6df0e634eba5c343b04a120699122eb0b1e840a78e9117c1f6804d8580", size = 203461, upload-time = "2026-06-12T11:19:37.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/4a/c46780c74524ac20be54c1ac68383e21453c5b229ce7b4bf38ed235061bb/qwen3_embed-1.11.1-py3-none-any.whl", hash = "sha256:9a459e62aef1d948ec5344aacdb19286c418454e91b3452822a4caf9ceb73dbd", size = 60923, upload-time = "2026-06-09T02:53:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b3/42c80b5789441061acb449eb743ae5762b7154e9c19f259ef851707fb231/qwen3_embed-1.12.0b1-py3-none-any.whl", hash = "sha256:c00fc1ef8070f1615e803926bbda4a3050bbfdcf9282c974b192591d554e6444", size = 64546, upload-time = "2026-06-12T11:19:36.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Spec B Part B (crg).

**B3 (bug — cross-provider mixing):** `EmbeddingStore.search()` selected ALL rows with no provider filter, so switching embedding providers mixed incompatible vector spaces in one cosine ranking (silent corruption). Added `WHERE provider = ?` (bound to the active `_get_backend_name()`, matching the insert-time value) to both the count and the scan. New test stores two providers and asserts only the active one is scored; a pre-existing coverage test that relied on the unfiltered behavior was given a matching provider name (intent preserved).

**B4 (docs drift):** plugin.json claimed Jina/Cohere provide "reranking" but crg has no reranker. Removed the false claim (kept "cloud embedding fallback").

Pin: `qwen3-embed>=1.12.0b1`. Gate green (1202 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)