### PR TITLE
[FIX] Long function: _filter_valid_paths

### DIFF
--- a/fix_filter.py
+++ b/fix_filter.py
@@ -1,0 +1,65 @@
+import sys
+
+content = open('src/better_code_review_graph/tools.py').read()
+
+search_text = """    for f in changed_files:
+        if f in result_cache:
+            res = result_cache[f]
+            if res is not None:
+                abs_files.append(res)
+            continue
+
+        full_path_raw = root / f
+        try:
+            parent_raw = full_path_raw.parent
+            if parent_raw not in parent_cache:
+                try:
+                    parent_cache[parent_raw] = parent_raw.resolve(strict=True)
+                except OSError:
+                    # Parent directory might not exist yet if it's a deleted file,
+                    # fallback to resolving the full path.
+                    parent_cache[parent_raw] = None
+
+            parent_resolved = parent_cache[parent_raw]
+            if parent_resolved:
+                full_path = parent_resolved / full_path_raw.name
+            else:
+                full_path = full_path_raw.resolve()
+
+            if not full_path.is_relative_to(root_resolved):
+                result_cache[f] = None
+                continue
+
+            if full_path_raw.is_symlink() or full_path.is_symlink():
+                result_cache[f] = None
+                continue
+
+            res_str = str(full_path)
+            result_cache[f] = res_str
+            abs_files.append(res_str)
+        except (OSError, ValueError):
+            result_cache[f] = None
+            continue"""
+
+replace_text = """    for f in changed_files:
+        if f in result_cache:
+            res = result_cache[f]
+            if res is not None:
+                abs_files.append(res)
+            continue
+
+        full_path = _resolve_secure_path(root, root_resolved, f, parent_cache)
+        if full_path:
+            res_str = str(full_path)
+            result_cache[f] = res_str
+            abs_files.append(res_str)
+        else:
+            result_cache[f] = None"""
+
+if search_text in content:
+    new_content = content.replace(search_text, replace_text)
+    with open('src/better_code_review_graph/tools.py', 'w') as f:
+        f.write(new_content)
+    print("Success")
+else:
+    print("Search text not found")

--- a/fix_indentation.py
+++ b/fix_indentation.py
@@ -1,0 +1,63 @@
+import sys
+
+with open('src/better_code_review_graph/tools.py', 'r') as f:
+    lines = f.readlines()
+
+# Indentation fix for _get_source_snippets
+# Looking for the loop starting at rel_path in unique_files
+start_line = -1
+for i, line in enumerate(lines):
+    if "for rel_path in unique_files:" in line and i > 1900:
+        start_line = i
+        break
+
+if start_line != -1:
+    # Lines after the loop header
+    # 1945: full_path = ...
+    # 1946: if not full_path:
+    # 1947:     continue
+    # 1948:
+    # 1949: if full_path.is_file():
+    # 1950:       try:
+
+    # We want to re-indent from line 1950 to the end of the loop
+    # Let's just rewrite the whole loop body to be sure
+
+    loop_body = [
+        "        full_path = _resolve_secure_path(root, root_resolved, rel_path, parent_cache)\n",
+        "        if not full_path:\n",
+        "            continue\n",
+        "\n",
+        "        if full_path.is_file():\n",
+        "            try:\n",
+        "                lines_content = full_path.read_text(errors='replace').splitlines()\n",
+        "                if len(lines_content) > max_lines_per_file:\n",
+        "                    snippets[rel_path] = _extract_relevant_lines(\n",
+        "                        lines_content, changed_nodes, str(full_path)\n",
+        "                    )\n",
+        "                else:\n",
+        "                    snippets[rel_path] = '\n'.join(\n",
+        "                        f'{i + 1}: {line}' for i, line in enumerate(lines_content)\n",
+        "                    )\n",
+        "            except (OSError, UnicodeDecodeError):\n",
+        "                snippets[rel_path] = '(could not read file)'\n"
+    ]
+
+    # Find where the next function starts to know where to stop replacing
+    end_line = -1
+    for i in range(start_line + 1, len(lines)):
+        if line.startswith("def _build_review_summary_text"): # Wait, need to check the actual next function name
+             pass
+        if "return snippets" in lines[i]:
+            end_line = i
+            break
+
+    if end_line != -1:
+        new_lines = lines[:start_line + 1] + loop_body + lines[end_line:]
+        with open('src/better_code_review_graph/tools.py', 'w') as f:
+            f.writelines(new_lines)
+        print("Success")
+    else:
+        print("Could not find end of loop")
+else:
+    print("Could not find start of loop")

