### PR TITLE
feat: mount shared cli builder with graph build/embed subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "qwen3-embed>=1.12.1",
     "httpx",
     "pydantic-settings",
-    "n24q02m-mcp-core[llm]>=1.18.2,<2",
+    "n24q02m-mcp-core[llm]>=1.19.0b4,<2",
     # litellm security floor (transitive via mcp-core[llm]). 1.83.x-1.87.x carry 4
     # advisories in litellm's PROXY server: GHSA-r75f-5x8p-qvmc (SQLi in proxy key
     # verify), GHSA-xqmj-j6mv-4862 (SSTI /prompts/test), GHSA-v4p8-mg3p-g94g (cmd-exec

--- a/src/better_code_review_graph/cli.py
+++ b/src/better_code_review_graph/cli.py
@@ -1,10 +1,79 @@
-"""CLI entry point -- starts MCP server."""
+"""Console-script entry: mounts the shared mcp_core CLI builder.
+
+Bare invocation and any leading-dash argv (e.g. --http) start the server
+exactly as before; a leading positional argv[0] routes to a subcommand
+(``graph build|embed``) instead.
+"""
 
 from __future__ import annotations
 
+import argparse
+import json
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 
-def main() -> None:
-    """Main CLI entry point -- starts the MCP server."""
+
+def _version() -> str:
+    """Resolve the installed package version, falling back to 'dev'."""
+    try:
+        return pkg_version("better-code-review-graph")
+    except PackageNotFoundError:
+        return "dev"
+
+
+def _serve(argv: list[str]) -> int | None:
     from .server import serve_main
 
     serve_main()
