### PR TITLE
[FIX] N+1 Query Pattern in Temporal Check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,9 @@
 ## 2024-06-25 - Use str.translate over generator expressions for fast sanitization
 **Learning:** In hot serialization loops (like returning large JSON responses containing node metadata), using a generator expression with `"".join(...)` to filter string characters is a significant performance bottleneck in Python.
 **Action:** When filtering known character sets (like removing control characters), always define a pre-compiled mapping module constant (e.g., `_MAP = {i: None for i in range(32)}`) and use `str.translate()`, which pushes the iteration into optimized C code, yielding roughly 7.5x performance improvements.
+
+## 2026-06-23 - Eliminate N+1 Query Patterns in Batch Operations
+
+**Learning:** Direct SQL execution within a loop structure causes N+1 query patterns, leading to significant performance degradation as the data set grows. In SQLite, this is especially impactful during write-heavy operations like temporal closing.
+
+**Action:** Refactor row-by-row updates into batch operations using `UPDATE ... WHERE ... IN (SELECT value FROM json_each(?))`. This pushes the filtering logic into the database engine and reduces the overhead of multiple `execute()` calls and potential transaction management. Always use `cursor.rowcount` to track affected rows when removing the manual loop counter.

--- a/src/better_code_review_graph/temporal.py
+++ b/src/better_code_review_graph/temporal.py
@@ -446,21 +446,13 @@ class TemporalIndex:
         Returns:
             Number of nodes whose ``valid_to_sha`` was set in this call.
         """
-        rows = self._store._conn.execute(
-            "SELECT id, qualified_name FROM nodes "
-            "WHERE file_path = ? AND valid_to_sha IS NULL",
-            (file_path,),
-        ).fetchall()
-        closed = 0
-        for row in rows:
-            row_id = row[0]
-            qualified = row[1]
-            if qualified not in observed_qualified:
-                self._store._conn.execute(
-                    "UPDATE nodes SET valid_to_sha = ? WHERE id = ?",
-                    (self._current_sha, row_id),
-                )
-                closed += 1
+        cursor = self._store._conn.execute(
+            "UPDATE nodes SET valid_to_sha = ? "
+            "WHERE file_path = ? AND valid_to_sha IS NULL "
+            "AND qualified_name NOT IN (SELECT value FROM json_each(?))",
+            (self._current_sha, file_path, json.dumps(list(observed_qualified))),
+        )
+        closed = cursor.rowcount
         if closed:
             self._store._conn.commit()
         return closed

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b9"
+version = "3.18.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR addresses an N+1 query performance bottleneck in `TemporalIndex.close_missing_nodes`. 

Previously, the method performed a SELECT to find all currently-valid nodes for a file, then iterated through them in Python to execute individual UPDATE statements for each node not present in the new parse. This resulted in O(N) database round-trips where N is the number of nodes in the file.

The fix replaces this with a single `UPDATE` statement that uses SQLite's `json_each` to handle the `NOT IN` filter efficiently in the database engine. This reduces the operation to O(1) database round-trips.

Verification:
- Ran `tests/test_temporal.py` (Passed)
- Ran full test suite (1235 passed)
- Verified code style and types with `ruff` and `ty`.
- Recorded the pattern in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7071156098960488709](https://jules.google.com/task/7071156098960488709) started by @n24q02m*