--- a/fix_newline.py
+++ b/fix_newline.py
@@ -1,0 +1,16 @@
+import sys
+
+content = open('src/better_code_review_graph/tools.py').read()
+
+bad_snippet = """                    snippets[rel_path] = '
+'.join("""
+
+good_snippet = """                    snippets[rel_path] = '\n'.join("""
+
+if bad_snippet in content:
+    new_content = content.replace(bad_snippet, good_snippet)
+    with open('src/better_code_review_graph/tools.py', 'w') as f:
+        f.write(new_content)
+    print("Success")
+else:
+    print("Bad snippet not found")

--- a/fix_newline_v2.py
+++ b/fix_newline_v2.py
@@ -1,0 +1,17 @@
+import sys
+
+with open('src/better_code_review_graph/tools.py', 'rb') as f:
+    content = f.read()
+
+# Look for the hex pattern of '\n'.join where \n is a literal newline
+# ' is 0x27, \n is 0x0a
+bad_pattern = b"snippets[rel_path] = '\n'.join("
+good_pattern = b"snippets[rel_path] = '\\n'.join("
+
+if bad_pattern in content:
+    new_content = content.replace(bad_pattern, good_pattern)
+    with open('src/better_code_review_graph/tools.py', 'wb') as f:
+        f.write(new_content)
+    print("Success")
+else:
+    print("Bad pattern not found")

