### PR TITLE
[FIX] N+1 Query Pattern in Migration

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -491,19 +491,21 @@ class GraphStore:
           call unconditionally on every connect.
         """
         node_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(nodes)")}
+        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+
+        script = []
         if "repo_id" not in node_cols:
-            self._conn.execute(
+            script.append(
                 "ALTER TABLE nodes ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
             )
-        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
         if "repo_id" not in edge_cols:
-            self._conn.execute(
+            script.append(
                 "ALTER TABLE edges ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
             )
         # Repos registry table — created by migration 003 on disk-backed
         # DBs. Mirror it here for in-memory connections so RepoRegistry
         # works against ``:memory:`` GraphStores too.
-        self._conn.execute(
+        script.append(
             """CREATE TABLE IF NOT EXISTS repos (
                 repo_id TEXT PRIMARY KEY NOT NULL,
                 path TEXT NOT NULL,
@@ -513,13 +515,14 @@ class GraphStore:
                 last_indexed_at INTEGER NOT NULL
             )"""
         )
-        self._conn.execute(
+        script.append(
             "CREATE INDEX IF NOT EXISTS idx_nodes_repo_kind ON nodes(repo_id, kind)"
         )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_edges_repo ON edges(repo_id)"
-        )
-        self._conn.commit()
+        script.append("CREATE INDEX IF NOT EXISTS idx_edges_repo ON edges(repo_id)")
+
+        if script:
+            self._conn.executescript("; ".join(script))
+            self._conn.commit()
 
     def _ensure_temporal_columns(self) -> None:
         """Backfill Phase 3 Task 6 temporal columns on legacy / in-memory DBs.
@@ -547,30 +550,36 @@ class GraphStore:
         downstream temporal queries treat the two paths identically.
         """
         node_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(nodes)")}
+        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+
+        script = []
         if "valid_from_sha" not in node_cols:
-            self._conn.execute(
+            script.append(
                 "ALTER TABLE nodes ADD COLUMN valid_from_sha TEXT NOT NULL "
                 "DEFAULT '0000000000000000000000000000000000000000'"
             )
         if "valid_to_sha" not in node_cols:
-            self._conn.execute("ALTER TABLE nodes ADD COLUMN valid_to_sha TEXT")
-        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+            script.append("ALTER TABLE nodes ADD COLUMN valid_to_sha TEXT")
         if "valid_from_sha" not in edge_cols:
-            self._conn.execute(
+            script.append(
                 "ALTER TABLE edges ADD COLUMN valid_from_sha TEXT NOT NULL "
                 "DEFAULT '0000000000000000000000000000000000000000'"
             )
         if "valid_to_sha" not in edge_cols:
-            self._conn.execute("ALTER TABLE edges ADD COLUMN valid_to_sha TEXT")
-        self._conn.execute(
+            script.append("ALTER TABLE edges ADD COLUMN valid_to_sha TEXT")
+
+        script.append(
             "CREATE INDEX IF NOT EXISTS idx_nodes_temporal "
             "ON nodes(valid_from_sha, valid_to_sha)"
         )
-        self._conn.execute(
+        script.append(
             "CREATE INDEX IF NOT EXISTS idx_edges_temporal "
             "ON edges(valid_from_sha, valid_to_sha)"
         )
-        self._conn.commit()
+
+        if script:
+            self._conn.executescript("; ".join(script))
+            self._conn.commit()
 
     def _ensure_summary_columns(self) -> None:
         """Backfill Phase 1 v1.6.x summary columns on pre-existing DBs.
@@ -589,13 +598,19 @@ class GraphStore:
             "source_hash": "ALTER TABLE nodes ADD COLUMN source_hash TEXT",
             "source_text": "ALTER TABLE nodes ADD COLUMN source_text TEXT",
         }
+
+        script = []
         for column in _SUMMARY_COLUMNS:
             if column not in existing and column in column_sqls:
-                self._conn.execute(column_sqls[column])
-        self._conn.execute(
+                script.append(column_sqls[column])
+
+        script.append(
             "CREATE INDEX IF NOT EXISTS idx_nodes_source_hash ON nodes(source_hash)"
         )
-        self._conn.commit()
+
+        if script:
+            self._conn.executescript("; ".join(script))
+            self._conn.commit()
 
     def _invalidate_cache(self) -> None:
         """Invalidate the cached NetworkX graph after write operations."""

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b9"
+version = "3.18.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Optimized the schema migration and backfill methods (_ensure_summary_columns, _ensure_federation_columns, and _ensure_temporal_columns) in GraphStore to batch SQL statements using executescript(). This addresses the N+1 database roundtrip pattern and improves initialization performance.

---
*PR created automatically by Jules for task [17001810464185842625](https://jules.google.com/task/17001810464185842625) started by @n24q02m*