### PR TITLE
fix: scope graph DB per JWT sub in HTTP multi-user mode

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -76,11 +76,31 @@ def find_project_root(start: Path | None = None) -> Path:
 def get_db_path(repo_root: Path) -> Path:
     """Determine the database path for a repository.
 
+    HTTP multi-user remote mode (a JWT ``sub`` is bound to the current
+    request by the ``auth_scope`` middleware): the graph DB is scoped to
+    that sub at ``<CRG_DATA_DIR>/subs/<sub>/graph.db`` so one user's
+    code-graph nodes/edges/summaries never reach another concurrent user
+    sharing the same deployment. ``repo_root`` is ignored in this mode --
+    the analyzed-repo directory is not a safe shared location for a
+    per-tenant database.
+
+    Stdio / single-user HTTP (no sub bound): the database lives inside the
+    analyzed repository at ``<repo_root>/.code-review-graph/graph.db``.
     Creates the ``.code-review-graph/`` directory and an inner ``.gitignore``
     (with ``*``) so generated files are never committed.  If a legacy
     ``.code-review-graph.db`` exists at the repo root the database is migrated
     into the new directory (WAL/SHM side-files are discarded).
+
+    Imported lazily to keep the module-load import graph (and the stdio
+    hot path) untouched; the per-sub value flows request-scoped and is
+    never written to the process-global environment.
     """
+    from .credential_state import db_path_for_sub, get_current_sub
+
+    sub = get_current_sub()
+    if sub is not None:
+        return db_path_for_sub(sub)
+
     crg_dir = repo_root / ".code-review-graph"
     new_db = crg_dir / "graph.db"
 

--- a/tests/test_per_sub_graph_db.py
+++ b/tests/test_per_sub_graph_db.py
@@ -1,0 +1,135 @@
+"""Per-JWT-sub graph DB isolation in HTTP multi-user mode.
+
+The credential + model-chain dispatch became per-sub in #741, but the
+graph DB itself was still resolved to ``<repo_root>/.code-review-graph/graph.db``
+regardless of the bound sub -- so every concurrent JWT sub in a single
+multi-user deployment shared ONE graph.db (user A could read user B's
+code-graph nodes/edges/summaries).
+
+These tests pin the contract that ``get_db_path``:
+
+* returns the per-sub path (``<CRG_DATA_DIR>/subs/<sub>/graph.db``) when a
+  JWT sub is bound (multi-user remote mode), distinct per sub; and
+* falls back to the repo-relative path when no sub is bound
+  (stdio / single-user HTTP), leaving that path byte-for-byte unchanged.
+
+They exercise the contextvar plumbing directly (no full HTTP boot), the
+same way ``test_multi_user.py`` does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from better_code_review_graph.credential_state import _current_sub
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.incremental import get_db_path
+from better_code_review_graph.parser import NodeInfo
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvar():
+    """Ensure each test starts with no active sub binding."""
+    token = _current_sub.set(None)
+    try:
+        yield
+    finally:
+        _current_sub.reset(token)
+
+
+def _node(name: str) -> NodeInfo:
+    return NodeInfo(
+        kind="Function",
+        name=name,
+        file_path="mod.py",
+        line_start=1,
+        line_end=2,
+        language="python",
+        parent_name=None,
+        params=None,
+        return_type=None,
+        modifiers=None,
+        is_test=False,
+    )
+
+
+def test_stdio_no_sub_uses_repo_relative_path(tmp_path, monkeypatch):
+    """No sub bound (stdio / single-user) -> ``<repo>/.code-review-graph/graph.db``."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    from better_code_review_graph.credential_state import set_current_sub
+
+    set_current_sub(None)
+    path = get_db_path(repo)
+    assert path == repo / ".code-review-graph" / "graph.db"
+
+
+def test_bound_sub_uses_per_sub_path(tmp_path, monkeypatch):
+    """A bound JWT sub -> ``<CRG_DATA_DIR>/subs/<sub>/graph.db`` (not repo-relative)."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    from better_code_review_graph.credential_state import (
+        db_path_for_sub,
+        set_current_sub,
+    )
+
+    set_current_sub("user-a")
+    path = get_db_path(repo)
+    assert path == db_path_for_sub("user-a")
+    # The analyzed-repo path must NOT be used for a bound sub.
+    assert path != repo / ".code-review-graph" / "graph.db"
+    assert "user-a" in str(path)
+
+
+def test_two_subs_get_distinct_db_paths(tmp_path, monkeypatch):
+    """Two different subs resolve to two different DB files."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    from better_code_review_graph.credential_state import set_current_sub
+
+    set_current_sub("user-a")
+    pa = get_db_path(repo)
+    set_current_sub("user-b")
+    pb = get_db_path(repo)
+
+    assert pa != pb
+    assert "user-a" in str(pa)
+    assert "user-b" in str(pb)
+
+
+def test_sub_b_query_does_not_see_sub_a_nodes(tmp_path, monkeypatch):
+    """End-to-end isolation: sub A's written node is invisible to sub B.
+
+    Opens the live store-open path (``get_db_path`` -> ``GraphStore``) once
+    per sub, mirroring how each per-tool-call request resolves its store,
+    and asserts the second sub's search returns nothing.
+    """
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    from better_code_review_graph.credential_state import set_current_sub
+
+    # sub A writes a node into its own graph DB.
+    set_current_sub("user-a")
+    store_a = GraphStore(get_db_path(repo))
+    try:
+        store_a.upsert_node(_node("secret_fn_of_a"))
+        store_a.commit()
+        assert store_a.search_nodes("secret_fn_of_a")
+    finally:
+        store_a.close()
+
+    # sub B opens its store the same way and must NOT see sub A's node.
+    set_current_sub("user-b")
+    store_b = GraphStore(get_db_path(repo))
+    try:
+        assert store_b.search_nodes("secret_fn_of_a") == []
+    finally:
+        store_b.close()