--- a/fix_snippets.py
+++ b/fix_snippets.py
@@ -1,0 +1,41 @@
+import sys
+
+content = open('src/better_code_review_graph/tools.py').read()
+
+search_text = """    for rel_path in unique_files:
+        full_path_raw = root / rel_path
+        try:
+            parent_raw = full_path_raw.parent
+            if parent_raw not in parent_cache:
+                try:
+                    parent_cache[parent_raw] = parent_raw.resolve(strict=True)
+                except OSError:
+                    parent_cache[parent_raw] = None
+
+            parent_resolved = parent_cache[parent_raw]
+            if parent_resolved:
+                full_path = parent_resolved / full_path_raw.name
+            else:
+                full_path = full_path_raw.resolve()
+
+            if not full_path.is_relative_to(root_resolved):
+                continue
+            if full_path_raw.is_symlink() or full_path.is_symlink():
+                continue
+
+            if full_path.is_file():"""
+
+replace_text = """    for rel_path in unique_files:
+        full_path = _resolve_secure_path(root, root_resolved, rel_path, parent_cache)
+        if not full_path:
+            continue
+
+        if full_path.is_file():"""
+
+if search_text in content:
+    new_content = content.replace(search_text, replace_text)
+    with open('src/better_code_review_graph/tools.py', 'w') as f:
+        f.write(new_content)
+    print("Success")
+else:
+    print("Search text not found")

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1861,6 +1861,39 @@ def renamed_in_diff(
 
 # ---------------------------------------------------------------------------
 # Tool 4: get_review_context
+def _resolve_secure_path(
+    root: Path,
+    root_resolved: Path,
+    rel_path: str,
+    parent_cache: dict[Path, Path | None],
+) -> Path | None:
+    """Resolve a relative path securely against a root, handling symlinks and scoping."""
+    full_path_raw = root / rel_path
+    try:
+        parent_raw = full_path_raw.parent
+        if parent_raw not in parent_cache:
+            try:
+                parent_cache[parent_raw] = parent_raw.resolve(strict=True)
+            except OSError:
+                parent_cache[parent_raw] = None
+
+        parent_resolved = parent_cache[parent_raw]
+        if parent_resolved:
+            full_path = parent_resolved / full_path_raw.name
+        else:
+            full_path = full_path_raw.resolve()
+
+        if not full_path.is_relative_to(root_resolved):
+            return None
+
+        if full_path_raw.is_symlink() or full_path.is_symlink():
+            return None
+
+        return full_path
+    except (OSError, ValueError):
+        return None
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -1883,37 +1916,13 @@ def _filter_valid_paths(root: Path, changed_files: list[str]) -> list[str]:
                 abs_files.append(res)
             continue
 
-        full_path_raw = root / f
-        try:
-            parent_raw = full_path_raw.parent
-            if parent_raw not in parent_cache:
-                try:
-                    parent_cache[parent_raw] = parent_raw.resolve(strict=True)
-                except OSError:
-                    # Parent directory might not exist yet if it's a deleted file,
-                    # fallback to resolving the full path.
-                    parent_cache[parent_raw] = None
-
-            parent_resolved = parent_cache[parent_raw]
-            if parent_resolved:
-                full_path = parent_resolved / full_path_raw.name
-            else:
-                full_path = full_path_raw.resolve()
-
-            if not full_path.is_relative_to(root_resolved):
-                result_cache[f] = None
-                continue
-
-            if full_path_raw.is_symlink() or full_path.is_symlink():
-                result_cache[f] = None
-                continue
-
+        full_path = _resolve_secure_path(root, root_resolved, f, parent_cache)
+        if full_path:
             res_str = str(full_path)
             result_cache[f] = res_str
             abs_files.append(res_str)
-        except (OSError, ValueError):
+        else:
             result_cache[f] = None
-            continue
 
     return abs_files
 
@@ -1933,41 +1942,23 @@ def _get_source_snippets(
     parent_cache: dict[Path, Path | None] = {}
 
     for rel_path in unique_files:
-        full_path_raw = root / rel_path
-        try:
-            parent_raw = full_path_raw.parent
-            if parent_raw not in parent_cache:
-                try:
-                    parent_cache[parent_raw] = parent_raw.resolve(strict=True)
-                except OSError:
-                    parent_cache[parent_raw] = None
-
-            parent_resolved = parent_cache[parent_raw]
-            if parent_resolved:
-                full_path = parent_resolved / full_path_raw.name
-            else:
-                full_path = full_path_raw.resolve()
-
-            if not full_path.is_relative_to(root_resolved):
-                continue
-            if full_path_raw.is_symlink() or full_path.is_symlink():
-                continue
-
-            if full_path.is_file():
-                try:
-                    lines = full_path.read_text(errors="replace").splitlines()
-                    if len(lines) > max_lines_per_file:
-                        snippets[rel_path] = _extract_relevant_lines(
-                            lines, changed_nodes, str(full_path)
-                        )
-                    else:
-                        snippets[rel_path] = "\n".join(
-                            f"{i + 1}: {line}" for i, line in enumerate(lines)
-                        )
-                except (OSError, UnicodeDecodeError):
-                    snippets[rel_path] = "(could not read file)"
-        except (OSError, ValueError):
+        full_path = _resolve_secure_path(root, root_resolved, rel_path, parent_cache)
+        if not full_path:
             continue
+
+        if full_path.is_file():
+            try:
+                lines_content = full_path.read_text(errors="replace").splitlines()
+                if len(lines_content) > max_lines_per_file:
+                    snippets[rel_path] = _extract_relevant_lines(
+                        lines_content, changed_nodes, str(full_path)
+                    )
+                else:
+                    snippets[rel_path] = "\n".join(
+                        f"{i + 1}: {line}" for i, line in enumerate(lines_content)
+                    )
+            except (OSError, UnicodeDecodeError):
+                snippets[rel_path] = "(could not read file)"
     return snippets
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b9"
+version = "3.18.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `_filter_valid_paths` function was excessively long due to complex path resolution and security logic. I extracted this logic into a reusable `_resolve_secure_path` helper, which is now also used by `_get_source_snippets`, reducing duplication and improving maintainability.

---
*PR created automatically by Jules for task [4501907249612537689](https://jules.google.com/task/4501907249612537689) started by @n24q02m*