+    return 0
+
+
+def _configure_graph(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "graph_action", choices=["build", "embed"], help="Graph action to run"
+    )
+    p.add_argument(
+        "--full-rebuild",
+        action="store_true",
+        default=False,
+        help="Re-parse every file (build only; ignored for embed)",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path (auto-detected if omitted)",
+    )
+    p.add_argument(
+        "--base",
+        default="HEAD~1",
+        help="Git ref for incremental diff (build only; ignored for embed)",
+    )
+
+
+def _handle_graph(args: argparse.Namespace) -> int:
+    if args.graph_action == "build":
+        from .tools import build_or_update_graph
+
+        result = build_or_update_graph(
+            full_rebuild=args.full_rebuild,
+            repo_root=args.repo_root,
+            base=args.base,
+        )
+    else:
+        from .tools import embed_graph
+
+        result = embed_graph(repo_root=args.repo_root)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 1 if "error" in result else 0
+
+
+def main() -> int:
+    from mcp_core import build_cli
+
+    return build_cli(
+        "better-code-review-graph",
+        serve=_serve,
+        extra={"graph": (_configure_graph, _handle_graph)},
+        version=_version(),
+    )(None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,24 +1,43 @@
-"""Tests for the CLI module (cli.py) -- pure MCP server entry."""
+"""Tests for the CLI module (cli.py) -- shared mcp_core CLI builder mount."""
 
 from __future__ import annotations
 
 import os
+import sys
 from unittest.mock import patch
+
+import pytest
 
 from better_code_review_graph.cli import main
 
 
-class TestMainCLI:
+class TestServeDispatch:
     def test_starts_server(self):
-        with patch("better_code_review_graph.server.serve_main") as mock_serve:
-            main()
-            mock_serve.assert_called_once()
+        with (
+            patch.object(sys, "argv", ["better-code-review-graph"]),
+            patch("better_code_review_graph.server.serve_main") as mock_serve,
+        ):
+            rc = main()
+
+        mock_serve.assert_called_once()
+        assert rc == 0
+
+    def test_http_flag_passes_through_argv_unchanged(self):
+        with (
+            patch.object(sys, "argv", ["better-code-review-graph", "--http"]),
+            patch("better_code_review_graph.server.serve_main") as mock_serve,
+        ):
+            rc = main()
+
+        mock_serve.assert_called_once()
+        assert rc == 0
 
     def test_main_runs_stdio_directly(self):
         """serve_main(stdio) invokes FastMCP stdio directly (no bridge layer)."""
         from better_code_review_graph import server as server_module
 
         with (
+            patch.object(sys, "argv", ["better-code-review-graph"]),
             patch.object(server_module.mcp, "run") as mock_run,
             patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
         ):
@@ -27,6 +46,7 @@ class TestMainCLI:
 
     def test_main_continues_on_relay_error(self):
         with (
+            patch.object(sys, "argv", ["better-code-review-graph"]),
             patch(
                 "better_code_review_graph.credential_state.resolve_credential_state",
                 side_effect=Exception("relay broken"),
@@ -38,3 +58,106 @@ class TestMainCLI:
                 main()
             except Exception:
                 pass
+
+
+class TestGraphSubcommand:
+    """`better-code-review-graph graph build|embed` -- lazy tools.py calls."""
+
+    def test_build_passes_args_and_prints_json(self, capsys):
+        result = {"status": "ok", "build_type": "full", "files_parsed": 3}
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["better-code-review-graph", "graph", "build", "--full-rebuild"],
+            ),
+            patch(
+                "better_code_review_graph.tools.build_or_update_graph",
+                return_value=result,
+            ) as mock_build,
+        ):
+            rc = main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=True, repo_root=None, base="HEAD~1"
+        )
+        assert rc == 0
+        assert '"status": "ok"' in capsys.readouterr().out
+
+    def test_build_incremental_default_args(self):
+        result = {"status": "ok", "build_type": "incremental"}
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "build",
+                    "--repo-root",
+                    "/tmp/repo",
+                    "--base",
+                    "main",
+                ],
+            ),
+            patch(
+                "better_code_review_graph.tools.build_or_update_graph",
+                return_value=result,
+            ) as mock_build,
+        ):
+            rc = main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=False, repo_root="/tmp/repo", base="main"
+        )
+        assert rc == 0
+
+    def test_build_error_status_returns_nonzero(self, capsys):
+        result = {"status": "error", "error": "boom"}
+        with (
+            patch.object(sys, "argv", ["better-code-review-graph", "graph", "build"]),
+            patch(
+                "better_code_review_graph.tools.build_or_update_graph",
+                return_value=result,
+            ),
+        ):
+            rc = main()
+
+        assert rc == 1
+        assert "boom" in capsys.readouterr().out
+
+    def test_embed_passes_repo_root_and_prints_json(self, capsys):
+        result = {
+            "status": "ok",
+            "newly_embedded": 5,
+            "total_embeddings": 42,
+            "backend": "local",
+        }
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "embed",
+                    "--repo-root",
+                    "/tmp/repo",
+                ],
+            ),
+            patch(
+                "better_code_review_graph.tools.embed_graph", return_value=result
+            ) as mock_embed,
+        ):
+            rc = main()
+
+        mock_embed.assert_called_once_with(repo_root="/tmp/repo")
+        assert rc == 0
+        assert '"backend": "local"' in capsys.readouterr().out
+
+    def test_unknown_graph_action_exits_2(self):
+        with patch.object(sys, "argv", ["better-code-review-graph", "graph", "bogus"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.91.0" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b4,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.2"
+version = "1.19.0b4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1160,9 +1160,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/de/0e08cc5b07e1818d9028b3ea9da7e6852ffd14bc3893143e20c4eb3bdf85/n24q02m_mcp_core-1.18.2.tar.gz", hash = "sha256:0ea9e06c89fc8427c175cad14121b68ad9f8e4a2e9be03e5fa0beb62382d3d19", size = 305617, upload-time = "2026-07-05T13:09:09.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/94/4a0f9d5407080cf82cc96d666ea9ec60fc4f34e2db9421181cc71cf39eee/n24q02m_mcp_core-1.19.0b4.tar.gz", hash = "sha256:37a9895b2dad090b1299642d812b5ebf31a3fcb884bf825355edfa1f142d6c58", size = 317619, upload-time = "2026-07-11T07:13:12.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/22/462bc0faebcd9f322cd4fff96bd0fb6bcc0464fb994836c97c2af59505d3/n24q02m_mcp_core-1.18.2-py3-none-any.whl", hash = "sha256:5a26acaa7d57267e5b7d42a1c4d1367ac33a3b27346db995e1cc982f77e01262", size = 170061, upload-time = "2026-07-05T13:09:08.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f5/c979129112a73c433559be78d613c6ec989f5e11423e9257b51bcbdc7c47/n24q02m_mcp_core-1.19.0b4-py3-none-any.whl", hash = "sha256:65cb2060b37d3d726ff573509b6ff443812dc71d44654475b38c1c0840e6752f", size = 176888, upload-time = "2026-07-11T07:13:11.319Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## S6 / WS-B4 (crg half)

- `cli.py` (was a 9-line launcher) now mounts `mcp_core.build_cli`: bare/`--http` → `serve_main()` byte-identically (verified across 3 layers); new `graph build|embed` subcommand with `--full-rebuild/--repo-root/--base`, lazy-importing `build_or_update_graph`/`embed_graph` — CLI operator path for the artifact-portability plan (graph build on CI runner, import on laptop later).
- rc mapping mirrors the real tools.py contract (`status: error` → rc 1); JSON to stdout.
- Pin bump `n24q02m-mcp-core>=1.19.0b4,<2` (arg-spec tuple support).

Evidence: full suite pass, coverage 95.49% (gate 95), ruff/ty/pre-commit clean; task-reviewed (Approved — rc verified against tools.py source, not assumed).