### PR DESCRIPTION
## Problem

In HTTP multi-user remote mode (`PUBLIC_URL` set) the graph DB path was resolved to `<repo_root>/.code-review-graph/graph.db` regardless of the bound JWT `sub`. Every concurrent `sub` on one deployment therefore shared a single `graph.db` — a data-isolation breach where user A could read user B's code-graph nodes, edges, and summaries.

#741 had already routed per-sub **credentials + model chains** through request-scoped dispatch, but the **graph DB itself** stayed shared. That left the deployment in an unsafe half-state: creds-isolated but DB-shared.

`db_path_for_sub(sub)` (→ `<CRG_DATA_DIR>/subs/<sub>/graph.db`) already existed in `credential_state.py` but was referenced only by tests — never by the live DB-open path.

## Fix

Wire `get_db_path()` — the single choke point every store-open path goes through (`_get_store`, `embed`, `stats`, the semantic-search header) — to return `db_path_for_sub(get_current_sub())` when a JWT sub is bound (multi-user), falling back to the existing repo-relative path when `sub` is `None` (stdio / single-user HTTP).

- One gated branch isolates every store-open call site at once.
- The per-sub value flows request-scoped via the `_current_sub` contextvar set by the `auth_scope` middleware; it is **never** written to `os.environ`, so it cannot leak to a concurrent sub.
- Stdio / single-user behavior is byte-for-byte unchanged (no sub bound → repo-relative path, same as before).

This mirrors the request-scoped pattern #741 established for credentials (`config_value_for_current_request`).

## Tests

New `tests/test_per_sub_graph_db.py`:
- stdio / no-sub → repo-relative `<repo>/.code-review-graph/graph.db` (unchanged).
- bound sub → per-sub `<CRG_DATA_DIR>/subs/<sub>/graph.db`, not repo-relative.
- two subs → distinct DB files.
- end-to-end isolation: sub A writes a node through the live `get_db_path` → `GraphStore` path; sub B's query does **not** return it.

Full suite: 1234 passed, 1 skipped (47 integration deselected by default), 95% coverage gate green. `ruff check` + `ruff format` + `ty check` all green.
