### PR TITLE
fix: document all 7 query-tool actions in AGENTS and CLAUDE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud via the `EMBEDDING_MODELS` chain (litellm passthrough, `mcp_core.llm`; order = fallback, empty = local). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config, security, help, config__open_relay (mcp-core relay helper). Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config, security, help, config__open_relay (mcp-core relay helper). Returns JSON strings.
 
 ## Embedding backends
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX (qwen3-embed, default, zero-config) or cloud via the `EMBEDDING_MODELS` chain (litellm passthrough, `mcp_core.llm`; order = fallback, empty = local). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help, config__open_relay (mcp-core relay helper). Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help, config__open_relay (mcp-core relay helper). Returns JSON strings.
 
 ## Embedding + LLM backends
 

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -197,7 +197,8 @@ def graph(
 
 
 # ---------------------------------------------------------------------------
-# Tool 2: query -- read operations (query, search, impact, large_functions)
+# Tool 2: query -- read operations (query, search, impact, large_functions,
+#         spot_check, renamed_in_diff, diff)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`AGENTS.md` and `CLAUDE.md` described the `query` tool as having 4 actions (`query/search/impact/large_functions`), but the implementation in `src/better_code_review_graph/server.py` dispatches **7**. The `README.md` already lists all 7 correctly.

## Verified against `server.py`

The `query()` `match action` block has 7 `case` arms and the fall-through `valid_actions` list has 7 entries:

`query`, `search`, `impact`, `large_functions`, `spot_check`, `renamed_in_diff`, `diff`

## Change

Docs-only alignment (no behavior change):
- `AGENTS.md` — Server section now lists all 7 query actions.
- `CLAUDE.md` — same.
- `server.py` — the "Tool 2: query" section comment (which understated the action list as 4) now lists all 7.

Ordering matches the existing `README.md` and the `case`-arm order in `server.py`.