### PR TITLE
fix: shorten server.json description to satisfy MCP Registry 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-code-review-graph",
-  "description": "Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase.",
+  "description": "Token-efficient code review knowledge graph: semantic search and call-graph resolution.",
   "repository": {
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"


### PR DESCRIPTION
## Summary
- v3.18.0 STABLE CD failed at "Publish to MCP Registry": server returned 422, `description` length 115 > 100 max.
- Shortened `server.json`'s `description` from 115 to 87 chars, keeping both key capabilities (semantic search, call-graph resolution).

## Test plan
- [x] `python3 -c "import json; json.load(open('server.json'))"` -- valid JSON
- [x] Description length = 87 (<= 100)
- [ ] Re-dispatch STABLE CD after merge; verify "Publish to MCP Registry" job succeeds this time