### PR TITLE
fix: correct relay/storage docs to match OAuth-form setup and PerPluginStore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `graph.py` -- SQLite GraphStore, search, impact radius, NetworkX cache
   - `incremental.py` -- Git integration, file watching, incremental updates
   - `embeddings.py` -- Dual-mode embedding: ONNX local (qwen3-embed) + cloud chain (`EMBEDDING_MODELS`) via litellm passthrough (`mcp_core.llm`)
-  - `relay_setup.py` -- Zero-config relay: create session, poll for config
+  - `relay_setup.py` -- `apply_config` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused)
   - `relay_schema.py` -- Relay form schema (embedding provider fields)
   - `docs/` -- Help tool documentation (graph.md, query.md, review.md, config.md, recipes.md, security.md)
   - `cli.py` -- CLI: starts MCP server (pure entry point)

--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -239,8 +239,9 @@ def save_credentials(
 ) -> dict | None:
     """Save credentials from OAuth form and apply to environment.
 
-    Single-user mode (default, ``PUBLIC_URL`` unset): writes to the shared
-    ``config.enc`` on the host -- one set of cloud API keys for one user.
+    Single-user mode (default, ``PUBLIC_URL`` unset): writes via
+    ``PerPluginStore`` to ``~/.better-code-review-graph-mcp/config.json``
+    (AES-GCM, machine-bound key) -- one set of cloud API keys for one user.
 
     Multi-user remote mode (``PUBLIC_URL`` set): scopes credentials by the
     per-authorize JWT ``sub`` from ``context``. Each user's keys land in

--- a/src/better_code_review_graph/relay_setup.py
+++ b/src/better_code_review_graph/relay_setup.py
@@ -2,7 +2,7 @@
 
 Resolution order (relay only when ALL local sources are empty):
 1. ENV VARS          -- User explicitly set (highest priority, skip everything)
-2. RELAY CONFIG      -- Saved from previous relay setup (~/.config/mcp/config.enc)
+2. RELAY CONFIG      -- Saved from previous setup (PerPluginStore, ~/.better-code-review-graph-mcp/config.json)
 3. RELAY SETUP       -- Interactive, ONLY when steps 1-2 are ALL empty (30s timeout)
 4. LOCAL MODE        -- Fallback (qwen3-embed ONNX)
 """


### PR DESCRIPTION
The architecture notes drifted from how setup and credential storage actually work.

## What was wrong

- The component list described `relay_setup.py` as "Zero-config relay: create session, poll for config". That refers to the legacy ECDH relay client (`ensure_config` -> `create_session`/`poll_for_result`), which has no live caller in the package -- it is only exercised by tests. The live setup UX is the OAuth-AS browser form served by the HTTP entry point at `<PUBLIC_URL>/authorize`; the only part of `relay_setup.py` used in production is the `apply_config` env-applier.
- `save_credentials` claimed single-user mode "writes to the shared `config.enc` on the host". The code calls `PerPluginStore(...).save(...)`, which writes `~/.better-code-review-graph-mcp/config.json` (AES-GCM, machine-bound key). This also contradicted the module header, which already states the migration away from the shared `config.enc`.
- The `ensure_config` resolution-order docstring pointed at `~/.config/mcp/config.enc` for saved config, but step 2 loads via `PerPluginStore`, i.e. `~/.better-code-review-graph-mcp/config.json`.

## Changes

- `CLAUDE.md`: describe `relay_setup.py` by its live role and flag the create-session/poll path as legacy/unused.
- `credential_state.save_credentials`: fix the single-user storage docstring.
- `relay_setup.py`: fix the saved-config path in the resolution-order docstring.

Docs/docstrings only -- no behavior change.