### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix S110 and S112 lint errors in exception handlers

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -132,8 +132,11 @@ def resolve_credential_state() -> CredentialState:
                 logger.info("Config loaded from encrypted per-plugin store")
                 _state = CredentialState.CONFIGURED
                 return _state
-        except Exception:
-            pass
+        except Exception as e:
+            # SECURITY: Swallowing exceptions during credential loading masks
+            # misconfigurations and decryption failures, leaving the system
+            # in an unknown state. We explicitly log the error for visibility.
+            logger.debug("Failed to load from per-plugin store: %s", e)
 
         try:
             from mcp_core import get_mode
@@ -143,8 +146,10 @@ def resolve_credential_state() -> CredentialState:
                 logger.info("Local mode marker found, skipping relay")
                 _state = CredentialState.LOCAL
                 return _state
-        except Exception:
-            pass
+        except Exception as e:
+            # SECURITY: Always log marker lookup failures to prevent silently
+            # falling back to unauthenticated relay behavior when local mode was intended.
+            logger.debug("Failed to get local mode marker: %s", e)
 
     logger.info("No credentials found -- server starting in awaiting_setup mode")
     _state = CredentialState.AWAITING_SETUP
@@ -316,8 +321,10 @@ def reset_state() -> None:
 
         clear_mode(SERVER_NAME)
         PerPluginStore(PLUGIN_NAME).clear()
-    except Exception:
-        pass
+    except Exception as e:
+        # SECURITY: Failures to clear credential state risk cross-session leakage.
+        # Log the failure so administrators are aware of dirty state.
+        logger.debug("Failed to clear state: %s", e)
 
 
 # ---------------------------------------------------------------------------

--- a/src/better_code_review_graph/relay_setup.py
+++ b/src/better_code_review_graph/relay_setup.py
@@ -68,8 +68,10 @@ async def ensure_config() -> dict[str, str] | None:
             for key, value in saved.items():
                 os.environ.setdefault(key, value)
             return saved
-    except Exception:
-        pass
+    except Exception as e:
+        # SECURITY: Log decryption or lookup failures from the per-plugin store
+        # to ensure local fallback states are auditable and not silently triggered.
+        logger.debug("Failed to load from per-plugin store: %s", e)
 
     # 3. No local credentials found -- trigger relay setup.
     # Per mode-matrix 2.5, better-code-review-graph default is `http local relay`;
@@ -126,8 +128,10 @@ async def ensure_config() -> dict[str, str] | None:
                         "text": "CRG config saved. Setup complete!",
                     },
                 )
-        except Exception:
-            pass
+        except Exception as e:
+            # SECURITY: Even for non-critical HTTP callbacks, errors should be logged
+            # rather than swallowed to identify potential availability or routing issues.
+            logger.debug("Failed to notify relay page: %s", e)
 
         # Inject into environment
         for key, value in config.items():

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -14,6 +14,7 @@ Exposes 9 tools:
 
 import hashlib
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,8 @@ from .security.semgrep_engine import (
     SemgrepScanner,
     _resolve_overlay_rules_dir,
 )
+
+logger = logging.getLogger(__name__)
 
 # Common JS/TS builtin method names filtered from callers_of results.
 # "Who calls .map()?" returns hundreds of hits and is never useful.
@@ -941,8 +944,10 @@ def _scan_dynamic_dispatch_hints(
     try:
         for e in store.get_edges_by_target(target_file, kind="IMPORTS_FROM"):  # type: ignore[attr-defined]
             candidate_files.add(e.file_path)
-    except Exception:
-        pass
+    except Exception as e:
+        # SECURITY: Log database or path resolution failures rather than silently swallowing
+        # them. This ensures file enumeration issues aren't masked.
+        logger.debug("Failed to get target imports: %s", e)
 
     hits: list[dict[str, Any]] = []
     for fp in candidate_files:
@@ -1816,7 +1821,10 @@ def renamed_in_diff(
                 base_nodes, _ = parser.parse_bytes(full_path, base_source)
                 head_source = full_path.read_bytes()
                 head_nodes, _ = parser.parse_bytes(full_path, head_source)
-            except Exception:
+            except Exception as e:
+                # SECURITY: Parsing exceptions (e.g. out-of-memory or corrupt bytes) should
+                # be logged so that incomplete coverage responses are traceable.
+                logger.debug("Failed to parse bytes: %s", e)
                 continue
 
             base_lines = {

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.18.0b9"
+version = "3.18.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixes S110 (try-except-pass) and S112 (try-except-continue) vulnerabilities in src/better_code_review_graph by replacing silent failures with logger.debug() calls. This prevents the masking of critical failures in credential state loading, relay setup, and graph tool queries. Added security comments detailing the risks.

---
*PR created automatically by Jules for task [3388874632567822332](https://jules.google.com/task/3388874632567822332) started by @n24q02m*