### PR TITLE
fix: graph build slow on Windows under stdio (git subprocess stall)

### DIFF
--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -292,6 +292,9 @@ def backfill_commits_for_repo(
             text=True,
             check=False,
             timeout=_GIT_LOG_TIMEOUT_SECONDS,
+            # Detach stdin: an inherited stdio pipe stalls the output reader in
+            # the MCP server's worker thread on Windows. See incremental.py.
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.TimeoutExpired):
         return 0

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -137,6 +137,18 @@ def _is_binary(path: Path) -> bool:
 
 _GIT_TIMEOUT = 30  # seconds
 
+# Every git subprocess below passes ``stdin=subprocess.DEVNULL``.
+#
+# The git child must not inherit the parent's stdin handle. When the MCP server
+# runs over stdio, its own stdin is a pipe from the client, and FastMCP executes
+# each sync tool in an anyio worker thread (under the asyncio Proactor loop). On
+# Windows, a git child that inherits that stdin pipe keeps subprocess's
+# output-reader thread (``_communicate`` -> ``_readerthread``) from ever seeing
+# EOF, so ``communicate()`` blocks until ``_GIT_TIMEOUT`` -- turning an instant
+# ``git ls-files``/``git status`` into a 30 s stall per call (a full build that
+# makes several git calls then takes a minute+). Detaching stdin breaks the
+# inheritance and the reads return immediately.
+
 
 def _run_git(
     repo_root: Path, args: list[str]
@@ -152,6 +164,7 @@ def _run_git(
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
@@ -190,6 +203,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
@@ -219,6 +233,7 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         files = []
         for line in result.stdout.splitlines():
@@ -246,6 +261,7 @@ def get_all_tracked_files(repo_root: Path) -> list[str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         return [f.strip() for f in result.stdout.splitlines() if f.strip()]
     except (FileNotFoundError, subprocess.TimeoutExpired):

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1795,6 +1795,10 @@ def renamed_in_diff(
                     capture_output=True,
                     timeout=15,
                     check=False,
+                    # Detach stdin: an inherited stdio pipe stalls the output
+                    # reader in the MCP server's worker thread on Windows.
+                    # See incremental.py.
+                    stdin=subprocess.DEVNULL,
                 )
             except (OSError, subprocess.SubprocessError):
                 continue

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -14,6 +14,7 @@ from better_code_review_graph.incremental import (
     get_all_tracked_files,
     get_changed_files,
     get_db_path,
+    get_head_sha,
     get_staged_and_unstaged,
     incremental_update,
     incremental_update_from_hook,
@@ -188,6 +189,24 @@ class TestGitOperations:
         )
         result = get_all_tracked_files(tmp_path)
         assert result == ["a.py", "b.py", "c.go"]
+
+    @patch("better_code_review_graph.incremental.shutil.which", return_value="git")
+    @patch("better_code_review_graph.incremental.subprocess.run")
+    def test_git_calls_detach_stdin(self, mock_run, mock_which, tmp_path):
+        """Every git subprocess passes stdin=DEVNULL so an inherited stdio pipe
+        cannot stall the output reader inside the MCP worker thread on Windows."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        for invoke in (
+            lambda: get_changed_files(tmp_path),
+            lambda: get_staged_and_unstaged(tmp_path),
+            lambda: get_all_tracked_files(tmp_path),
+            lambda: get_head_sha(tmp_path),
+        ):
+            mock_run.reset_mock()
+            invoke()
+            assert mock_run.call_args.kwargs.get("stdin") is subprocess.DEVNULL, (
+                f"git call is missing stdin=DEVNULL: {mock_run.call_args}"
+            )
 
 
 class TestFullBuild:


### PR DESCRIPTION
## Problem

`graph build` took **~60s** for a 3-file repo on Windows under the stdio transport. A `faulthandler` thread dump pins the worker thread in:

```
get_all_tracked_files -> subprocess.run -> communicate -> _readerthread
```

The git child inherits the MCP server's **stdin pipe** (the client connection). On Windows that keeps subprocess's output-reader thread from ever seeing EOF, so each `communicate()` blocks until the 30s git timeout. A full build makes several git calls, so the stalls stack to a minute+.

## Fix

Pass `stdin=subprocess.DEVNULL` to every git subprocess so the child never inherits the stdio pipe. Covers:
- `incremental.py`: `rev-parse` / `diff` / `status --porcelain` / `ls-files` (5 calls)
- `federation.py`: commit backfill `git log --first-parent`
- `tools.py`: diff base-content `git show`

## Verification (protocol-test-primary)

Reproduced + fixed over the MCP stdio protocol (Windows), confirmed by a faulthandler thread dump:
- Cold `graph build`: **~1.1s** (was **~60.7s**).
- Follow-up `graph embed` + `query search`: ~4.7s / ~3.8s.
- Regression test asserts every git call passes `stdin=DEVNULL`.
- Full suite **1212 passed, 1 skipped**; ruff + ty clean.

> Third of three Windows-stdio fixes for local crg: #705 (config status migration git subprocess), #706 (numpy worker-thread import deadlock), and this (git subprocess stdin stall in build/incremental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)