### PR TITLE
[TEST] Missing error path test in file watching update

### DIFF
--- a/tests/test_watch_error_path.py
+++ b/tests/test_watch_error_path.py
@@ -1,0 +1,66 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+from better_code_review_graph.incremental import GraphUpdateHandler
+
+
+def test_update_file_error_path(tmp_path, caplog):
+    """Test that _update_file logs an error when _update_single_file fails."""
+    repo_root = tmp_path
+    sample_file = repo_root / "sample.py"
+    sample_file.write_text("def foo(): pass")
+
+    mock_store = MagicMock()
+    mock_parser = MagicMock()
+
+    handler = GraphUpdateHandler(
+        repo_root=repo_root, store=mock_store, parser=mock_parser, ignore_patterns=[]
+    )
+
+    abs_path = str(sample_file)
+
+    with patch(
+        "better_code_review_graph.incremental._update_single_file",
+        side_effect=Exception("Test Error"),
+    ):
+        with caplog.at_level(logging.ERROR):
+            handler._update_file(abs_path)
+
+    assert f"Error updating {abs_path}: Test Error" in caplog.text
+
+
+def test_update_file_non_existent(tmp_path, caplog):
+    """Test that _update_file returns early if file doesn't exist."""
+    repo_root = tmp_path
+    non_existent = repo_root / "missing.py"
+
+    mock_store = MagicMock()
+    mock_parser = MagicMock()
+    handler = GraphUpdateHandler(
+        repo_root=repo_root, store=mock_store, parser=mock_parser, ignore_patterns=[]
+    )
+
+    with caplog.at_level(logging.ERROR):
+        handler._update_file(str(non_existent))
+
+    assert len(caplog.records) == 0
+    assert not mock_store.commit.called
+
+
+def test_update_file_binary(tmp_path, caplog):
+    """Test that _update_file returns early for binary files."""
+    repo_root = tmp_path
+    binary_file = repo_root / "data.bin"
+    binary_file.write_bytes(b"hello\x00world")
+
+    mock_store = MagicMock()
+    mock_parser = MagicMock()
+    handler = GraphUpdateHandler(
+        repo_root=repo_root, store=mock_store, parser=mock_parser, ignore_patterns=[]
+    )
+
+    with caplog.at_level(logging.ERROR):
+        handler._update_file(str(binary_file))
+
+    assert len(caplog.records) == 0
+    assert not mock_store.commit.called


### PR DESCRIPTION
This PR adds missing test coverage for the error paths in `GraphUpdateHandler._update_file` within `src/better_code_review_graph/incremental.py`.

Specifically, it addresses the following:
1.  **Exception Handling:** Verified that exceptions during file updates (e.g., in `_update_single_file`) are caught and logged as errors.
2.  **Early Returns:** Added tests to ensure the function returns early without attempting to parse if the file is missing or detected as binary.

These changes improve the robustness of the file watching mechanism by ensuring error conditions are correctly handled and verified through unit tests.

---
*PR created automatically by Jules for task [3691555042180172181](https://jules.google.com/task/3691555042180172181) started by @n24q02m*