### PR TITLE
⚡ Bolt: Optimize SQLite LIKE clause by removing redundant LOWER() calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 **Learning:** Direct SQL execution within a loop structure causes N+1 query patterns, leading to significant performance degradation as the data set grows. In SQLite, this is especially impactful during write-heavy operations like temporal closing.
 
 **Action:** Refactor row-by-row updates into batch operations using `UPDATE ... WHERE ... IN (SELECT value FROM json_each(?))`. This pushes the filtering logic into the database engine and reduces the overhead of multiple `execute()` calls and potential transaction management. Always use `cursor.rowcount` to track affected rows when removing the manual loop counter.
+
+## 2024-07-07 - SQLite LIKE Case-Insensitivity
+**Learning:** SQLite's `LIKE` operator is naturally case-insensitive for ASCII characters. Using `LOWER()` function calls on the operands in a `LIKE` clause adds unnecessary per-row function evaluation overhead during table scans with no change to the query behavior for ASCII text.
+**Action:** When filtering case-insensitively using `LIKE` in SQLite, avoid redundant `LOWER()` calls on the column and the value to improve table scan performance.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1106,8 +1106,10 @@ class GraphStore:
             WHERE (
                 SELECT COUNT(*)
                 FROM json_each(?)
-                WHERE LOWER(nodes.name) LIKE '%' || LOWER(value) || '%'
-                   OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
+                /* ⚡ Bolt: Removed redundant LOWER() calls. SQLite's LIKE is case-insensitive for ASCII by default.
+                   This avoids per-row function evaluation overhead during table scans. */
+                WHERE nodes.name LIKE '%' || value || '%'
+                   OR nodes.qualified_name LIKE '%' || value || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
               AND (? IS NULL OR kind = ?)
               AND (? = '' OR repo_id = ?){frag}


### PR DESCRIPTION
💡 What: Removed redundant `LOWER()` function calls from `nodes.name`, `nodes.qualified_name`, and `value` in the SQLite `LIKE` query inside `GraphStore.search_nodes()`.
🎯 Why: SQLite's `LIKE` operator is natively case-insensitive for ASCII strings. Applying `LOWER()` incurs unnecessary per-row function evaluation overhead during table scans without changing the behavior.
📊 Impact: Avoids redundant string manipulation functions per-row per-value for text column searches. Expected to reduce query latency by avoiding thousands of function evaluations in queries iterating over extensive rows.
🔬 Measurement: Run search queries calling `GraphStore.search_nodes` or the graph tool. The performance profile on large database tables with many rows should yield slightly quicker queries, while functionality remains strictly identical. Tests fully pass.

---
*PR created automatically by Jules for task [16981262164060476268](https://jules.google.com/task/16981262164060476268) started by @n24q02m*