### PR TITLE
fix: route per-sub creds + model chains through request-scoped dispatch

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -234,6 +234,31 @@ def credentials_for_current_request() -> dict[str, str]:
     return read_for_sub(sub)
 
 
+def config_value_for_current_request(key: str) -> str | None:
+    """Return a single config value scoped to the current request.
+
+    HTTP multi-user mode (``_current_sub`` set by the ``auth_scope``
+    middleware): reads ``key`` from that user's per-sub bucket
+    (``<CRG_DATA_DIR>/subs/<sub>/config.json``) and NOTHING else, so one
+    user's API keys / model chain never reach another concurrent user's
+    request. Returns ``None`` if the sub has not configured that key.
+
+    Stdio / single-user HTTP / no-JWT contexts (``_current_sub`` is
+    ``None``): falls back to the process environment via ``os.environ.get``,
+    preserving the existing single-user ``apply_config`` -> env behavior.
+
+    This helper is the request-scoped read path that live dispatch
+    (embedding + summarizer chain/key resolution) MUST use instead of
+    reading ``os.environ`` directly: per-sub values flow request-scoped and
+    are never written to the process-global environment.
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return os.environ.get(key)
+    value = read_for_sub(sub).get(key)
+    return value if value else None
+
+
 def save_credentials(
     config: dict[str, str], context: dict[str, str] | None = None
 ) -> dict | None:

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -223,10 +223,17 @@ _KEY_ALIASES = {"GEMINI_API_KEY": "GOOGLE_API_KEY", "COHERE_API_KEY": "CO_API_KE
 
 
 def _key_available(env_var: str) -> bool:
-    if os.getenv(env_var):
+    """True if ``env_var`` (or its alias) is set for the current request.
+
+    Request-scoped: in HTTP multi-user mode reads the bound sub's per-sub
+    bucket; in stdio/single-user falls back to ``os.environ``.
+    """
+    from .credential_state import config_value_for_current_request
+
+    if config_value_for_current_request(env_var):
         return True
     alias = _KEY_ALIASES.get(env_var)
-    return bool(alias and os.getenv(alias))
+    return bool(alias and config_value_for_current_request(alias))
 
 
 def resolve_embedding_chain() -> list[str]:
@@ -235,13 +242,20 @@ def resolve_embedding_chain() -> list[str]:
     Empty -> local ONNX. Legacy EMBEDDING_MODEL honored one release (warning).
     Default keeps ONLY models whose provider key is configured; none -> empty
     -> local. Not "any key" (that would keep keyless cloud models).
+
+    Request-scoped: ``EMBEDDING_MODELS`` / ``EMBEDDING_MODEL`` come from the
+    bound JWT sub's per-sub bucket in HTTP multi-user mode, falling back to
+    ``os.environ`` in stdio/single-user mode. Per-sub model selection must
+    not leak across concurrent users.
     """
     from mcp_core.llm.providers import key_env_for_model
 
-    explicit = os.getenv("EMBEDDING_MODELS", "").strip()
+    from .credential_state import config_value_for_current_request
+
+    explicit = (config_value_for_current_request("EMBEDDING_MODELS") or "").strip()
     if explicit:
         return [m.strip() for m in explicit.split(",") if m.strip()]
