### PR TITLE
[FIX] LiteLLM env read fix mentioned in tests

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -241,7 +241,7 @@ def config_value_for_current_request(key: str) -> str | None:
     middleware): reads ``key`` from that user's per-sub bucket
     (``<CRG_DATA_DIR>/subs/<sub>/config.json``) and NOTHING else, so one
     user's API keys / model chain never reach another concurrent user's
-    request. Returns ``None`` if the sub has not configured that key.
+    request. Returns ``""`` (empty string) if the sub has not configured that key, which suppresses fallback to the process environment.
 
     Stdio / single-user HTTP / no-JWT contexts (``_current_sub`` is
     ``None``): falls back to the process environment via ``os.environ.get``,
@@ -256,7 +256,7 @@ def config_value_for_current_request(key: str) -> str | None:
     if sub is None:
         return os.environ.get(key)
     value = read_for_sub(sub).get(key)
-    return value if value else None
+    return value if value is not None else ""
 
 
 def save_credentials(

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -291,7 +291,7 @@ class CloudEmbeddingBackend:
     def name(self) -> str:
         return f"cloud:{self._provider}:{self.model}"
 
-    def _resolve_api_key(self) -> str:
+    def _resolve_api_key(self) -> str | None:
         """Resolve API key for the current provider (request-scoped).
 
         In HTTP multi-user mode the key comes from the bound JWT sub's
@@ -304,12 +304,12 @@ class CloudEmbeddingBackend:
             return self.api_key
         from .credential_state import config_value_for_current_request
 
-        def _cfg(*keys: str) -> str:
+        def _cfg(*keys: str) -> str | None:
             for key in keys:
                 value = config_value_for_current_request(key)
-                if value:
+                if value is not None:
                     return value
-            return ""
+            return None
 
         if self._provider == "jina":
             return _cfg("JINA_AI_API_KEY")
@@ -346,13 +346,15 @@ class CloudEmbeddingBackend:
         if self._provider == "cohere":
             kwargs["input_type"] = "search_document"
 
-        # Normalise empty string to None: mcp_core.llm forwards a non-None
-        # api_key to litellm, which suppresses provider env-var fallback (401).
+        # Pass api_key as-is: None allows litellm to fall back to the process
+        # environment (desired for stdio/single-user mode), while an empty
+        # string (returned for missing keys in multi-user mode) suppresses
+        # fallback to prevent cross-user credential leaks.
         resp = embedding(
             model=self._litellm_model(),
             input=texts,
             api_base=os.getenv("EMBEDDING_API_BASE") or None,
-            api_key=self._resolve_api_key() or None,
+            api_key=self._resolve_api_key(),
             **kwargs,
         )
 

--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -205,13 +205,15 @@ def summarize_node(
     from mcp_core.llm import completion
 
     try:
-        # Normalise empty string to None: mcp_core.llm forwards a non-None
-        # api_key to litellm, which suppresses provider env-var fallback (401).
+        # Pass api_key as-is: None allows litellm to fall back to the process
+        # environment (desired for stdio/single-user mode), while an empty
+        # string (returned for missing keys in multi-user mode) suppresses
+        # fallback to prevent cross-user credential leaks.
         response = completion(
             model=model,
             messages=[{"role": "user", "content": prompt}],
             api_base=os.environ.get("LLM_API_BASE") or None,
-            api_key=api_key or None,
+            api_key=api_key,
         )
     except Exception as exc:
         raise RuntimeError(f"summarize_node failed via {provider}: {exc}") from exc


### PR DESCRIPTION
This PR fixes a potential security leak in multi-user mode where a missing per-user API key would cause LiteLLM to fall back to process-global environment variables. By returning an empty string instead of None for missing keys in multi-user mode and forwarding it explicitly, we ensure that LiteLLM suppresses environment fallback when a specific user has not configured a key, while preserving the intended fallback behavior for stdio/single-user mode.

---
*PR created automatically by Jules for task [9783194685103236360](https://jules.google.com/task/9783194685103236360) started by @n24q02m*