### PR TITLE
[FIX] Overly long function: _run_alembic_upgrade

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -280,6 +280,33 @@ class GraphStore:
         Imported lazily so ``alembic`` (and its SQLAlchemy dependency) are
         only loaded when a ``GraphStore`` is actually instantiated.
         """
+        import os
+
+        # Phase 3 Task 1 — early-exit downgrade path.
+        if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
+            self._restore_pre_2_0_backup()
+            return
+
+        cfg, command, ScriptDirectory, CommandError = self._get_alembic_config()
+
+        self._maybe_stamp_legacy_db(cfg, command)
+        self._maybe_backup_before_upgrade(cfg, ScriptDirectory)
+
+        try:
+            command.upgrade(cfg, "head")
+        except CommandError as exc:
+            # Re-raise with a human-readable recovery hint.
+            recorded = self._read_alembic_version()
+            head = ScriptDirectory.from_config(cfg).get_current_head()
+            raise RuntimeError(
+                f"Graph DB at {self.db_path} reports alembic revision "
+                f"{recorded!r} which is not shipped with this version of "
+                f"better-code-review-graph (head={head!r}). Either downgrade "
+                "the package or recreate the DB."
+            ) from exc
+
+    def _get_alembic_config(self):
+        """Initialize Alembic config and return it with needed modules."""
         from alembic import command
         from alembic.config import Config
         from alembic.script import ScriptDirectory
@@ -289,27 +316,10 @@ class GraphStore:
         cfg = Config()
         cfg.set_main_option("script_location", str(migrations_dir))
         cfg.set_main_option("sqlalchemy.url", f"sqlite:///{self.db_path}")
+        return cfg, command, ScriptDirectory, CommandError
 
-        # Phase 3 Task 1 — early-exit downgrade path.
-        #
-        # When the operator sets ``CRG_DOWNGRADE_TO_1_X=1`` we restore
-        # the pre-2.0 backup BEFORE any alembic activity (including
-        # the auto-stamp branch below — stamping a v1.x DB to "002"
-        # is the same idempotent outcome as the restored DB already
-        # being at "002", but we still skip it to avoid touching the
-        # restored file at all).
-        if os.environ.get(_DOWNGRADE_ENV_VAR) == "1":
-            self._restore_pre_2_0_backup()
-            return
-
-        # Detect "legacy DB": pre-existing structural tables but alembic
-        # has not yet recorded a head revision. Two sub-cases:
-        #   1. ``alembic_version`` table is missing entirely.
-        #   2. ``alembic_version`` exists but has no row (an interrupted
-        #      prior run, or a test fixture that touched the DB before
-        #      alembic was wired up).
-        # In both cases we stamp at ``002`` so the baseline ``CREATE
-        # TABLE`` is skipped on the subsequent ``upgrade("head")``.
+    def _maybe_stamp_legacy_db(self, cfg, command):
+        """Detect legacy DB and stamp at 002 if needed."""
         existing = {
             row[0]
             for row in self._conn.execute(
@@ -326,42 +336,12 @@ class GraphStore:
             if needs_stamp:
                 command.stamp(cfg, "002")
 
-        # Phase 3 Task 1 — backup before BREAKING migration crosses the
-        # 005 boundary.  Read the current recorded revision (post-stamp)
-        # and the script-directory head; if the chain crosses 005,
-        # snapshot the SQLite file via ``shutil.copy2`` so the operator
-        # can roll back via ``CRG_DOWNGRADE_TO_1_X=1`` if the BREAKING
-        # migration produces a worse outcome than expected.  Idempotent:
-        # an existing backup is preserved (could be from an earlier
-        # partial run that aborted mid-upgrade — that copy is closer to
-        # the true v1.x state than anything we'd produce now).
+    def _maybe_backup_before_upgrade(self, cfg, ScriptDirectory):
+        """Backup before BREAKING migration crosses 005 boundary."""
         current_rev = self._read_alembic_version()
         target_rev = ScriptDirectory.from_config(cfg).get_current_head()
         if _crosses_breaking_boundary(current_rev, target_rev):
             self._take_pre_2_0_backup()
-
-        try:
-            command.upgrade(cfg, "head")
-        except CommandError as exc:
-            # Most likely cause: ``alembic_version`` references a revision
-            # this package does not ship.  Re-raise with the unknown
-            # revision and the local head spelt out so the operator knows
-            # whether to downgrade the package or recreate the DB.
-            recorded: str | None
-            try:
-                row = self._conn.execute(
-                    "SELECT version_num FROM alembic_version"
-                ).fetchone()
-                recorded = row[0] if row else None
-            except sqlite3.Error:
-                recorded = None
-            head = ScriptDirectory.from_config(cfg).get_current_head()
-            raise RuntimeError(
-                f"Graph DB at {self.db_path} reports alembic revision "
-                f"{recorded!r} which is not shipped with this version of "
-                f"better-code-review-graph (head={head!r}). Either downgrade "
-                "the package or recreate the DB."
-            ) from exc
 
     # ------------------------------------------------------------------
     # Phase 3 Task 1 — backup / restore helpers


### PR DESCRIPTION
Refactored the overly long _run_alembic_upgrade function in src/better_code_review_graph/graph.py by extracting setup, legacy database detection, and breaking boundary backup logic into dedicated helper methods. This improves code readability and maintainability while preserving existing functionality. All tests passed, and formatting/linting checks were completed.

---
*PR created automatically by Jules for task [4086623266739625530](https://jules.google.com/task/4086623266739625530) started by @n24q02m*