### PR TITLE
fix: config status hangs on Windows under stdio

### DIFF
--- a/migrations/versions/005_temporal_columns.py
+++ b/migrations/versions/005_temporal_columns.py
@@ -63,7 +63,6 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -95,6 +94,11 @@ depends_on: str | Sequence[str] | None = None
 # the test fixture's tmp_path ``.git``. Pinning to exactly 3 slashes
 # preserves the leading slash on POSIX absolute paths.
 _SQLITE_URL_RE = re.compile(r"^sqlite:///(?P<path>.+)$")
+
+# A git object name is 40 lower-hex chars (SHA-1) or 64 (SHA-256). Used to
+# tell a detached-HEAD raw SHA apart from a symbolic ``ref: ...`` line and
+# to validate the value read out of a loose / packed ref.
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$|^[0-9a-f]{64}$")
 
 # Sentinel SHA used when the migration cannot read a real HEAD:
 # 40 zeros is git's empty-tree marker and stable across hosts. The
@@ -171,40 +175,111 @@ def _find_repo_root(db_path: Path) -> Path:
     )
 
 
-def _read_head_sha(repo_root: Path) -> str:
-    """Run ``git rev-parse HEAD`` in ``repo_root`` and return the SHA.
+def _looks_like_sha(value: str) -> bool:
+    """True if ``value`` is a bare git object name (SHA-1 or SHA-256)."""
+    return bool(_SHA_RE.match(value))
 
-    Raises :class:`RuntimeError` with the actionable message on any
-    git failure (binary missing, repo corrupt, no commits yet). The
-    error spells out the same downgrade escape hatch as the no-git
-    branch so operators see one consistent recovery path.
+
+def _resolve_ref(gitdir: Path, commondir: Path, ref: str) -> str | None:
+    """Resolve a symbolic ref (e.g. ``refs/heads/main``) to a SHA.
+
+    Checks loose refs first (per-worktree ``gitdir`` then the shared
+    ``commondir``), then ``packed-refs`` in the common dir. Follows a
+    chained symref one hop. Returns ``None`` when the ref cannot be
+    resolved on disk.
     """
+    for base in (gitdir, commondir):
+        loose = base / ref
+        try:
+            if loose.is_file():
+                value = loose.read_text(encoding="utf-8").strip()
+                if value.startswith("ref:"):  # chained symbolic ref
+                    return _resolve_ref(gitdir, commondir, value[4:].strip())
+                if _looks_like_sha(value):
+                    return value
+        except OSError:
+            pass
+
+    packed = commondir / "packed-refs"
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=str(repo_root),
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
-        raise RuntimeError(
+        if packed.is_file():
+            for raw in packed.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith(("#", "^")):
+                    continue
+                sha, _, name = line.partition(" ")
+                if name.strip() == ref and _looks_like_sha(sha):
+                    return sha
+    except OSError:
+        pass
+    return None
+
+
+def _read_head_sha(repo_root: Path) -> str:
+    """Resolve the current HEAD commit SHA by reading git's on-disk refs.
+
+    Pure-Python: deliberately does NOT shell out to ``git rev-parse``.
+    Spawning a subprocess from inside the MCP stdio server's worker
+    thread stalls for tens of seconds on Windows (subprocess creation
+    under the asyncio Proactor event loop), so the first ``GraphStore``
+    construction — which runs this migration — would appear to hang.
+    Reading ``.git`` directly is both faster and free of that
+    interaction (and drops the hard dependency on a ``git`` binary at
+    migration time).
+
+    Handles the regular-clone, detached-HEAD, git-worktree and submodule
+    layouts (``.git`` as a directory or as a ``gitdir:`` pointer file)
+    plus both loose and packed refs. Raises :class:`RuntimeError` with
+    the same actionable message as the rest of the module on any failure
+    so the ``CRG_TEST_ALLOW_NO_GIT`` escape hatch keeps working.
+    """
+
+    def _fail(reason: str) -> RuntimeError:
+        return RuntimeError(
             "005_temporal_columns requires git in repo containing the graph "
             "DB. The migration backfills valid_from_sha with the current "
-            f"HEAD commit. `git rev-parse HEAD` failed in {repo_root}: "
-            f"{exc}. To skip migration, set CRG_DOWNGRADE_TO_1_X=1 to "
-            "restore the pre-2.0 backup."
-        ) from exc
-    sha = result.stdout.strip()
-    if not sha:
-        raise RuntimeError(
-            "005_temporal_columns requires git in repo containing the graph "
-            "DB. The migration backfills valid_from_sha with the current "
-            f"HEAD commit. `git rev-parse HEAD` returned empty output in "
-            f"{repo_root}. To skip migration, set CRG_DOWNGRADE_TO_1_X=1 "
-            "to restore the pre-2.0 backup."
+            f"HEAD commit. {reason} in {repo_root}. To skip migration, set "
+            "CRG_DOWNGRADE_TO_1_X=1 to restore the pre-2.0 backup."
         )
-    return sha
+
+    marker = repo_root / ".git"
+    try:
+        if marker.is_file():
+            # Worktree / submodule: ``.git`` is a text file ``gitdir: <path>``.
+            content = marker.read_text(encoding="utf-8").strip()
+            if not content.startswith("gitdir:"):
+                raise _fail(f"unrecognized .git file contents {content!r}")
+            gitdir = Path(content[len("gitdir:") :].strip())
+            if not gitdir.is_absolute():
+                gitdir = (repo_root / gitdir).resolve()
+        elif marker.is_dir():
+            gitdir = marker
+        else:
+            raise _fail("no .git found")
+
+        # Linked worktrees keep shared refs in the common dir; HEAD itself
+        # is per-worktree under ``gitdir``.
+        commondir_file = gitdir / "commondir"
+        if commondir_file.is_file():
+            cd = Path(commondir_file.read_text(encoding="utf-8").strip())
+            commondir = cd if cd.is_absolute() else (gitdir / cd).resolve()
+        else:
+            commondir = gitdir
+
+        head = (gitdir / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise _fail(f"could not read git HEAD ({exc})") from exc
+
+    if head.startswith("ref:"):
+        ref = head[len("ref:") :].strip()
+        sha = _resolve_ref(gitdir, commondir, ref)
+        if sha is None:
+            raise _fail(f"could not resolve HEAD ref {ref!r} (no commits yet?)")
+        return sha
+    # Detached HEAD: the file already holds the raw object name.
+    if _looks_like_sha(head):
+        return head
+    raise _fail(f"unrecognized HEAD contents {head!r}")
 
 
 def _resolve_head_sha() -> str:

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -17,7 +17,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from mcp_core.relay.tool_helpers import register_open_relay_tool
 
-from .embeddings import EmbeddingStore, init_backend, resolve_backend
+from .embeddings import EmbeddingStore, resolve_backend
 from .incremental import get_db_path
 from .tools import (
     build_or_update_graph,
@@ -698,8 +698,12 @@ def _config_status(repo_root: str | None) -> str:
         try:
             stats = store.get_stats()
             db_path = get_db_path(root)
-            backend = init_backend()
-            emb_store = EmbeddingStore(db_path, backend)
+            # Counting stored embeddings is a pure SQL op (SELECT COUNT(*)).
+            # Do NOT init_backend() here: constructing the local backend loads
+            # the qwen3-embed ONNX model, which can block/hang the status call
+            # on Windows under stdio. Open the store without a backend; the
+            # backend name is reported separately via resolve_backend().
+            emb_store = EmbeddingStore(db_path)
             try:
                 emb_count = emb_store.count()
             finally:
@@ -772,8 +776,9 @@ def _config_cache_clear(repo_root: str | None) -> str:
         store, root = _get_store(repo_root)
         try:
             db_path = get_db_path(root)
-            backend = init_backend()
-            emb_store = EmbeddingStore(db_path, backend)
+            # count() + clear() are pure SQL; no backend/model load needed
+            # (avoids blocking on the local ONNX model under Windows stdio).
+            emb_store = EmbeddingStore(db_path)
             try:
                 count_before = emb_store.count()
                 emb_store.clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -305,6 +305,37 @@ class TestConfigTool:
         assert "Unknown action 'models'" in result["error"]
         assert "models" not in result["valid_actions"]
 
+    async def test_status_does_not_load_embedding_model(self, tmp_path):
+        """config(status) must NOT init the embedding backend.
+
+        Constructing the local backend loads the qwen3-embed ONNX model, which
+        can block/hang the status call on Windows under stdio. embeddings_count
+        is a pure SQL COUNT(*), so no model is needed. Patch init_backend to
+        explode if it is ever called from the status path.
+        """
+        repo = _make_mini_repo(tmp_path)
+        with patch(
+            "better_code_review_graph.embeddings.init_backend",
+            side_effect=AssertionError("status must not init the embedding backend"),
+        ):
+            result = json.loads(await config(action="status", repo_root=str(repo)))
+        assert result["status"] == "ok"
+        assert "embeddings_count" in result
+        assert result["embedding_backend"] in ("local", "cloud")
+
+    async def test_cache_clear_does_not_load_embedding_model(self, tmp_path):
+        """config(cache_clear) only counts + deletes rows: no model load."""
+        repo = _make_mini_repo(tmp_path)
+        with patch(
+            "better_code_review_graph.embeddings.init_backend",
+            side_effect=AssertionError(
+                "cache_clear must not init the embedding backend"
+            ),
+        ):
+            result = json.loads(await config(action="cache_clear", repo_root=str(repo)))
+        assert result["status"] == "cache cleared"
+        assert "embeddings_removed" in result
+
     async def test_set_missing_key(self):
         result = json.loads(await config(action="set"))
         assert result["error"] == "key is required for set action"

--- a/tests/test_temporal_migration.py
+++ b/tests/test_temporal_migration.py
@@ -13,14 +13,15 @@ It also creates ``idx_nodes_temporal(valid_from_sha, valid_to_sha)``
 and the analogous ``idx_edges_temporal``.
 
 Because the column is NOT NULL but no compile-time default exists,
-the migration has to read the actual repo HEAD via ``git rev-parse
-HEAD`` and bake it into the DDL default. These tests verify both
-the happy path (real git fixture in tmp_path) and the no-git path
-(synthesized DB outside any repo → migration aborts with an actionable
-:class:`RuntimeError`).
+the migration has to read the actual repo HEAD (by reading git's
+on-disk refs — no ``git`` subprocess; see ``_read_head_sha``) and bake
+it into the DDL default. These tests verify both the happy path (real
+git fixture in tmp_path) and the no-git path (synthesized DB outside
+any repo → migration aborts with an actionable :class:`RuntimeError`).
 
-Test fixtures use real ``git init`` + ``git commit`` so the migration's
-subprocess.run path is exercised end-to-end.
+Test fixtures use real ``git init`` + ``git commit`` to produce a
+genuine ``.git`` directory; the migration then resolves HEAD straight
+from that directory's refs end-to-end.
 """
 
 from __future__ import annotations
