### PR TITLE
[TEST] Untested function: config_value_for_current_request

### DIFF
--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -14,6 +14,7 @@ from better_code_review_graph.credential_state import (
     CLOUD_KEYS,
     SERVER_NAME,
     CredentialState,
+    config_value_for_current_request,
     get_current_sub,
     get_setup_url,
     get_state,
@@ -21,6 +22,7 @@ from better_code_review_graph.credential_state import (
     resolve_credential_state,
     set_current_sub,
     set_state,
+    store_for_sub,
 )
 
 # ---------------------------------------------------------------------------
@@ -397,3 +399,37 @@ class TestCurrentSub:
         assert get_current_sub() == "user-456"
         set_current_sub(None)
         assert get_current_sub() is None
+
+
+class TestConfigValueForCurrentRequest:
+    def test_config_value_no_sub_reads_environ(self, monkeypatch):
+        """Verify config_value_for_current_request reads from os.environ when no sub is set."""
+        set_current_sub(None)
+        monkeypatch.setenv("TEST_CONFIG_KEY", "env-value")
+        assert config_value_for_current_request("TEST_CONFIG_KEY") == "env-value"
+
+    def test_config_value_with_sub_reads_store(self, monkeypatch, tmp_path):
+        """Verify config_value_for_current_request reads from per-sub store when sub is set."""
+        monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TEST_CONFIG_KEY", "env-value")
+
+        sub = "user-123"
+        store_for_sub(sub, {"TEST_CONFIG_KEY": "sub-value"})
+        set_current_sub(sub)
+
+        # Should return sub-value even though env-value exists
+        assert config_value_for_current_request("TEST_CONFIG_KEY") == "sub-value"
+
+    def test_config_value_missing_returns_none(self, monkeypatch, tmp_path):
+        """Verify config_value_for_current_request returns None for missing keys."""
+        # Case 1: No sub, key missing from environ
+        set_current_sub(None)
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        assert config_value_for_current_request("MISSING_KEY") is None
+
+        # Case 2: Sub set, key missing from sub store
+        monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+        sub = "user-456"
+        store_for_sub(sub, {"OTHER_KEY": "other-value"})
+        set_current_sub(sub)
+        assert config_value_for_current_request("MISSING_KEY") is None


### PR DESCRIPTION
I have added unit tests for the `config_value_for_current_request` function in `src/better_code_review_graph/credential_state.py`. 

The implementation involved:
1.  Updating imports in `tests/test_credential_state.py` to include `config_value_for_current_request` and `store_for_sub`.
2.  Adding a new `TestConfigValueForCurrentRequest` class with three test cases:
    *   `test_config_value_no_sub_reads_environ`: Verifies that values are correctly retrieved from `os.environ` in stdio/single-user mode.
    *   `test_config_value_with_sub_reads_store`: Verifies that per-subscriber configurations are prioritized and isolated from the process environment in multi-user mode.
    *   `test_config_value_missing_returns_none`: Ensures `None` is returned for non-existent keys in both modes.

All 33 tests in `tests/test_credential_state.py` passed, and the full suite of 1240 tests also passed. Linting and type checks are clean.

---
*PR created automatically by Jules for task [3193400736777877153](https://jules.google.com/task/3193400736777877153) started by @n24q02m*