### PR TITLE
[FIX] Overly long function: config

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -550,120 +550,19 @@ async def config(
         case "status":
             return _config_status(repo_root)
         case "set":
-            if not key:
-                return _json(
-                    {
-                        "error": "key is required for set action",
-                        "valid_keys": ["log_level"],
-                    }
-                )
-            if value is None:
-                return _json({"error": "value is required for set action"})
             return _config_set(key, value)
         case "cache_clear":
             return _config_cache_clear(repo_root)
         case "setup_status":
-            from mcp_core.storage.per_plugin_store import PerPluginStore
-
-            from . import credential_state as _cs
-
-            # Refresh module-level state from live PerPluginStore load + env
-            # to ensure setup_status is always accurate.
-            _cs.resolve_credential_state()
-
-            _saved = PerPluginStore(_cs.PLUGIN_NAME).load() or {}
-            _env_keys = [k for k in _cs.CLOUD_KEYS if os.environ.get(k)]
-            _store_keys = [k for k in _cs.CLOUD_KEYS if _saved.get(k)]
-            _providers = list(dict.fromkeys(_env_keys + _store_keys))
-
-            # Logic for deriving state when resolve_credential_state() is limited
-            # (e.g. in stdio mode where it ignores PerPluginStore).
-            _state = _cs.get_state().value
-            if _providers and _state != "configured":
-                _state = "configured"
-
-            return _json(
-                {
-                    "state": _state,
-                    "setup_url": _cs.get_setup_url(),
-                    "cloud_keys_in_env": _env_keys,
-                    "providers_configured": _providers,
-                }
-            )
+            return _config_setup_status()
         case "setup_start":
-            from .credential_state import CredentialState, get_state
-
-            if get_state() == CredentialState.CONFIGURED and not force:
-                return _json(
-                    {
-                        "status": "already_configured",
-                        "message": "Already configured. Use force=true to reconfigure.",
-                    }
-                )
-            # In stdio mode (default after spec 2026-05-01) the server reads
-            # API keys from env vars only; the browser-based relay form is
-            # served by the HTTP-mode entry point at <PUBLIC_URL>/authorize.
-            public_url = os.environ.get("PUBLIC_URL")
-            if public_url:
-                url = f"{public_url.rstrip('/')}/authorize"
-                return _json(
-                    {
-                        "status": "setup_started",
-                        "setup_url": url,
-                        "message": "Open this URL to configure API keys.",
-                    }
-                )
-            return _json(
-                {
-                    "status": "stdio_mode",
-                    "message": (
-                        "Stdio mode reads API keys from env vars only. "
-                        "Set GEMINI_API_KEY / OPENAI_API_KEY / JINA_AI_API_KEY / "
-                        "COHERE_API_KEY in the plugin config, or switch to HTTP "
-                        "mode to use the browser-based setup form."
-                    ),
-                }
-            )
+            return _config_setup_start(force)
         case "setup_skip":
-            from mcp_core import set_local_mode
-
-            from .credential_state import CredentialState, set_state
-
-            set_local_mode(SERVER_NAME)
-            set_state(CredentialState.LOCAL)
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Local mode set. Relay will not trigger on restart.",
-                }
-            )
+            return _config_setup_skip()
         case "setup_reset":
-            from .credential_state import reset_state
-
-            reset_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Credentials cleared. Next tool call will offer setup.",
-                }
-            )
+            return _config_setup_reset()
         case "setup_complete":
-            from .credential_state import (
-                get_state as _get_state,
-            )
-            from .credential_state import (
-                resolve_credential_state,
-            )
-
-            resolve_credential_state()
-            state = _get_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "state": state.value,
-                    "message": "Credential state refreshed.",
-                }
-            )
+            return _config_setup_complete()
         case _:
             import difflib
 
@@ -739,9 +638,19 @@ def _config_status(repo_root: str | None) -> str:
         )
 
 
-def _config_set(key: str, value: str) -> str:
+def _config_set(key: str | None, value: str | None) -> str:
     """Update a runtime setting."""
     import logging
