### PR TITLE
fix: bump deps and stop Renovate raising the semgrep floor

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.release.outputs.tag }}
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uv build
       - name: Publish to PyPI
         run: uv publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Setup Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "mcp>=1.27.1,<2",
-    "fastmcp>=3.3.1,<4",
+    "mcp>=1.27.2,<2",
+    "fastmcp>=3.4.2,<4",
     "tree-sitter>=0.25.2,<1",
     "tree-sitter-language-pack>=0.13.0,<1",
     "networkx>=3.6.1,<4",
     "watchdog>=4.0.2,<6",
-    "qwen3-embed>=1.12.0b1",
+    "qwen3-embed>=1.12.0b2",
     "httpx",
     "pydantic-settings",
     "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
@@ -36,7 +36,7 @@ dependencies = [
     # but Dependency Review flags the package version. 1.88.0+ clears all four.
     # crg's optional semgrep extra otherwise pins the resolver to litellm 1.83.0; this
     # floor lifts it (semgrep resolves to 1.79.x, fine for a dev-only SAST tool).
-    "litellm>=1.88.0",
+    "litellm>=1.88.1",
     "Pygments>=2.20.0",
     "alembic>=1.18.4,<2",
     "defusedxml>=0.7.1",
@@ -60,9 +60,9 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov",
     "pytest-timeout",
-    "ruff>=0.15.14",
+    "ruff>=0.15.17",
     "syrupy",
-    "ty>=0.0.40",
+    "ty>=0.0.49",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/renovate.json
+++ b/renovate.json
@@ -71,11 +71,12 @@
       "allowedVersions": ">=10.0.0"
     },
     {
-      "description": "Pin semgrep <1.162 — semgrep >=1.162 pins mcp==1.23.3, which conflicts with the project's mcp floor and makes the [security] extra unresolvable (see pyproject.toml comment). Closed PR #684.",
+      "description": "Pin semgrep <1.162 — semgrep >=1.162 pins mcp==1.23.3, which conflicts with the project's mcp floor and makes the [security] extra unresolvable (see pyproject.toml comment). Closed PRs #684, #703. rangeStrategy:in-range-only stops the global bump strategy from raising the floor to 1.161.0 (which ALSO pins mcp==1.23.3) — only lock refreshes inside the existing >=1.0,<1.162 range are allowed.",
       "matchPackageNames": [
         "semgrep"
       ],
-      "allowedVersions": "<1.162"
+      "allowedVersions": "<1.162",
+      "rangeStrategy": "in-range-only"
     },
     {
       "description": "Pin Python runtime to 3.13.x",

--- a/uv.lock
+++ b/uv.lock
@@ -191,15 +191,15 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4,<2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
-    { name = "fastmcp", specifier = ">=3.3.1,<4" },
+    { name = "fastmcp", specifier = ">=3.4.2,<4" },
     { name = "httpx" },
-    { name = "litellm", specifier = ">=1.88.0" },
-    { name = "mcp", specifier = ">=1.27.1,<2" },
+    { name = "litellm", specifier = ">=1.88.1" },
+    { name = "mcp", specifier = ">=1.27.2,<2" },
     { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
-    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b2" },
     { name = "semgrep", marker = "extra == 'security'", specifier = ">=1.0,<1.162" },
     { name = "tree-sitter", specifier = ">=0.25.2,<1" },
     { name = "tree-sitter-language-pack", specifier = ">=0.13.0,<1" },
@@ -213,9 +213,9 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
-    { name = "ruff", specifier = ">=0.15.14" },
+    { name = "ruff", specifier = ">=0.15.17" },
     { name = "syrupy" },
-    { name = "ty", specifier = ">=0.0.40" },
+    { name = "ty", specifier = ">=0.0.49" },
 ]
 
 [[package]]


### PR DESCRIPTION
Recreates the genuine bumps from broken Renovate #703 (mcp 1.27.2, fastmcp 3.4.2, qwen3-embed 1.12.0b2, litellm 1.88.1, ruff 0.15.17, ty 0.0.49, setup-uv v8.2.0) **minus** the semgrep floor bump that made it unresolvable.

#703 bumped `semgrep>=1.0`→`>=1.161.0`; semgrep 1.161.0 pins `mcp==1.23.3`, so via the `[security]` extra that floor made `mcp>=1.27.2` unsatisfiable. main deliberately keeps `semgrep>=1.0,<1.162` to avoid this. Kept semgrep pinned; everything resolves (144 packages).

Stops the recurrence: added `rangeStrategy: in-range-only` to the semgrep Renovate rule so the global `bump` strategy never lifts the floor to 1.161.0 again.

Verified: uv lock resolves, full suite green, ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)