### PR TITLE
fix: fail the release when the computed version already exists on the registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,6 +52,54 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
+      # Dry-run PSR (no_operation_mode => --noop: no commit/tag/push/release) purely to
+      # learn the version it WOULD publish, so the PyPI-collision guard below can fire
+      # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
+      # same prerelease inputs as the real step, run against the same untouched checkout.
+      - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
+        id: dryrun
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          prerelease: ${{ inputs.release_type == 'beta' }}
+          prerelease_token: beta
+          no_operation_mode: true
+
+      # PyPI never allows reusing a version number. Fail early and loudly if the version
+      # PSR intends to publish already exists, before any tag or Release is created --
+      # this turns a silent release freeze (PSR sees a matching tag, sets released=false,
+      # every publish job is skipped) or an opaque upload failure deep in `uv publish`
+      # into one explicit, actionable error.
+      - name: Guard against re-publishing an already-published PyPI version
+        if: steps.dryrun.outputs.released == 'true'
+        env:
+          COMPUTED_VERSION: ${{ steps.dryrun.outputs.version }}
+        run: |
+          set -uo pipefail
+          PKG='better-code-review-graph'
+          URL="https://pypi.org/pypi/${PKG}/${COMPUTED_VERSION}/json"
+          echo "Checking PyPI for ${PKG} ${COMPUTED_VERSION} before semantic-release tags anything..."
+
+          # PyPI normalizes the version in the URL path (e.g. 1.2.3-beta.1 and 1.2.3b1
+          # both resolve to the same release), so PSR's raw version output can be used
+          # directly in the URL.
+          #   200            -> exists         -> COLLISION
+          #   404             -> not found      -> FREE
+          #   anything else  -> network/registry error -> UNKNOWN, never treated as free
+          http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$URL")
+
+          if [ "$http_code" = "200" ]; then
+            echo "::error::Computed release version ${COMPUTED_VERSION} already exists on PyPI as ${PKG}==${COMPUTED_VERSION}. PyPI NEVER allows re-publishing a version number, even one later yanked. This almost always means the git history diverged from what was actually published to PyPI. Do NOT retry the same version: bump PAST the already-published range (higher than any version ever published) and dispatch the release again."
+            exit 1
+          fi
+
+          if [ "$http_code" = "404" ]; then
+            echo "OK: ${PKG}==${COMPUTED_VERSION} is not on PyPI (404) -- safe to publish."
+            exit 0
+          fi
+
+          echo "::error::Could not verify whether ${PKG}==${COMPUTED_VERSION} exists on PyPI: unexpected HTTP status ${http_code} from ${URL} (likely a transient network/registry error, rate limit, or outage). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable."
+          exit 1
+
       - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
         id: release
         with:


### PR DESCRIPTION
## Problem

PyPI never allows reusing a version number. If this repo's git history is ever rewritten away from what was published, python-semantic-release (PSR) can later compute an already-published version. Two bad outcomes follow:

- **Silent freeze:** if a matching git tag exists, PSR reports the version "already released", sets `released=false`, and every downstream publish job (`publish-pypi`, Docker, MCP Registry, marketplace sync) is silently **skipped**. Nobody notices.
- **Opaque failure:** if no tag exists, `uv publish` dies with an opaque 409 deep inside the pipeline, after PSR has already created a git tag and GitHub Release, leaving a messy half-done state.

Neither is acceptable. This adds a loud, early, actionable failure instead.

## Change (`.github/workflows/cd.yml` only)

Placed in the `release` job, **before** the real semantic-release step, so it fires before any tag or Release is created:

1. **Dry-run step** (`id: dryrun`) -- the exact same pinned PSR action (`350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0`) with `no_operation_mode: true` (`--noop`: no commit/tag/push/release) and the same `prerelease`/`prerelease_token` inputs as the real `id: release` step. This repo's real step passes no `config_file`, so the dry-run doesn't either -- both compute the version identically against the same untouched checkout. No new action or dependency.
2. **Guard step** -- gated on `steps.dryrun.outputs.released == 'true'` (mirrors the existing `needs.release.outputs.released == 'true'` gate on `publish-pypi`, so a "no releasable commits" dispatch doesn't false-fail on the current already-published version). Queries PyPI for `better-code-review-graph==<computed version>` (name verbatim from `pyproject.toml` `[project].name`) and classifies:

   | `curl -o /dev/null -w '%{http_code}'` | meaning | action |
   |---|---|---|
   | `200` | **COLLISION** -- version exists | `::error::` + `exit 1` |
   | `404` | **FREE** -- version/package absent | proceed |
   | anything else | **UNKNOWN** -- network/registry error | `::error::` + `exit 1`, never treated as free |

   I confirmed myself (not just asserted) that PyPI normalizes the version string in the URL path: `https://pypi.org/pypi/qwen3-embed/1.12.1-beta.1/json` and `https://pypi.org/pypi/qwen3-embed/1.12.1b1/json` both return `200` for the same release, so PSR's raw semver `version` output can go straight into the URL without reformatting.

A transient error is deliberately treated as fatal rather than "free" -- reading it as free would let a real collision slip through, which is worse than the bug this guard prevents.

The `release` job's outputs (`released`/`tag`/`version`/`is_prerelease`) still come from the real `id: release` step and are unchanged, so `publish-pypi`, `build-docker`, `merge-docker`, `publish-mcp-registry`, `sync-marketplace` consume them exactly as before.

## Verification

YAML parses:
```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/cd.yml')); print('YAML OK: parsed successfully')"
YAML OK: parsed successfully
```

Guard's shell classification logic exercised live against the real PyPI registry, using the exact `curl` invocation from the guard, three ways:

```
CASE 1  version 3.19.1 (published)   -> http=200 -> CLASSIFICATION: COLLISION (fail, exit 1)
CASE 2  version 99.99.99 (unused)    -> http=404 -> CLASSIFICATION: FREE (proceed, exit 0)
CASE 3  forced-unreachable endpoint  -> http=000 -> CLASSIFICATION: UNKNOWN (fail, exit 1)
```

Existing versions/PyPI state discovered via:
```
curl -s https://pypi.org/pypi/better-code-review-graph/json | grep -oE '"[0-9][^"]*"' ...
```

Commit created with pre-commit hooks running normally (gitleaks, check-yaml, enforce-commit, preserve-diacritics all passed; the Python-only hooks -- ruff/ty/pytest -- correctly skip a YAML-only change).

Do not merge.