### PR TITLE
[FIX] N+1 Query Pattern in Federation Insert

### DIFF
--- a/src/better_code_review_graph/federation.py
+++ b/src/better_code_review_graph/federation.py
@@ -304,7 +304,7 @@ def backfill_commits_for_repo(
     if proc.returncode != 0:
         return 0
 
-    inserted = 0
+    to_insert = []
     for line in proc.stdout.splitlines():
         # Each row is exactly 4 NUL-separated columns; anything else
         # signals a malformed line (e.g. truncated output) and we skip
@@ -323,13 +323,17 @@ def backfill_commits_for_repo(
             # or future git version that emits something else should
             # not blow up the backfill. Skip the row instead.
             continue
-        cursor = store._conn.execute(
-            "INSERT OR IGNORE INTO commits "
-            "(sha, repo_id, parent_sha, timestamp, message) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (sha, repo_id, parent_sha, ts, message),
-        )
-        if cursor.rowcount > 0:
-            inserted += 1
+        to_insert.append((sha, repo_id, parent_sha, ts, message))
+
+    if not to_insert:
+        return 0
+
+    cursor = store._conn.executemany(
+        "INSERT OR IGNORE INTO commits "
+        "(sha, repo_id, parent_sha, timestamp, message) "
+        "VALUES (?, ?, ?, ?, ?)",
+        to_insert,
+    )
+    inserted = cursor.rowcount
     store._conn.commit()
     return inserted

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b9"
+version = "3.18.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `backfill_commits_for_repo` function previously performed a separate SQL `INSERT` for each commit found in the `git log` output. This created an N+1 query pattern, which is a bottleneck for repositories with a large number of commits.

This PR optimizes the function by:
1. Collecting all valid commit data into a list.
2. Using `cursor.executemany` to perform the insertions in a single batch.
3. Utilizing `cursor.rowcount` to accurately return the number of rows actually inserted (respecting the `INSERT OR IGNORE` semantics).

Verification:
- Ran `tests/test_commits_migration.py` and `tests/test_federation.py`.
- Ran the full test suite (1235 tests passed).
- Verified with `ruff` and `ty`.

---
*PR created automatically by Jules for task [17613396392287852928](https://jules.google.com/task/17613396392287852928) started by @n24q02m*