-    legacy = os.getenv("EMBEDDING_MODEL", "").strip()
+    legacy = (config_value_for_current_request("EMBEDDING_MODEL") or "").strip()
     if legacy:
         logger.warning(
             "Deprecated EMBEDDING_MODEL honored; migrate to EMBEDDING_MODELS "
@@ -278,17 +292,33 @@ class CloudEmbeddingBackend:
         return f"cloud:{self._provider}:{self.model}"
 
     def _resolve_api_key(self) -> str:
-        """Resolve API key for the current provider."""
+        """Resolve API key for the current provider (request-scoped).
+
+        In HTTP multi-user mode the key comes from the bound JWT sub's
+        per-sub bucket; in stdio/single-user mode it falls back to
+        ``os.environ``. The per-sub key is read at dispatch time and never
+        written to the process-global environment, so one user's key cannot
+        leak to another concurrent user's embedding call.
+        """
         if self.api_key:
             return self.api_key
+        from .credential_state import config_value_for_current_request
+
+        def _cfg(*keys: str) -> str:
+            for key in keys:
+                value = config_value_for_current_request(key)
+                if value:
+                    return value
+            return ""
+
         if self._provider == "jina":
-            return os.getenv("JINA_AI_API_KEY") or ""
+            return _cfg("JINA_AI_API_KEY")
         if self._provider == "gemini":
-            return os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY") or ""
+            return _cfg("GEMINI_API_KEY", "GOOGLE_API_KEY")
         if self._provider == "openai":
-            return os.getenv("OPENAI_API_KEY") or ""
+            return _cfg("OPENAI_API_KEY")
         # cohere
-        return os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
+        return _cfg("COHERE_API_KEY", "CO_API_KEY")
 
     def _litellm_model(self) -> str:
         """Map crg's model naming to a litellm ``provider/model`` string."""

--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -92,11 +92,18 @@ def resolve_summary_chain() -> list[str]:
     Empty -> summaries disabled. Legacy ``SUMMARY_MODEL`` honored one release
     (warning). Default keeps ONLY models whose provider key is configured;
     none -> empty -> disabled.
+
+    Request-scoped: ``SUMMARY_MODELS`` / ``SUMMARY_MODEL`` and the default
+    chain's key-gate come from the bound JWT sub's per-sub bucket in HTTP
+    multi-user mode, falling back to ``os.environ`` in stdio/single-user
+    mode. Per-sub model selection must not leak across concurrent users.
     """
-    explicit = os.getenv("SUMMARY_MODELS", "").strip()
+    from .credential_state import config_value_for_current_request
+
+    explicit = (config_value_for_current_request("SUMMARY_MODELS") or "").strip()
     if explicit:
         return [m.strip() for m in explicit.split(",") if m.strip()]
-    legacy = os.getenv("SUMMARY_MODEL", "").strip()
+    legacy = (config_value_for_current_request("SUMMARY_MODEL") or "").strip()
     if legacy:
         logger.warning(
             "Deprecated SUMMARY_MODEL honored; migrate to SUMMARY_MODELS "
@@ -110,8 +117,9 @@ def resolve_summary_chain() -> list[str]:
     keyed = []
     for m in _DEFAULT_SUMMARY_CHAIN:
         env_var = key_env_for_model(m)
-        if os.getenv(env_var) or (
-            env_var == "GEMINI_API_KEY" and os.getenv("GOOGLE_API_KEY")
+        if config_value_for_current_request(env_var) or (
+            env_var == "GEMINI_API_KEY"
+            and config_value_for_current_request("GOOGLE_API_KEY")
         ):
             keyed.append(m)
     return keyed
@@ -278,10 +286,25 @@ def batch_summarize(
 
     # The chain carries explicit ``provider/model`` routing. Use the primary
     # (first) model and derive the cache-key provider tag from its prefix so a
-    # model swap invalidates stale summaries. ``api_key=None`` lets litellm
-    # resolve the provider's key from the environment for the chosen model.
+    # model swap invalidates stale summaries.
     model = chain[0]
     cache_provider = provider_of_model(model)
+
+    # Resolve the provider key request-scoped: in HTTP multi-user mode it
+    # comes from the bound JWT sub's per-sub bucket; in stdio/single-user mode
+    # ``config_value_for_current_request`` falls back to ``os.environ``. We
+    # pass it explicitly to ``summarize_node`` rather than letting litellm read
+    # the process environment, so one user's key never reaches another
+    # concurrent user's summary call. ``None`` (stdio, no key set) preserves
+    # litellm's env fallback for the single-user path.
+    from mcp_core.llm.providers import key_env_for_model
+
+    from .credential_state import config_value_for_current_request
+
+    key_env = key_env_for_model(model)
+    api_key = config_value_for_current_request(key_env)
+    if not api_key and key_env == "GEMINI_API_KEY":
+        api_key = config_value_for_current_request("GOOGLE_API_KEY")
 
     rows = store._conn.execute(
         "SELECT id, source_text, source_hash, summary, summary_provider FROM nodes "
@@ -318,7 +341,7 @@ def batch_summarize(
                     source_hash=live_hash,
                 ),
                 provider=cache_provider,
-                api_key=None,
+                api_key=api_key,
                 model=model,
             )
         except Exception as exc:

--- a/tests/test_multi_user_dispatch.py
+++ b/tests/test_multi_user_dispatch.py
@@ -1,0 +1,278 @@
+"""HTTP multi-user dispatch wiring: per-sub key + model chain reach litellm.
+
+The contextvar plumbing (``credentials_for_current_request`` / per-sub
+buckets) is exercised by ``test_multi_user.py``. This file closes the loop:
+it asserts the *live dispatch paths* (embedding + summarizer) actually
+consult the bound sub's bucket -- the per-sub API key AND the per-sub
+``EMBEDDING_MODELS`` / ``SUMMARY_MODELS`` chain must reach the (mocked)
+``mcp_core.llm`` call, and a second concurrent sub must be isolated.
+
+Regression guard for the multi-user leak: before this fix the resolvers
+read ``os.environ`` directly, so in HTTP multi-user mode every sub got the
+deployment-global env (or nothing) instead of their own per-sub config.
+
+CRITICAL INVARIANT: per-sub values flow request-scoped (read at dispatch
+time via the per-sub accessor) -- they are NEVER written to the
+process-global ``os.environ`` (that would leak one sub's secret to a
+concurrent request of another sub). The isolation assertions below fail
+loudly if a future change reintroduces an ``os.environ.setdefault`` leak.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from better_code_review_graph.credential_state import (
+    CLOUD_KEYS,
+    _current_sub,
+    store_for_sub,
+)
+from better_code_review_graph.embeddings import (
+    CloudEmbeddingBackend,
+    resolve_embedding_chain,
+)
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.summarizer import batch_summarize, resolve_summary_chain
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvar():
+    """Each test starts and ends with no active sub binding."""
+    token = _current_sub.set(None)
+    try:
+        yield
+    finally:
+        _current_sub.reset(token)
+
+
+@pytest.fixture
+def _clean_cloud_env(monkeypatch):
+    """Strip cloud keys + model chains so per-sub config is the only source."""
+    for key in (*CLOUD_KEYS, "EMBEDDING_MODELS", "SUMMARY_MODELS"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _embedding_response(n: int, dim: int = 768) -> MagicMock:
+    resp = MagicMock()
+    resp.data = [{"index": i, "embedding": [0.1] * dim} for i in range(n)]
+    return resp
+
+
+def _completion_response(text: str) -> MagicMock:
+    resp = MagicMock()
+    choice = MagicMock()
+    choice.message.content = text
+    resp.choices = [choice]
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# resolve_embedding_chain / resolve_summary_chain: per-sub vs env
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_chain_reads_per_sub_config(tmp_path, monkeypatch, _clean_cloud_env):
+    """When a sub is bound, EMBEDDING_MODELS comes from that sub's bucket."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {
+            "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+            "GEMINI_API_KEY": "gm-a",
+        },
+    )
+
+    _current_sub.set("sub-a")
+    assert resolve_embedding_chain() == ["gemini/gemini-embedding-001"]
+
+
+def test_embedding_chain_second_sub_isolated(tmp_path, monkeypatch, _clean_cloud_env):
+    """sub-b's chain is its own; sub-a's EMBEDDING_MODELS does not bleed in."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub("sub-a", {"EMBEDDING_MODELS": "gemini/gemini-embedding-001"})
+    store_for_sub("sub-b", {"EMBEDDING_MODELS": "openai/text-embedding-3-large"})
+
+    _current_sub.set("sub-b")
+    assert resolve_embedding_chain() == ["openai/text-embedding-3-large"]
+
+
+def test_summary_chain_reads_per_sub_config(tmp_path, monkeypatch, _clean_cloud_env):
+    """When a sub is bound, SUMMARY_MODELS comes from that sub's bucket."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {"SUMMARY_MODELS": "openai/gpt-4o-mini", "OPENAI_API_KEY": "sk-a"},
+    )
+
+    _current_sub.set("sub-a")
+    assert resolve_summary_chain() == ["openai/gpt-4o-mini"]
+
+
+def test_chain_falls_back_to_env_when_no_sub(monkeypatch, _clean_cloud_env):
+    """Stdio / single-user (sub is None): env is the source of truth."""
+    monkeypatch.setenv("EMBEDDING_MODELS", "openai/text-embedding-3-large")
+    monkeypatch.setenv("SUMMARY_MODELS", "gemini/gemini-2.5-flash")
+
+    assert _current_sub.get() is None
+    assert resolve_embedding_chain() == ["openai/text-embedding-3-large"]
+    assert resolve_summary_chain() == ["gemini/gemini-2.5-flash"]
+
+
+# ---------------------------------------------------------------------------
+# Embedding dispatch: per-sub key reaches the mocked litellm embedding call
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_dispatch_uses_per_sub_key(tmp_path, monkeypatch, _clean_cloud_env):
+    """The per-sub API key reaches mcp_core.llm.embedding; env stays clean."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {
+            "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+            "GEMINI_API_KEY": "gm-a",
+        },
+    )
+
+    _current_sub.set("sub-a")
+    backend = CloudEmbeddingBackend()
+    assert backend.model == "gemini/gemini-embedding-001"
+
+    with patch("mcp_core.llm.embedding") as mock_embed:
+        mock_embed.return_value = _embedding_response(1)
+        backend.embed_texts(["hello"], dimensions=768)
+
+    call_kwargs = mock_embed.call_args.kwargs
+    assert call_kwargs["model"] == "gemini/gemini-embedding-001"
+    assert call_kwargs["api_key"] == "gm-a"
+    # Per-sub key must NOT have leaked into the process environment.
+    assert os.environ.get("GEMINI_API_KEY") is None
+
+
+def test_embedding_dispatch_second_sub_isolated(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """A second sub gets its own key/model -- never sub-a's."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {"EMBEDDING_MODELS": "gemini/gemini-embedding-001", "GEMINI_API_KEY": "gm-a"},
+    )
+    store_for_sub(
+        "sub-b",
+        {
+            "EMBEDDING_MODELS": "openai/text-embedding-3-large",
+            "OPENAI_API_KEY": "sk-b",
+        },
+    )
+
+    _current_sub.set("sub-b")
+    backend = CloudEmbeddingBackend()
+    with patch("mcp_core.llm.embedding") as mock_embed:
+        mock_embed.return_value = _embedding_response(1)
+        backend.embed_texts(["hello"], dimensions=768)
+
+    call_kwargs = mock_embed.call_args.kwargs
+    assert call_kwargs["model"] == "openai/text-embedding-3-large"
+    assert call_kwargs["api_key"] == "sk-b"
+    # sub-a's key must NOT appear anywhere in sub-b's dispatch.
+    assert call_kwargs["api_key"] != "gm-a"
+    assert os.environ.get("OPENAI_API_KEY") is None
+    assert os.environ.get("GEMINI_API_KEY") is None
+
+
+# ---------------------------------------------------------------------------
+# Summarizer dispatch: per-sub key + chain reach the mocked completion call
+# ---------------------------------------------------------------------------
+
+
+def _seed_function_node(store: GraphStore) -> None:
+    store._conn.execute(
+        "INSERT INTO nodes (id, qualified_name, name, kind, file_path, "
+        "updated_at, source_text) VALUES (1, 'f.py::foo', 'foo', 'Function', "
+        "'f.py', 0.0, 'def foo():\n    return 1\n')"
+    )
+    store._conn.commit()
+
+
+def test_summarizer_dispatch_uses_per_sub_key(tmp_path, monkeypatch, _clean_cloud_env):
+    """batch_summarize sends the per-sub model + key to mcp_core.llm.completion."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {"SUMMARY_MODELS": "openai/gpt-4o-mini", "OPENAI_API_KEY": "sk-a"},
+    )
+
+    store = GraphStore(str(tmp_path / "graph_a.db"))
+    _seed_function_node(store)
+
+    _current_sub.set("sub-a")
+    with patch("mcp_core.llm.completion") as mock_completion:
+        mock_completion.return_value = _completion_response("does a thing")
+        result = batch_summarize(store)
+    store.close()
+
+    assert result.generated == 1
+    assert result.provider == "openai"
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/gpt-4o-mini"
+    assert call_kwargs["api_key"] == "sk-a"
+    assert os.environ.get("OPENAI_API_KEY") is None
+
+
+def test_summarizer_dispatch_per_sub_google_alias_key(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """A per-sub GOOGLE_API_KEY is accepted as the GEMINI_API_KEY alias."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-g",
+        {"SUMMARY_MODELS": "gemini/gemini-2.5-flash", "GOOGLE_API_KEY": "g-alias"},
+    )
+
+    store = GraphStore(str(tmp_path / "graph_g.db"))
+    _seed_function_node(store)
+
+    _current_sub.set("sub-g")
+    with patch("mcp_core.llm.completion") as mock_completion:
+        mock_completion.return_value = _completion_response("alias works")
+        result = batch_summarize(store)
+    store.close()
+
+    assert result.generated == 1
+    assert mock_completion.call_args.kwargs["api_key"] == "g-alias"
+
+
+def test_summarizer_dispatch_second_sub_isolated(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """sub-b's summary dispatch sees its own key/model, never sub-a's."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "sub-a",
+        {"SUMMARY_MODELS": "openai/gpt-4o-mini", "OPENAI_API_KEY": "sk-a"},
+    )
+    store_for_sub(
+        "sub-b",
+        {"SUMMARY_MODELS": "gemini/gemini-2.5-flash", "GEMINI_API_KEY": "gm-b"},
+    )
+
+    store = GraphStore(str(tmp_path / "graph_b.db"))
+    _seed_function_node(store)
+
+    _current_sub.set("sub-b")
+    with patch("mcp_core.llm.completion") as mock_completion:
+        mock_completion.return_value = _completion_response("does b thing")
+        result = batch_summarize(store)
+    store.close()
+
+    assert result.provider == "gemini"
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
+    assert call_kwargs["api_key"] == "gm-b"
+    assert call_kwargs["api_key"] != "sk-a"
+    assert os.environ.get("GEMINI_API_KEY") is None
+    assert os.environ.get("OPENAI_API_KEY") is None

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -754,8 +754,10 @@ def test_batch_summarize_cache_provider_from_summary_model(tmp_path, monkeypatch
 def test_batch_summarize_default_chain_passes_prefixed_model(monkeypatch, tmp_path):
     """Default chain (key-gated) passes chain[0] as an explicit prefixed model.
 
-    api_key is always None (litellm resolves the provider's env key from the
-    model prefix) and the cache provider is derived from the model prefix.
+    The provider key is resolved request-scoped and forwarded explicitly to
+    ``summarize_node`` (stdio path: from ``os.environ``; HTTP multi-user: from
+    the bound sub's bucket) so one user's key never reaches another concurrent
+    user's call. The cache provider is derived from the model prefix.
     """
     from better_code_review_graph.graph import GraphStore
     from better_code_review_graph.parser import NodeInfo
@@ -793,7 +795,9 @@ def test_batch_summarize_default_chain_passes_prefixed_model(monkeypatch, tmp_pa
         assert result.generated == 1
         assert result.provider == "gemini"
         call_kwargs = mock_sum.call_args.kwargs
-        assert call_kwargs["api_key"] is None
+        # Stdio path: GEMINI_API_KEY env value is resolved request-scoped and
+        # forwarded explicitly (was None pre-fix when litellm read env itself).
+        assert call_kwargs["api_key"] == "g-key"
         assert call_kwargs["provider"] == "gemini"
         assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
     finally:


### PR DESCRIPTION
## Problem

In HTTP multi-user mode (`PUBLIC_URL` set), the live embedding + summarizer dispatch read API keys and `EMBEDDING_MODELS`/`SUMMARY_MODELS` from `os.environ` directly. The per-sub config saved at `/authorize` (`<CRG_DATA_DIR>/subs/<sub>/config.json`) was persisted but **never reached the actual litellm call** — every authenticated sub got the deployment-global env (or nothing).

`credentials_for_current_request()` / `read_for_sub()` existed but were referenced only by their own module + tests, never by live dispatch:

- `embeddings.py` `resolve_embedding_chain()` / `_resolve_api_key()` read `os.getenv(...)`
- `summarizer.py` `resolve_summary_chain()` read `os.getenv("SUMMARY_MODELS")`; `batch_summarize` passed `api_key=None`

Result in multi-user: **both the per-sub key AND the per-sub model selection were dropped.**

## Fix

- Add `config_value_for_current_request(key)` in `credential_state.py`: when a JWT sub is bound (HTTP multi-user) it reads that sub's per-sub bucket **exclusively**; when sub is `None` (stdio / single-user) it falls back to `os.environ`.
- Route `resolve_embedding_chain()`, `resolve_summary_chain()`, `CloudEmbeddingBackend._resolve_api_key()`, `_key_available()`, and `batch_summarize`'s key resolution through it.
- `batch_summarize` now resolves the chosen model's provider key request-scoped and passes it **explicitly** to `summarize_node` (was `api_key=None`).

## Security invariant

Per-sub values flow **request-scoped** (read at dispatch time via the per-sub accessor) and are **never written to the process-global `os.environ`** — so one user's secret/chain cannot leak to a concurrent request of another sub. No `os.environ.setdefault`. Single-user / stdio behavior (`apply_config` -> env) is unchanged.

## Tests

New `tests/test_multi_user_dispatch.py` (9 tests) asserts the live dispatch paths:
- per-sub `EMBEDDING_MODELS` + key reach the mocked `mcp_core.llm.embedding` call
- per-sub `SUMMARY_MODELS` + key reach the mocked `mcp_core.llm.completion` call
- **a second sub is isolated** (never sees sub-a's key/chain) for both embedding and summarizer
- per-sub `GOOGLE_API_KEY` accepted as `GEMINI_API_KEY` alias
- env fallback when no sub bound (stdio)
- per-sub keys never leak into `os.environ`

Updated one existing summarizer test whose assertion encoded the old `api_key=None` implementation detail (stdio path now forwards the resolved env key explicitly — functionally equivalent, request-scoped).

## Verification

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 148 files formatted
- `uv run ty check` — passed
- Full suite: **1230 passed, 1 skipped**, total coverage **95.45%** (gate 95.0%); `summarizer.py` 100%

## Scope note

Kept strictly to cred/chain dispatch wiring so it does not collide with the separate F7 change (gate multi-user start + summarizer prefix).