@@ -557,29 +558,92 @@ def test_find_repo_root_detects_dot_git_file(tmp_path: Path) -> None:
     assert found == repo_root
 
 
-def test_read_head_sha_handles_empty_output(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Empty ``git rev-parse HEAD`` output → RuntimeError with downgrade hint."""
+def test_read_head_sha_loose_ref(tmp_path: Path) -> None:
+    """HEAD -> loose ref -> SHA (the regular-clone path)."""
     module = _load_migration_module()
+    git = tmp_path / ".git"
+    (git / "refs" / "heads").mkdir(parents=True)
+    sha = "a" * 40
+    (git / "HEAD").write_text("ref: refs/heads/main\n")
+    (git / "refs" / "heads" / "main").write_text(sha + "\n")
+    assert module._read_head_sha(tmp_path) == sha
 
-    class _Result:
-        stdout = ""
 
-    monkeypatch.setattr(module.subprocess, "run", lambda *_a, **_kw: _Result())
-    with pytest.raises(RuntimeError, match="returned empty"):
+def test_read_head_sha_detached(tmp_path: Path) -> None:
+    """A detached HEAD stores the raw object name directly in ``HEAD``."""
+    module = _load_migration_module()
+    git = tmp_path / ".git"
+    git.mkdir()
+    sha = "b" * 40
+    (git / "HEAD").write_text(sha + "\n")
+    assert module._read_head_sha(tmp_path) == sha
+
+
+def test_read_head_sha_packed_refs(tmp_path: Path) -> None:
+    """HEAD ref absent as a loose file but present in ``packed-refs``."""
+    module = _load_migration_module()
+    git = tmp_path / ".git"
+    git.mkdir()
+    sha = "c" * 40
+    (git / "HEAD").write_text("ref: refs/heads/main\n")
+    (git / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{sha} refs/heads/main\n"
+        f"^{'0' * 40}\n"  # peeled tag line — must be ignored
+    )
+    assert module._read_head_sha(tmp_path) == sha
+
+
+def test_read_head_sha_worktree_pointer(tmp_path: Path) -> None:
+    """A ``.git`` file ``gitdir:`` pointer (worktree) resolves via commondir."""
+    module = _load_migration_module()
+    # Common repo dir holds the shared refs.
+    common = tmp_path / "main" / ".git"
+    (common / "refs" / "heads").mkdir(parents=True)
+    sha = "d" * 40
+    (common / "refs" / "heads" / "feature").write_text(sha + "\n")
+    # Linked-worktree private gitdir: per-worktree HEAD + commondir pointer.
+    wt_gitdir = common / "worktrees" / "wt1"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/feature\n")
+    (wt_gitdir / "commondir").write_text("../..\n")  # -> common
+    # The worktree checkout dir with the ``.git`` text-file pointer.
+    repo_root = tmp_path / "wt"
+    repo_root.mkdir()
+    (repo_root / ".git").write_text(f"gitdir: {wt_gitdir}\n")
+    assert module._read_head_sha(repo_root) == sha
+
+
+def test_read_head_sha_unresolvable_ref(tmp_path: Path) -> None:
+    """HEAD points at a ref with no loose/packed entry (no commits yet)."""
+    module = _load_migration_module()
+    git = tmp_path / ".git"
+    git.mkdir()
+    (git / "HEAD").write_text("ref: refs/heads/main\n")
+    with pytest.raises(RuntimeError, match="could not resolve HEAD ref"):
         module._read_head_sha(tmp_path)
 
 
-def test_read_head_sha_wraps_subprocess_error(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """A subprocess failure is wrapped with the actionable downgrade message."""
+def test_read_head_sha_no_git(tmp_path: Path) -> None:
+    """No ``.git`` at the repo root → actionable RuntimeError."""
     module = _load_migration_module()
-
-    def _boom(*_a, **_kw):
-        raise FileNotFoundError("git not on PATH")
-
-    monkeypatch.setattr(module.subprocess, "run", _boom)
     with pytest.raises(RuntimeError, match="CRG_DOWNGRADE_TO_1_X"):
+        module._read_head_sha(tmp_path)
+
+
+def test_read_head_sha_unrecognized_head(tmp_path: Path) -> None:
+    """A HEAD file that is neither a ref nor a SHA → RuntimeError."""
+    module = _load_migration_module()
+    git = tmp_path / ".git"
+    git.mkdir()
+    (git / "HEAD").write_text("garbage contents\n")
+    with pytest.raises(RuntimeError, match="unrecognized HEAD"):
+        module._read_head_sha(tmp_path)
+
+
+def test_read_head_sha_bad_git_file(tmp_path: Path) -> None:
+    """A ``.git`` file without a ``gitdir:`` prefix → RuntimeError."""
+    module = _load_migration_module()
+    (tmp_path / ".git").write_text("not a gitdir pointer\n")
+    with pytest.raises(RuntimeError, match="unrecognized .git file"):
         module._read_head_sha(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b3"
+version = "3.18.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Problem

The first `GraphStore` construction in an MCP session runs the `005_temporal` alembic migration, which read the repo HEAD via a `git rev-parse HEAD` **subprocess**. Spawning a subprocess from inside the FastMCP **stdio** server's worker thread stalls for tens of seconds (>180s observed) on **Windows** under the asyncio Proactor event loop. So the first tool call to touch the graph — typically `config action=status` — appeared to hang. A second identical call returned in <1s once the DB was already at the alembic head.

## Root cause fix

Resolve HEAD by reading git's on-disk refs in **pure Python** (loose refs, `packed-refs`, detached HEAD, and the worktree/submodule `.git` pointer-file + `commondir` layout), dropping the subprocess entirely. Also removes the hard dependency on a `git` binary at migration time.

Secondary: `config status` / `config cache_clear` no longer construct the embedding backend just to count/clear stored vectors (pure SQL), avoiding a ~570MB qwen3-embed ONNX model load on a status check.

## Verification (protocol-test-primary)

Re-ran the **exact failing scenario** over the MCP stdio protocol:
- Cold `config status` now returns in **0.64s** (was **>180s timeout**).
- Full crg protocol scenario **12/13** (the single non-pass is the anyio stdio teardown artifact, after all real checks passed).
- Migration HEAD resolution covered by a pure-Python test battery (loose / packed / detached / worktree + failure paths).
- Full suite **1210 passed, 1 skipped**; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)