### PR TITLE
fix: local ONNX embed hangs on Windows under stdio

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -1033,6 +1033,23 @@ def serve_main(repo_root: str | None = None) -> None:
     global _default_repo_root
     _default_repo_root = repo_root
 
+    # Warm numpy's C-extension import on the MAIN thread before serving.
+    #
+    # The embedding backends import numpy lazily, inside a tool call. FastMCP
+    # runs each sync tool in an anyio worker thread while the asyncio event loop
+    # holds the GIL on the main thread. On Windows, the very first import of
+    # numpy's ``_multiarray_umath`` C extension from a non-main thread in that
+    # configuration deadlocks (the C-extension init waits on the main thread,
+    # which is parked in the Proactor loop), so the first local-ONNX
+    # ``graph embed`` would hang forever. Importing numpy here -- on the main
+    # thread, before the loop starts -- makes the later worker-thread import a
+    # no-op cache hit. Cheap (numpy is already a transitive dependency) and
+    # backend-agnostic (both local ONNX and the cloud vector paths touch numpy).
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        pass
+
     is_http = (
         "--http" in sys.argv
         or os.environ.get("MCP_TRANSPORT") == "http"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -503,3 +503,18 @@ class TestServeMain:
             serve_main(repo_root=None)
         assert server_module._default_repo_root is None
         mock_run.assert_called_once_with(transport="stdio")
+
+    @patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"})
+    def test_serve_main_survives_missing_numpy(self):
+        """The main-thread numpy warm-up is best-effort: a missing numpy must
+        not abort startup (the import is only there to dodge a worker-thread
+        C-extension import deadlock, not a hard requirement to serve)."""
+        import sys
+
+        import better_code_review_graph.server as server_module
+
+        # ``sys.modules[name] = None`` makes ``import name`` raise ImportError.
+        with patch.dict(sys.modules, {"numpy": None}):
+            with patch.object(server_module.mcp, "run") as mock_run:
+                serve_main(repo_root=None)
+        mock_run.assert_called_once_with(transport="stdio")


### PR DESCRIPTION
## Problem

The first `graph embed` in a local-backend session **hangs forever** on Windows under the stdio transport. A `faulthandler` thread dump pins the worker thread inside `import numpy` -- loading the `_multiarray_umath` C extension -- reached via the embedding backend's lazy `from qwen3_embed import ...` inside the tool call.

## Root cause

FastMCP runs each sync tool in an anyio worker thread while the asyncio Proactor event loop holds the GIL on the main thread. On Windows, the **first** import of numpy's C extension from a non-main thread in that configuration deadlocks (the extension init waits on the main thread, which is parked in the loop). onnxruntime and tree-sitter do **not** trip this; numpy does.

## Fix

Warm the `numpy` import on the **main thread** in `serve_main`, before the event loop starts. The later worker-thread import becomes a no-op cache hit. Cheap (numpy is already a transitive dependency), backend-agnostic, and best-effort (a missing numpy never aborts startup).

## Verification (protocol-test-primary)

Reproduced + fixed over the MCP stdio protocol (Windows):
- Cold `graph embed` (local ONNX): **~3.8s** (was an **unbounded hang**).
- Follow-up `query search` (semantic): **~2.9s**.
- Mechanism confirmed by faulthandler dump + a minimal main-thread-preimport experiment.
- Full suite **1211 passed, 1 skipped**; ruff + ty clean.

> Note: this pairs with a qwen3-embed fix (offline HF cache detection) that eliminates a needless network revision-check on every model load; both are needed for fast, reliable local embedding under stdio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)