### PR TITLE
fix: sync README tagline to current capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/better-code-review-graph
 
-**Knowledge graph for token-efficient code reviews -- fixed search, configurable embeddings, qualified call resolution.**
+**Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase.**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/better-code-review-graph/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-code-review-graph/actions/workflows/ci.yml)


### PR DESCRIPTION
Sync the README tagline to the cleaned-up, jargon-free repo description (drop dated/internal jargon and brittle tool counts; frame by capability).