### PR TITLE
[SECURITY] Potential Command Injection in Semgrep Engine

### DIFF
--- a/src/better_code_review_graph/security/semgrep_engine.py
+++ b/src/better_code_review_graph/security/semgrep_engine.py
@@ -172,6 +172,7 @@ class SemgrepScanner:
         ]
         proc = subprocess.run(
             cmd,
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/tests/test_semgrep_engine.py
+++ b/tests/test_semgrep_engine.py
@@ -438,3 +438,16 @@ def test_scan_path_with_registry_config(tmp_path):
     # Verify -- is still before target
     assert "--" in cmd
     assert cmd.index("--") == cmd.index(str(target)) - 1
+
+
+def test_scan_path_uses_devnull_stdin(tmp_path):
+    target = tmp_path / "src.py"
+    target.write_text("print(1)")
+    scanner = SemgrepScanner(executable="/fake/semgrep")
+    with patch(
+        "better_code_review_graph.security.semgrep_engine.subprocess.run",
+        return_value=_mock_completed(0, stdout='{"results": []}'),
+    ) as run_mock:
+        scanner.scan_path(target)
+
+    assert run_mock.call_args.kwargs["stdin"] == subprocess.DEVNULL


### PR DESCRIPTION
The `SemgrepScanner.scan_path` method was calling `subprocess.run` without explicitly redirecting `stdin` to `DEVNULL`. While it was already using list-based arguments and the `--` separator to prevent argument injection for the target path, adding `stdin=subprocess.DEVNULL` is a standard security hardening measure in this codebase to prevent the subprocess from inheriting and potentially reading from the parent's standard input.

Additionally, I verified that:
1. `SemgrepScanner.__init__` already validates that `config` and `executable` do not start with a hyphen.
2. `SemgrepScanner.scan_path` already uses the `f"--config={self._config}"` format and the `--` separator before the target path.

These combined measures provide robust protection against command and argument injection.

---
*PR created automatically by Jules for task [8370935559125014008](https://jules.google.com/task/8370935559125014008) started by @n24q02m*