### PR TITLE
[FIX] Overly long function: get_impact_radius

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1128,6 +1128,100 @@ class GraphStore:
 
     # --- Impact / Graph traversal ---
 
+    def _get_impact_seeds(
+        self, changed_files: list[str], repo: str, as_of: str
+    ) -> set[str]:
+        """Resolve initial nodes from changed files, filtered by repo."""
+        seed_nodes = self.get_nodes_by_files(changed_files, as_of=as_of)
+        if repo:
+            seed_nodes = [n for n in seed_nodes if self._node_repo_id(n) == repo]
+        return {n.qualified_name for n in seed_nodes}
+
+    def _get_repo_qualified_names(self, repo: str) -> set[str] | None:
+        """Fetch all qualified names belonging to a specific repo."""
+        if not repo:
+            return None
+        cursor = self._conn.execute(
+            "SELECT qualified_name FROM nodes WHERE repo_id = ?",
+            (repo,),
+        )
+        return {r["qualified_name"] for r in cursor}
+
+    def _perform_impact_bfs(
+        self,
+        nxg: nx.DiGraph,
+        seeds: set[str],
+        repo_qns: set[str] | None,
+        max_depth: int,
+        max_nodes: int,
+    ) -> tuple[set[str], bool]:
+        """BFS from seeds to find all impacted nodes within max_depth."""
+        visited: set[str] = set()
+        frontier = seeds.copy()
+        depth = 0
+        impacted: set[str] = set()
+        truncated = False
+
+        while frontier and depth < max_depth:
+            next_frontier: set[str] = set()
+            for qn in frontier:
+                visited.add(qn)
+                if qn in nxg:
+                    # Forward and reverse edges (everything this node affects or depends on)
+                    neighbors = list(nxg.neighbors(qn)) + list(nxg.predecessors(qn))
+                    for neighbor in neighbors:
+                        if neighbor in visited:
+                            continue
+                        if repo_qns is not None and neighbor not in repo_qns:
+                            continue
+                        next_frontier.add(neighbor)
+                        impacted.add(neighbor)
+            # Cap total nodes to prevent resource exhaustion on dense graphs
+            if len(visited) + len(next_frontier) > max_nodes:
+                truncated = True
+                break
+            frontier = next_frontier
+            depth += 1
+
+        return impacted, truncated
+
+    def _resolve_impact_results(
+        self, seeds: set[str], impacted: set[str], repo: str, as_of: str
+    ) -> dict[str, Any]:
+        """Resolve seeds and impacted nodes to full info and collect edges."""
+        # Record total count before any truncation
+        total_impacted = len(impacted - seeds)
+
+        # Resolve to full node info using batch fetch to prevent N+1 queries
+        changed_nodes = self.get_nodes_by_qualified_names(list(seeds), as_of=as_of)
+        impacted_nodes = self.get_nodes_by_qualified_names(
+            list(impacted - seeds), as_of=as_of
+        )
+
+        # Defensive re-filter (qualified_name set above is already
+        # repo-scoped, but get_nodes_by_qualified_names is repo-blind).
+        if repo:
+            changed_nodes = [n for n in changed_nodes if self._node_repo_id(n) == repo]
+            impacted_nodes = [
+                n for n in impacted_nodes if self._node_repo_id(n) == repo
+            ]
+
+        impacted_files = list({n.file_path for n in impacted_nodes})
+
+        # Collect relevant edges in a single batch query
+        relevant_edges = []
+        all_qns = seeds | impacted
+        if all_qns:
+            relevant_edges = self.get_edges_among(all_qns)
+
+        return {
+            "changed_nodes": changed_nodes,
+            "impacted_nodes": impacted_nodes,
+            "impacted_files": impacted_files,
+            "edges": relevant_edges,
+            "total_impacted": total_impacted,
+        }
+
     def get_impact_radius(
         self,
         changed_files: list[str],
@@ -1163,92 +1257,22 @@ class GraphStore:
         nxg = self._build_networkx_graph()
 
         # Seed: all qualified names in changed files (batched to avoid N+1).
-        # When ``repo`` is set, drop seed nodes that don't belong to it.
-        seed_nodes = self.get_nodes_by_files(changed_files, as_of=as_of)
-        if repo:
-            seed_nodes = [n for n in seed_nodes if self._node_repo_id(n) == repo]
-        seeds = {n.qualified_name for n in seed_nodes}
+        seeds = self._get_impact_seeds(changed_files, repo, as_of)
 
         # Pre-compute the set of qualified_names belonging to ``repo`` so
-        # the BFS expansion can prune cross-repo neighbours. Skipped when
-        # ``repo == ""`` to keep the legacy hot path zero-overhead.
-        repo_qns: set[str] | None = None
-        if repo:
-            cursor = self._conn.execute(
-                "SELECT qualified_name FROM nodes WHERE repo_id = ?",
-                (repo,),
-            )
-            repo_qns = {r["qualified_name"] for r in cursor}
+        # the BFS expansion can prune cross-repo neighbours.
+        repo_qns = self._get_repo_qualified_names(repo)
 
         # BFS outward through all edge types
-        visited: set[str] = set()
-        frontier = seeds.copy()
-        depth = 0
-        impacted: set[str] = set()
-        truncated = False
-
-        while frontier and depth < max_depth:
-            next_frontier: set[str] = set()
-            for qn in frontier:
-                visited.add(qn)
-                # Forward edges (things this node affects)
-                if qn in nxg:
-                    for neighbor in nxg.neighbors(qn):
-                        if neighbor in visited:
-                            continue
-                        if repo_qns is not None and neighbor not in repo_qns:
-                            continue
-                        next_frontier.add(neighbor)
-                        impacted.add(neighbor)
-                # Reverse edges (things that depend on this node)
-                if qn in nxg:
-                    for pred in nxg.predecessors(qn):
-                        if pred in visited:
-                            continue
-                        if repo_qns is not None and pred not in repo_qns:
-                            continue
-                        next_frontier.add(pred)
-                        impacted.add(pred)
-            # Cap total nodes to prevent resource exhaustion on dense graphs
-            if len(visited) + len(next_frontier) > max_nodes:
-                truncated = True
-                break
-            frontier = next_frontier
-            depth += 1
-
-        # Record total count before any truncation for the response
-        total_impacted = len(impacted - seeds)
-
-        # Resolve to full node info using batch fetch to prevent N+1 queries
-        changed_nodes = self.get_nodes_by_qualified_names(list(seeds), as_of=as_of)
-        impacted_nodes = self.get_nodes_by_qualified_names(
-            list(impacted - seeds), as_of=as_of
+        impacted, truncated = self._perform_impact_bfs(
+            nxg, seeds, repo_qns, max_depth, max_nodes
         )
 
-        # Defensive re-filter (qualified_name set above is already
-        # repo-scoped, but get_nodes_by_qualified_names is repo-blind).
-        if repo:
-            changed_nodes = [n for n in changed_nodes if self._node_repo_id(n) == repo]
-            impacted_nodes = [
-                n for n in impacted_nodes if self._node_repo_id(n) == repo
-            ]
+        # Resolve to full node info using batch fetch to prevent N+1 queries
+        results = self._resolve_impact_results(seeds, impacted, repo, as_of)
+        results["truncated"] = truncated
 
-        impacted_files = list({n.file_path for n in impacted_nodes})
-
-        # Collect relevant edges in a single batch query
-        relevant_edges = []
-        all_qns = seeds | impacted
-        if all_qns:
-            relevant_edges = self.get_edges_among(all_qns)
-
-        return {
-            "changed_nodes": changed_nodes,
-            "impacted_nodes": impacted_nodes,
-            "impacted_files": impacted_files,
-            "edges": relevant_edges,
-            "truncated": truncated,
-            "total_impacted": total_impacted,
-        }
+        return results
 
     def _node_repo_id(self, node: GraphNode) -> str:
         """Look up a GraphNode's persisted ``repo_id`` (column not on dataclass).


### PR DESCRIPTION
Refactored the get_impact_radius method in src/better_code_review_graph/graph.py by extracting its core logic into four private helper methods: _get_impact_seeds, _get_repo_qualified_names, _perform_impact_bfs, and _resolve_impact_results. This improves readability and maintainability without changing the original BFS impact-radius logic or filtering behavior. All 1237 tests passed.

---
*PR created automatically by Jules for task [2290543909507161094](https://jules.google.com/task/2290543909507161094) started by @n24q02m*