### PR TITLE
feat: document vertex_express provider option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
 
 - `EMBEDDING_MODELS` -- chain embedding. Empty = local ONNX (qwen3-embed).
 - **Local (default)**: `qwen3-embed` ONNX -- zero-config, ~570MB download on first use, 768-dim MRL truncation
-- API key follows the litellm convention `<PROVIDER>_API_KEY`. The 6 providers the server suggests:
+- API key follows the litellm convention `<PROVIDER>_API_KEY`. The 7 providers the server suggests:
 
   | model prefix | key env var | get it at |
   |---|---|---|
@@ -81,6 +81,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
   | `cohere/` | `COHERE_API_KEY` | dashboard.cohere.com |
   | `xai/` | `XAI_API_KEY` | console.x.ai |
   | `anthropic/` | `ANTHROPIC_API_KEY` | console.anthropic.com |
+  | `vertex_express/` | `GOOGLE_VERTEX_EXPRESS_API_KEY` | cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview |
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
 - Custom endpoint (SSRF-guarded): `EMBEDDING_API_BASE` -- custom OpenAI-compatible base URL for cloud embedding (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
 - `EMBEDDING_MODELS` -- chain embedding. Empty = local ONNX (qwen3-embed).
 - `SUMMARY_MODELS` -- chain summarizer (graph `summarize` action). Empty = summaries disabled.
 - **Local (default)**: `qwen3-embed` ONNX -- zero-config, ~570MB download on first use, 768-dim MRL truncation
-- API key theo convention litellm `<PROVIDER>_API_KEY`. 6 provider servers goi y:
+- API key theo convention litellm `<PROVIDER>_API_KEY`. 7 provider servers goi y:
 
   | model prefix | key env var | get it at |
   |---|---|---|
@@ -84,6 +84,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
   | `cohere/` | `COHERE_API_KEY` | dashboard.cohere.com |
   | `xai/` | `XAI_API_KEY` | console.x.ai |
   | `anthropic/` | `ANTHROPIC_API_KEY` | console.anthropic.com |
+  | `vertex_express/` | `GOOGLE_VERTEX_EXPRESS_API_KEY` | cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview |
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name. Summarizer providers must expose a chat-completion API (Jina/Cohere do not).
 - Custom endpoint (SSRF-guarded): `EMBEDDING_API_BASE` (embedding), `LLM_API_BASE` (summarizer)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ chat-completion API (so Jina and Cohere are embedding-only).
 | `gemini/` | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | <https://aistudio.google.com/apikey> |
 | `openai/` (or bare `text-embedding-*`) | `OPENAI_API_KEY` | <https://platform.openai.com/api-keys> |
 | `cohere/` | `COHERE_API_KEY` | <https://dashboard.cohere.com/api-keys> |
+| `vertex_express/` | `GOOGLE_VERTEX_EXPRESS_API_KEY` | <https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview> |
 
 Any other [litellm provider](https://docs.litellm.ai/docs/providers) works via
 its standard `<PROVIDER>_API_KEY`.


### PR DESCRIPTION
Adds vertex_express/ (GOOGLE_VERTEX_EXPRESS_API_KEY) to provider docs — invariant-9 parity. No model IDs.