+
+    if not key:
+        return _json(
+            {
+                "error": "key is required for set action",
+                "valid_keys": ["log_level"],
+            }
+        )
+    if value is None:
+        return _json({"error": "value is required for set action"})
 
     valid_keys = {"log_level"}
     if key not in valid_keys:
@@ -794,6 +703,118 @@ def _config_cache_clear(repo_root: str | None) -> str:
             store.close()
     except (RuntimeError, ValueError):
         return _json({"status": "cache cleared", "embeddings_removed": 0})
+
+
+def _config_setup_status() -> str:
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    from . import credential_state as _cs
+
+    # Refresh module-level state from live PerPluginStore load + env
+    # to ensure setup_status is always accurate.
+    _cs.resolve_credential_state()
+
+    _saved = PerPluginStore(_cs.PLUGIN_NAME).load() or {}
+    _env_keys = [k for k in _cs.CLOUD_KEYS if os.environ.get(k)]
+    _store_keys = [k for k in _cs.CLOUD_KEYS if _saved.get(k)]
+    _providers = list(dict.fromkeys(_env_keys + _store_keys))
+
+    # Logic for deriving state when resolve_credential_state() is limited
+    # (e.g. in stdio mode where it ignores PerPluginStore).
+    _state = _cs.get_state().value
+    if _providers and _state != "configured":
+        _state = "configured"
+
+    return _json(
+        {
+            "state": _state,
+            "setup_url": _cs.get_setup_url(),
+            "cloud_keys_in_env": _env_keys,
+            "providers_configured": _providers,
+        }
+    )
+
+
+def _config_setup_start(force: bool) -> str:
+    from .credential_state import CredentialState, get_state
+
+    if get_state() == CredentialState.CONFIGURED and not force:
+        return _json(
+            {
+                "status": "already_configured",
+                "message": "Already configured. Use force=true to reconfigure.",
+            }
+        )
+    # In stdio mode (default after spec 2026-05-01) the server reads
+    # API keys from env vars only; the browser-based relay form is
+    # served by the HTTP-mode entry point at <PUBLIC_URL>/authorize.
+    public_url = os.environ.get("PUBLIC_URL")
+    if public_url:
+        url = f"{public_url.rstrip('/')}/authorize"
+        return _json(
+            {
+                "status": "setup_started",
+                "setup_url": url,
+                "message": "Open this URL to configure API keys.",
+            }
+        )
+    return _json(
+        {
+            "status": "stdio_mode",
+            "message": (
+                "Stdio mode reads API keys from env vars only. "
+                "Set GEMINI_API_KEY / OPENAI_API_KEY / JINA_AI_API_KEY / "
+                "COHERE_API_KEY in the plugin config, or switch to HTTP "
+                "mode to use the browser-based setup form."
+            ),
+        }
+    )
+
+
+def _config_setup_skip() -> str:
+    from mcp_core import set_local_mode
+
+    from .credential_state import CredentialState, set_state
+
+    set_local_mode(SERVER_NAME)
+    set_state(CredentialState.LOCAL)
+    return _json(
+        {
+            "status": "ok",
+            "message": "Local mode set. Relay will not trigger on restart.",
+        }
+    )
+
+
+def _config_setup_reset() -> str:
+    from .credential_state import reset_state
+
+    reset_state()
+    return _json(
+        {
+            "status": "ok",
+            "message": "Credentials cleared. Next tool call will offer setup.",
+        }
+    )
+
+
+def _config_setup_complete() -> str:
+    from .credential_state import (
+        get_state as _get_state,
+    )
+    from .credential_state import (
+        resolve_credential_state,
+    )
+
+    resolve_credential_state()
+    state = _get_state()
+    return _json(
+        {
+            "status": "ok",
+            "state": state.value,
+            "message": "Credential state refreshed.",
+        }
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refactored the 'config' tool in src/better_code_review_graph/server.py by extracting its setup action logic and 'set' validation into dedicated private helper functions (_config_setup_status, _config_setup_start, _config_setup_skip, _config_setup_reset, _config_setup_complete, and an updated _config_set). This reduces the function length and complexity of the main config tool handler, adhering to the modular dispatcher pattern used across the codebase.

---
*PR created automatically by Jules for task [14320030997200075637](https://jules.google.com/task/14320030997200075637) started by @n24q02m*