### PR TITLE
[FIX] Overly long function: semantic_search_nodes

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2245,6 +2245,98 @@ def _looks_like_literal_identifier(query: str) -> bool:
     return all(ch in allowed for ch in q)
 
 
+def _perform_semantic_search(
+    query: str,
+    store: GraphStore,
+    emb_store: EmbeddingStore,
+    limit: int,
+    kind: str | None,
+    repo: str,
+) -> list[dict[str, Any]]:
+    """Helper to apply semantic search with all secondary filters."""
+    raw = semantic_search(query, store, emb_store, limit=limit * 2)
+    if kind:
+        raw = [r for r in raw if r.get("kind") == kind]
+    if repo:
+        # The vector store has no repo_id column; cross-check
+        # each hit against the SQL row and drop misses. Batched
+        # via json_each so it stays O(1) queries regardless of
+        # how many hits the vector store returned.
+        repo_qns = [
+            r.get("qualified_name") for r in raw if r.get("qualified_name") is not None
+        ]
+        repo_map: dict[str, str] = {}
+        if repo_qns:
+            cursor = store._conn.execute(
+                "SELECT n.qualified_name, n.repo_id FROM nodes n "
+                "JOIN json_each(?) j ON n.qualified_name = j.value",
+                (json.dumps(repo_qns),),
+            )
+            repo_map = {row["qualified_name"]: row["repo_id"] for row in cursor}
+        filtered = []
+        for r in raw:
+            qn = r.get("qualified_name")
+            if qn is None:
+                continue
+            r_repo = repo_map.get(qn)
+            if r_repo is not None and (r_repo or "") == repo:
+                filtered.append(r)
+        raw = filtered
+    # Default-path filter: vector hits should also exclude
+    # rows that have been closed-out at a later commit. The
+    # vector store does not know about ``valid_to_sha`` so
+    # we cross-check via the SQL row — batched via json_each.
+    surv_qns = [
+        r.get("qualified_name") for r in raw if r.get("qualified_name") is not None
+    ]
+    surviving_set: set[str] = set()
+    if surv_qns:
+        cursor = store._conn.execute(
+            "SELECT n.qualified_name FROM nodes n "
+            "JOIN json_each(?) j ON n.qualified_name = j.value "
+            "WHERE n.valid_to_sha IS NULL",
+            (json.dumps(surv_qns),),
+        )
+        surviving_set = {row["qualified_name"] for row in cursor}
+    surviving: list[dict] = []
+    for r in raw:
+        qn = r.get("qualified_name")
+        if qn is None:
+            continue
+        if qn in surviving_set:
+            surviving.append(r)
+    raw = surviving
+    return raw[:limit]
+
+
+def _perform_keyword_search(
+    query: str,
+    store: GraphStore,
+    limit: int,
+    kind: str | None,
+    repo: str,
+    as_of: str,
+) -> list[dict[str, Any]]:
+    """Helper to apply keyword search with custom scoring and kind filtering."""
+    results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
+
+    if kind:
+        results = [r for r in results if r.kind == kind]
+
+    def score(node):
+        name_lower = node.name.lower()
+        q_lower = query.lower()
+        if name_lower == q_lower:
+            return 0
+        if name_lower.startswith(q_lower):
+            return 1
+        return 2
+
+    results.sort(key=score)
+    results = results[:limit]
+    return [node_to_dict(r) for r in results]
+
+
 def semantic_search_nodes(
     query: str,
     kind: str | None = None,
@@ -2296,67 +2388,10 @@ def semantic_search_nodes(
             # safely return historical snapshots through it. Fall through
             # to the keyword path which threads ``as_of`` into the SQL.
             if as_of == "" and emb_store.available and emb_store.count() > 0:
-                # Vector search
                 search_mode = "semantic"
-                raw = semantic_search(query, store, emb_store, limit=limit * 2)
-                if kind:
-                    raw = [r for r in raw if r.get("kind") == kind]
-                if repo:
-                    # The vector store has no repo_id column; cross-check
-                    # each hit against the SQL row and drop misses. Batched
-                    # via json_each so it stays O(1) queries regardless of
-                    # how many hits the vector store returned.
-                    repo_qns = [
-                        r.get("qualified_name")
-                        for r in raw
-                        if r.get("qualified_name") is not None
-                    ]
-                    repo_map: dict[str, str] = {}
-                    if repo_qns:
-                        cursor = store._conn.execute(
-                            "SELECT n.qualified_name, n.repo_id FROM nodes n "
-                            "JOIN json_each(?) j ON n.qualified_name = j.value",
-                            (json.dumps(repo_qns),),
-                        )
-                        repo_map = {
-                            row["qualified_name"]: row["repo_id"] for row in cursor
-                        }
-                    filtered = []
-                    for r in raw:
-                        qn = r.get("qualified_name")
-                        if qn is None:
-                            continue
-                        r_repo = repo_map.get(qn)
-                        if r_repo is not None and (r_repo or "") == repo:
-                            filtered.append(r)
-                    raw = filtered
-                # Default-path filter: vector hits should also exclude
-                # rows that have been closed-out at a later commit. The
-                # vector store does not know about ``valid_to_sha`` so
-                # we cross-check via the SQL row — batched via json_each.
-                surv_qns = [
-                    r.get("qualified_name")
-                    for r in raw
-                    if r.get("qualified_name") is not None
-                ]
-                surviving_set: set[str] = set()
-                if surv_qns:
-                    cursor = store._conn.execute(
-                        "SELECT n.qualified_name FROM nodes n "
-                        "JOIN json_each(?) j ON n.qualified_name = j.value "
-                        "WHERE n.valid_to_sha IS NULL",
-                        (json.dumps(surv_qns),),
-                    )
-                    surviving_set = {row["qualified_name"] for row in cursor}
-                surviving: list[dict] = []
-                for r in raw:
-                    qn = r.get("qualified_name")
-                    if qn is None:
-                        continue
-                    if qn in surviving_set:
-                        surviving.append(r)
-                raw = surviving
-                raw = raw[:limit]
+                raw = _perform_semantic_search(
+                    query, store, emb_store, limit, kind, repo
+                )
                 return {
                     "status": "ok",
                     "query": query,
@@ -2372,22 +2407,7 @@ def semantic_search_nodes(
             emb_store.close()
 
         # Keyword fallback
-        results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
-
-        if kind:
-            results = [r for r in results if r.kind == kind]
-
-        def score(node):
-            name_lower = node.name.lower()
-            q_lower = query.lower()
-            if name_lower == q_lower:
-                return 0
-            if name_lower.startswith(q_lower):
-                return 1
-            return 2
-
-        results.sort(key=score)
-        results = results[:limit]
+        results = _perform_keyword_search(query, store, limit, kind, repo, as_of)
 
         response: dict[str, Any] = {
             "status": "ok",
@@ -2396,7 +2416,7 @@ def semantic_search_nodes(
             "summary": f"Found {len(results)} node(s) matching '{query}'"
             + (f" (kind={kind})" if kind else ""),
             "header": _build_response_header(store, db_path, keyword_only=True),
-            "results": [node_to_dict(r) for r in results],
+            "results": results,
         }
 
         # #317: warn when running keyword fallback on a query that looks


### PR DESCRIPTION
Refactored the 168-line semantic_search_nodes function in tools.py into smaller, well-named private helper functions (_perform_semantic_search and _perform_keyword_search). This improves readability and maintainability while preserving all existing functionality and logic.

---
*PR created automatically by Jules for task [12406438200396026273](https://jules.google.com/task/12406438200396026273) started by @n24q02m*