### PR TITLE
[FIX] Unused import: numpy

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -7,6 +7,7 @@ Run as: better-code-review-graph serve
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from importlib.metadata import PackageNotFoundError
@@ -1046,7 +1047,7 @@ def serve_main(repo_root: str | None = None) -> None:
     # no-op cache hit. Cheap (numpy is already a transitive dependency) and
     # backend-agnostic (both local ONNX and the cloud vector paths touch numpy).
     try:
-        import numpy  # noqa: F401
+        importlib.import_module("numpy")
     except ImportError:
         pass
 


### PR DESCRIPTION
Replaced the unused literal `import numpy` with `importlib.import_module("numpy")` in `src/better_code_review_graph/server.py`.

This maintains the intentional "warming" of numpy's C-extensions on the main thread, which is essential for avoiding deadlocks in asyncio/worker-thread environments on Windows (where the first import of a C-extension from a non-main thread can hang if the event loop is running).

By using `importlib.import_module`, we satisfy linting requirements without needing `# noqa: F401` and follow a more robust pattern for intentional side-effect-only imports.

---
*PR created automatically by Jules for task [11100858643595143775](https://jules.google.com/task/11100858643595143775) started by @n24q02m*