### PR TITLE
fix: stop embed tests downloading qwen3-embed model from HuggingFace in CI

### DIFF
--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -6,8 +6,10 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
+from better_code_review_graph.embeddings import _DEFAULT_DIMS
 from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.parser import EdgeInfo, NodeInfo
 from better_code_review_graph.tools import (
@@ -729,9 +731,20 @@ class TestListGraphStats:
 # ---------------------------------------------------------------------------
 
 
-def _mock_embed(texts, _dims=None):
-    """Return fake embeddings for testing without API keys."""
-    return [[0.1] * 128 for _ in texts]
+def _stub_local_model():
+    """Build a stub qwen3-embed model that returns deterministic vectors.
+
+    Mirrors the ``mock_qwen_inference`` fixture in test_embeddings.py so the
+    local-backend path runs without downloading the ONNX model from HuggingFace.
+    """
+    model = MagicMock()
+    model.embed.side_effect = lambda texts, **kwargs: [
+        np.full(kwargs.get("dim", _DEFAULT_DIMS), 0.1) for _ in texts
+    ]
+    model.query_embed.side_effect = lambda text, **kwargs: [
+        np.full(kwargs.get("dim", _DEFAULT_DIMS), 0.1)
+    ]
+    return model
 
 
 class TestEmbedGraph:
@@ -741,8 +754,8 @@ class TestEmbedGraph:
 
     def test_embed_graph(self, repo_with_graph):
         with patch(
-            "better_code_review_graph.embeddings.CloudEmbeddingBackend._call_provider",
-            side_effect=_mock_embed,
+            "better_code_review_graph.embeddings.Qwen3EmbedBackend._get_model",
+            return_value=_stub_local_model(),
         ):
             result = embed_graph(repo_root=str(repo_with_graph))
         assert result["status"] == "ok"
@@ -908,8 +921,8 @@ class TestSemanticSearchWithEmbeddings:
     def test_semantic_mode_when_embeddings_exist(self, repo_with_graph):
         """Embed first, then search should use semantic mode."""
         with patch(
-            "better_code_review_graph.embeddings.CloudEmbeddingBackend._call_provider",
-            side_effect=_mock_embed,
+            "better_code_review_graph.embeddings.Qwen3EmbedBackend._get_model",
+            return_value=_stub_local_model(),
         ):
             embed_result = embed_graph(repo_root=str(repo_with_graph))
             assert embed_result["status"] == "ok"
@@ -923,8 +936,8 @@ class TestSemanticSearchWithEmbeddings:
 
     def test_semantic_search_with_kind_filter_after_embed(self, repo_with_graph):
         with patch(
-            "better_code_review_graph.embeddings.CloudEmbeddingBackend._call_provider",
-            side_effect=_mock_embed,
+            "better_code_review_graph.embeddings.Qwen3EmbedBackend._get_model",
+            return_value=_stub_local_model(),
         ):
             embed_graph(repo_root=str(repo_with_graph))
             result = semantic_search_nodes(


### PR DESCRIPTION
## Problem

On `main` CI (`windows-latest`, *Run tests with coverage*) the build fails intermittently with:

```
Could not download model from HuggingFace ... 0 retries left
```

The stack trace bottoms out in `qwen3_embed.common.model_management._download_with_retries` — a test is downloading the ~570MB `n24q02m/Qwen3-Embedding-0.6B-ONNX` model from HuggingFace at test time, which is flaky over the network.

## Root cause

`tests/test_tools_full.py::TestEmbedGraph` and `::TestSemanticSearchWithEmbeddings` both:

1. Set `EMBEDDING_BACKEND=local` (via their `force_local_backend` fixture).
2. Patch `CloudEmbeddingBackend._call_provider`.

But with `EMBEDDING_BACKEND=local`, `resolve_backend()` returns `"local"` and `init_backend()` constructs **`Qwen3EmbedBackend`** (local ONNX) — `CloudEmbeddingBackend` is never instantiated. So the patch was a dead no-op, and `Qwen3EmbedBackend._get_model()` ran for real:

```
embed_graph -> embed_all_nodes -> EmbeddingStore.embed_nodes
  -> Qwen3EmbedBackend.embed_texts -> _get_model()
  -> qwen3_embed.TextEmbedding(...)  # real HuggingFace download
```

Reproduced locally by running the default selection with `HF_HUB_OFFLINE=1` (the model is not in cache): the first failing test was `test_tools_full.py::test_embed_graph` at the exact `model_management` path from the CI error.

## Fix

Patch the backend that is actually used — `Qwen3EmbedBackend._get_model` — to return a stub model yielding deterministic 768-dim vectors, mirroring the existing `mock_qwen_inference` fixture in `tests/test_embeddings.py` (the repo's established convention). The stub returns numpy arrays so the `.tolist()` contract in `embed_texts` / `embed_single_query` holds.

No test coverage is removed: the full `embed_graph -> store -> semantic_search_nodes` flow still runs, and every assertion (`status == "ok"`, `total_embeddings > 0`, `search_mode in (...)`) is preserved. Only the network download is replaced by a stub. No new network calls are added.

Surgical diff: one file, `tests/test_tools_full.py`.

## Verification (all run WITHOUT network)

- `uv run --no-sync ruff check .` -> All checks passed
- `uv run --no-sync ruff format --check .` -> already formatted
- `uv run --no-sync ty check` -> All checks passed
- `uv run --no-sync pytest -q` -> green
- `HF_HUB_OFFLINE=1 ... pytest -q` (forces any unmocked download to fail) -> green; confirms `test_tools_full.py` was the sole offender and no other default-selected test hits the network.