### PR TITLE
fix: remove literal v<auto> placeholder from stabilization note

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ graph(action="embed")
 
 > **2026-05-02 -- Architecture stabilization update**
 >
-> Past months saw significant churn around credential handling and the daemon-bridge auto-spawn pattern. This caused multi-process races, browser tab spam, and inconsistent setup UX across plugins. **As of v<auto>, the architecture is stable**: 2 clean modes (stdio + HTTP), no daemon-bridge layer, no auto-spawn from stdio.
+> Past months saw significant churn around credential handling and the daemon-bridge auto-spawn pattern. This caused multi-process races, browser tab spam, and inconsistent setup UX across plugins. **The architecture is now stable**: 2 clean modes (stdio + HTTP), no daemon-bridge layer, no auto-spawn from stdio.
 >
-> Apologies for the instability period. If you encountered issues with prior versions, please update to v<auto>+ and follow the current [Setup guide](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/) -- most prior workarounds are no longer needed.
+> Apologies for the instability period. If you encountered issues with prior versions, please update to the latest release and follow the current [Setup guide](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/) -- most prior workarounds are no longer needed.
 >
 > **Related plugins from the same author**:
 > - [wet-mcp](https://github.com/n24q02m/wet-mcp) -- Web search + content extraction


### PR DESCRIPTION
`v<auto>` render literal trên public README (note stabilization 2026-05-02). Reworded bỏ tham chiếu version token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)