### PR TITLE
feat: return structured content from domain tools

### DIFF
--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -12,6 +12,7 @@ import os
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from importlib.resources import files
+from typing import Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -121,7 +122,7 @@ def graph(
     output_path: str | None = None,
     max_nodes: int = 500,
     roots: list[str] | None = None,
-) -> str:
+) -> dict[str, Any]:
     """Build, update, and manage the code knowledge graph.
 
     Actions (required params -> optional):
@@ -145,36 +146,27 @@ def graph(
     """
     match action:
         case "build":
-            return _json(
-                build_or_update_graph(
-                    full_rebuild=full_rebuild,
-                    repo_root=repo_root,
-                    base=base,
-                    roots=roots,
-                )
+            return build_or_update_graph(
+                full_rebuild=full_rebuild,
+                repo_root=repo_root,
+                base=base,
+                roots=roots,
             )
         case "update":
-            return _json(
-                build_or_update_graph(
-                    full_rebuild=False, repo_root=repo_root, base=base
-                )
+            return build_or_update_graph(
+                full_rebuild=False, repo_root=repo_root, base=base
             )
         case "stats":
-            return _json(list_graph_stats(repo_root=repo_root))
+            return list_graph_stats(repo_root=repo_root)
         case "embed":
             result = embed_graph(repo_root=repo_root)
-            result = _maybe_include_setup_hint(result)
-            return _json(result)
+            return _maybe_include_setup_hint(result)
         case "export":
-            return _json(
-                export_graph_dispatch(
-                    repo_root=repo_root, format=format, output_path=output_path
-                )
+            return export_graph_dispatch(
+                repo_root=repo_root, format=format, output_path=output_path
             )
         case "summarize":
-            return _json(
-                summarize_graph_dispatch(repo_root=repo_root, max_nodes=max_nodes)
-            )
+            return summarize_graph_dispatch(repo_root=repo_root, max_nodes=max_nodes)
         case _:
             import difflib
 
@@ -188,12 +180,10 @@ def graph(
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            return {
+                "error": f"Unknown action '{action}'.{suggestion}",
+                "valid_actions": valid_actions,
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +241,7 @@ def query(
     as_of: str = "",
     from_sha: str = "",
     to_sha: str = "",
-) -> str:
+) -> dict[str, Any]:
     """Query the code knowledge graph for relationships, search, and impact analysis.
 
     Actions (required params -> optional):
@@ -273,36 +263,32 @@ def query(
     match action:
         case "query":
             if not pattern:
-                return _json(
-                    {
-                        "error": "pattern is required for query action",
-                        "valid_patterns": [
-                            "callers_of",
-                            "callees_of",
-                            "imports_of",
-                            "importers_of",
-                            "children_of",
-                            "tests_for",
-                            "inheritors_of",
-                            "file_summary",
-                        ],
-                    }
-                )
+                return {
+                    "error": "pattern is required for query action",
+                    "valid_patterns": [
+                        "callers_of",
+                        "callees_of",
+                        "imports_of",
+                        "importers_of",
+                        "children_of",
+                        "tests_for",
+                        "inheritors_of",
+                        "file_summary",
+                    ],
+                }
             if not target:
-                return _json({"error": "target is required for query action"})
-            return _json(
-                query_graph(
-                    pattern=pattern,
-                    target=target,
-                    repo_root=repo_root,
-                    languages=languages,
-                    repo=repo,
-                    as_of=as_of,
-                )
+                return {"error": "target is required for query action"}
+            return query_graph(
+                pattern=pattern,
+                target=target,
+                repo_root=repo_root,
+                languages=languages,
+                repo=repo,
+                as_of=as_of,
             )
         case "search":
             if not search_query:
-                return _json({"error": "search_query is required for search action"})
+                return {"error": "search_query is required for search action"}
             result = semantic_search_nodes(
                 query=search_query,
                 kind=kind,
@@ -311,56 +297,45 @@ def query(
                 repo=repo,
                 as_of=as_of,
             )
-            result = _maybe_include_setup_hint(result)
-            return _json(result)
+            return _maybe_include_setup_hint(result)
         case "impact":
-            return _json(
-                get_impact_radius(
-                    changed_files=changed_files,
-                    max_depth=max_depth,
-                    max_results=max_results,
-                    repo_root=repo_root,
-                    base=base,
-                    max_payload_bytes=max_payload_bytes,
-                    repo=repo,
-                    as_of=as_of,
-                )
+            return get_impact_radius(
+                changed_files=changed_files,
+                max_depth=max_depth,
+                max_results=max_results,
+                repo_root=repo_root,
+                base=base,
+                max_payload_bytes=max_payload_bytes,
+                repo=repo,
+                as_of=as_of,
             )
         case "large_functions":
-            return _json(
-                find_large_functions(
-                    min_lines=min_lines,
-                    kind=kind,
-                    file_path_pattern=file_path_pattern,
-                    limit=limit,
-                    repo_root=repo_root,
-                    repo=repo,
-                )
+            return find_large_functions(
+                min_lines=min_lines,
+                kind=kind,
+                file_path_pattern=file_path_pattern,
+                limit=limit,
+                repo_root=repo_root,
+                repo=repo,
             )
         case "spot_check":
-            return _json(
-                spot_check_last_callers(
-                    n=n,
-                    repo_root=repo_root,
-                    context_lines=context_lines,
-                )
+            return spot_check_last_callers(
+                n=n,
+                repo_root=repo_root,
+                context_lines=context_lines,
             )
         case "renamed_in_diff":
-            return _json(
-                renamed_in_diff(
-                    base=base,
-                    changed_files=changed_files,
-                    repo_root=repo_root,
-                )
+            return renamed_in_diff(
+                base=base,
+                changed_files=changed_files,
+                repo_root=repo_root,
             )
         case "diff":
-            return _json(
-                diff_graph(
-                    repo_root=repo_root,
-                    from_sha=from_sha,
-                    to_sha=to_sha,
-                    repo=repo,
-                )
+            return diff_graph(
+                repo_root=repo_root,
+                from_sha=from_sha,
+                to_sha=to_sha,
+                repo=repo,
             )
         case _:
             import difflib
@@ -376,12 +351,10 @@ def query(
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            return {
+                "error": f"Unknown action '{action}'.{suggestion}",
+                "valid_actions": valid_actions,
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +396,7 @@ def review(
     from_sha: str = "",
     to_sha: str = "",
     show_line_shifts: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Generate focused review context for code changes.
 
     Actions:
@@ -467,27 +440,23 @@ def review(
     """
     match action:
         case "context":
-            return _json(
-                get_review_context(
-                    changed_files=changed_files,
-                    max_depth=max_depth,
-                    include_source=include_source,
-                    max_lines_per_file=max_lines_per_file,
-                    repo_root=repo_root,
-                    base=base,
-                    languages=languages,
-                    repo=repo,
-                )
+            return get_review_context(
+                changed_files=changed_files,
+                max_depth=max_depth,
+                include_source=include_source,
+                max_lines_per_file=max_lines_per_file,
+                repo_root=repo_root,
+                base=base,
+                languages=languages,
+                repo=repo,
             )
         case "delta":
-            return _json(
-                review_delta(
-                    repo_root=repo_root,
-                    from_sha=from_sha,
-                    to_sha=to_sha,
-                    show_line_shifts=show_line_shifts,
-                    repo=repo,
-                )
+            return review_delta(
+                repo_root=repo_root,
+                from_sha=from_sha,
+                to_sha=to_sha,
+                show_line_shifts=show_line_shifts,
+                repo=repo,
             )
         case _:
             import difflib
@@ -495,12 +464,10 @@ def review(
             valid_actions = ["context", "delta"]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            return {
+                "error": f"Unknown action '{action}'.{suggestion}",
+                "valid_actions": valid_actions,
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -532,7 +499,7 @@ async def config(
     value: str | None = None,
     repo_root: str | None = None,
     force: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Server configuration, status, and credential setup.
 
     Config actions:
@@ -552,14 +519,12 @@ async def config(
             return _config_status(repo_root)
         case "set":
             if not key:
-                return _json(
-                    {
-                        "error": "key is required for set action",
-                        "valid_keys": ["log_level"],
-                    }
-                )
+                return {
+                    "error": "key is required for set action",
+                    "valid_keys": ["log_level"],
+                }
             if value is None:
-                return _json({"error": "value is required for set action"})
+                return {"error": "value is required for set action"}
             return _config_set(key, value)
         case "cache_clear":
             return _config_cache_clear(repo_root)
@@ -583,48 +548,40 @@ async def config(
             if _providers and _state != "configured":
                 _state = "configured"
 
-            return _json(
-                {
-                    "state": _state,
-                    "setup_url": _cs.get_setup_url(),
-                    "cloud_keys_in_env": _env_keys,
-                    "providers_configured": _providers,
-                }
-            )
+            return {
+                "state": _state,
+                "setup_url": _cs.get_setup_url(),
+                "cloud_keys_in_env": _env_keys,
+                "providers_configured": _providers,
+            }
         case "setup_start":
             from .credential_state import CredentialState, get_state
 
             if get_state() == CredentialState.CONFIGURED and not force:
-                return _json(
-                    {
-                        "status": "already_configured",
-                        "message": "Already configured. Use force=true to reconfigure.",
-                    }
-                )
+                return {
+                    "status": "already_configured",
+                    "message": "Already configured. Use force=true to reconfigure.",
+                }
             # In stdio mode (default after spec 2026-05-01) the server reads
             # API keys from env vars only; the browser-based relay form is
             # served by the HTTP-mode entry point at <PUBLIC_URL>/authorize.
             public_url = os.environ.get("PUBLIC_URL")
             if public_url:
                 url = f"{public_url.rstrip('/')}/authorize"
-                return _json(
-                    {
-                        "status": "setup_started",
-                        "setup_url": url,
-                        "message": "Open this URL to configure API keys.",
-                    }
-                )
-            return _json(
-                {
-                    "status": "stdio_mode",
-                    "message": (
-                        "Stdio mode reads API keys from env vars only. "
-                        "Set GEMINI_API_KEY / OPENAI_API_KEY / JINA_AI_API_KEY / "
-                        "COHERE_API_KEY in the plugin config, or switch to HTTP "
-                        "mode to use the browser-based setup form."
-                    ),
+                return {
+                    "status": "setup_started",
+                    "setup_url": url,
+                    "message": "Open this URL to configure API keys.",
                 }
-            )
+            return {
+                "status": "stdio_mode",
+                "message": (
+                    "Stdio mode reads API keys from env vars only. "
+                    "Set GEMINI_API_KEY / OPENAI_API_KEY / JINA_AI_API_KEY / "
+                    "COHERE_API_KEY in the plugin config, or switch to HTTP "
+                    "mode to use the browser-based setup form."
+                ),
+            }
         case "setup_skip":
             from mcp_core import set_local_mode
 
@@ -632,22 +589,18 @@ async def config(
 
             set_local_mode(SERVER_NAME)
             set_state(CredentialState.LOCAL)
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Local mode set. Relay will not trigger on restart.",
-                }
-            )
+            return {
+                "status": "ok",
+                "message": "Local mode set. Relay will not trigger on restart.",
+            }
         case "setup_reset":
             from .credential_state import reset_state
 
             reset_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "message": "Credentials cleared. Next tool call will offer setup.",
-                }
-            )
+            return {
+                "status": "ok",
+                "message": "Credentials cleared. Next tool call will offer setup.",
+            }
         case "setup_complete":
             from .credential_state import (
                 get_state as _get_state,
@@ -658,13 +611,11 @@ async def config(
 
             resolve_credential_state()
             state = _get_state()
-            return _json(
-                {
-                    "status": "ok",
-                    "state": state.value,
-                    "message": "Credential state refreshed.",
-                }
-            )
+            return {
+                "status": "ok",
+                "state": state.value,
+                "message": "Credential state refreshed.",
+            }
         case _:
             import difflib
 
@@ -680,16 +631,14 @@ async def config(
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            return {
+                "error": f"Unknown action '{action}'.{suggestion}",
+                "valid_actions": valid_actions,
+            }
 
 
-def _config_status(repo_root: str | None) -> str:
-    """Return server status as JSON."""
+def _config_status(repo_root: str | None) -> dict[str, Any]:
+    """Return server status."""
     from .tools import _get_store
 
     version = _pkg_version
@@ -710,66 +659,60 @@ def _config_status(repo_root: str | None) -> str:
             finally:
                 emb_store.close()
 
-            return _json(
-                {
-                    "status": "ok",
-                    "version": version,
-                    "graph_path": str(db_path),
-                    "embedding_backend": resolve_backend(),
-                    "total_nodes": stats.total_nodes,
-                    "total_edges": stats.total_edges,
-                    "files_count": stats.files_count,
-                    "languages": stats.languages,
-                    "embeddings_count": emb_count,
-                    "last_updated": stats.last_updated,
-                }
-            )
+            return {
+                "status": "ok",
+                "version": version,
+                "graph_path": str(db_path),
+                "embedding_backend": resolve_backend(),
+                "total_nodes": stats.total_nodes,
+                "total_edges": stats.total_edges,
+                "files_count": stats.files_count,
+                "languages": stats.languages,
+                "embeddings_count": emb_count,
+                "last_updated": stats.last_updated,
+            }
         finally:
             store.close()
     except (RuntimeError, ValueError):
-        return _json(
-            {
-                "status": "ok",
-                "version": version,
-                "graph_path": None,
-                "embedding_backend": resolve_backend(),
-                "total_nodes": 0,
-                "total_edges": 0,
-                "message": "No graph found. Run graph action=build first.",
-            }
-        )
+        return {
+            "status": "ok",
+            "version": version,
+            "graph_path": None,
+            "embedding_backend": resolve_backend(),
+            "total_nodes": 0,
+            "total_edges": 0,
+            "message": "No graph found. Run graph action=build first.",
+        }
 
 
-def _config_set(key: str, value: str) -> str:
+def _config_set(key: str, value: str) -> dict[str, Any]:
     """Update a runtime setting."""
     import logging
 
     valid_keys = {"log_level"}
     if key not in valid_keys:
-        return _json({"error": f"Invalid key: {key}", "valid_keys": sorted(valid_keys)})
+        return {"error": f"Invalid key: {key}", "valid_keys": sorted(valid_keys)}
 
     if key == "log_level":
         level = value.upper()
         if level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-            return _json(
-                {
-                    "error": f"Invalid log level: {value}",
-                    "valid_levels": [
-                        "DEBUG",
-                        "INFO",
-                        "WARNING",
-                        "ERROR",
-                        "CRITICAL",
-                    ],
-                }
-            )
+            return {
+                "error": f"Invalid log level: {value}",
+                "valid_levels": [
+                    "DEBUG",
+                    "INFO",
+                    "WARNING",
+                    "ERROR",
+                    "CRITICAL",
+                ],
+            }
         logging.getLogger().setLevel(level)
-        return _json({"status": "updated", "key": key, "value": level})
+        return {"status": "updated", "key": key, "value": level}
 
-    return _json({"error": f"Unhandled key: {key}"})  # pragma: no cover
+    return {"error": f"Unhandled key: {key}"}  # pragma: no cover
 
 
-def _config_cache_clear(repo_root: str | None) -> str:
+def _config_cache_clear(repo_root: str | None) -> dict[str, Any]:
     """Clear all embeddings from the graph."""
     from .tools import _get_store
 
@@ -783,18 +726,16 @@ def _config_cache_clear(repo_root: str | None) -> str:
             try:
                 count_before = emb_store.count()
                 emb_store.clear()
-                return _json(
-                    {
-                        "status": "cache cleared",
-                        "embeddings_removed": count_before,
-                    }
-                )
+                return {
+                    "status": "cache cleared",
+                    "embeddings_removed": count_before,
+                }
             finally:
                 emb_store.close()
         finally:
             store.close()
     except (RuntimeError, ValueError):
-        return _json({"status": "cache cleared", "embeddings_removed": 0})
+        return {"status": "cache cleared", "embeddings_removed": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -897,7 +838,7 @@ def security(
     format: str = "json",
     rule_id: str | None = None,
     remove: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Security scanning tool: scan / report / suppress / rule_list.
 
     Actions (required params -> optional):
@@ -914,27 +855,25 @@ def security(
     """
     match action:
         case "scan":
-            return _json(security_scan(repo_root=repo_root, engine=engine))
+            return security_scan(repo_root=repo_root, engine=engine)
         case "report":
-            return _json(security_report(repo_root=repo_root, format=format))
+            return security_report(repo_root=repo_root, format=format)
         case "suppress":
-            return _json(
-                security_suppress(repo_root=repo_root, rule_id=rule_id, remove=remove)
+            return security_suppress(
+                repo_root=repo_root, rule_id=rule_id, remove=remove
             )
         case "rule_list":
-            return _json(security_rule_list(engine=engine))
+            return security_rule_list(engine=engine)
         case _:
             import difflib
 
             valid_actions = ["report", "rule_list", "scan", "suppress"]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            return {
+                "error": f"Unknown action '{action}'.{suggestion}",
+                "valid_actions": valid_actions,
+            }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_as_of_diff.py
+++ b/tests/test_as_of_diff.py
@@ -23,7 +23,6 @@ suitable for these tests — it loses history by design.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -355,13 +354,12 @@ def test_server_query_diff_action_dispatches(
     idx_b.upsert_node(_make_function_node(name="brand_new"))
     store.close()
 
-    raw = query_tool(
+    payload = query_tool(
         action="diff",
         from_sha=_SHA_A,
         to_sha=_SHA_B,
         repo_root=str(workspace),
     )
-    payload = json.loads(raw)
     assert payload["from_sha"] == _SHA_A
     assert payload["to_sha"] == _SHA_B
     added_qns = [r["qualified_name"] for r in payload["added"]]

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -229,8 +229,8 @@ class TestConfigStatusVersionFallback:
         from better_code_review_graph.server import config
 
         with patch("better_code_review_graph.server._config_status") as mock_status:
-            mock_status.return_value = json.dumps({"status": "ok", "version": "dev"})
-            result = json.loads(await config(action="status"))
+            mock_status.return_value = {"status": "ok", "version": "dev"}
+            result = await config(action="status")
             assert result["version"] == "dev"
 
     def test_version_fallback_direct(self):
@@ -238,7 +238,7 @@ class TestConfigStatusVersionFallback:
         from better_code_review_graph.server import _config_status
 
         with patch("better_code_review_graph.server._pkg_version", "dev"):
-            result = json.loads(_config_status(repo_root=None))
+            result = _config_status(repo_root=None)
             assert result["version"] == "dev"
 
 
@@ -564,9 +564,7 @@ class TestConfigCacheClearFallback:
         from better_code_review_graph.server import config
 
         # Use a nonexistent path that will trigger RuntimeError
-        result = json.loads(
-            await config(action="cache_clear", repo_root="/nonexistent/path/xyz")
-        )
+        result = await config(action="cache_clear", repo_root="/nonexistent/path/xyz")
         assert result["status"] == "cache cleared"
         assert result["embeddings_removed"] == 0
 
@@ -581,9 +579,7 @@ class TestConfigStatusFallback:
         """Cover lines 381-382: _config_status handles RuntimeError."""
         from better_code_review_graph.server import config
 
-        result = json.loads(
-            await config(action="status", repo_root="/nonexistent/path/xyz")
-        )
+        result = await config(action="status", repo_root="/nonexistent/path/xyz")
         # Should return ok with 0 nodes (no graph found)
         assert result["status"] == "ok"
         assert result.get("total_nodes", 0) == 0

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -9,7 +9,6 @@ and always includes providers_configured in the response.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -22,8 +21,7 @@ def _call_config_setup_status_sync() -> dict[str, Any]:
 
     from better_code_review_graph.server import config
 
-    raw = asyncio.run(config(action="setup_status"))
-    return json.loads(raw)
+    return asyncio.run(config(action="setup_status"))
 
 
 class TestSetupStatusLiveDerivedState:

--- a/tests/test_review_delta_line_shifts.py
+++ b/tests/test_review_delta_line_shifts.py
@@ -28,7 +28,6 @@ so the tests do not depend on the parser end-to-end.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -362,14 +361,13 @@ def test_server_review_tool_dispatches_show_line_shifts(
     )
     store.close()
 
-    raw = review_tool(
+    payload = review_tool(
         action="delta",
         repo_root=str(workspace),
         from_sha=_SHA_A,
         to_sha=_SHA_B,
         show_line_shifts=True,
     )
-    payload = json.loads(raw)
     assert "diff" in payload
     assert "line_shifts" in payload
     qns = [s["qualified_name"] for s in payload["line_shifts"]]

--- a/tests/test_security_tool.py
+++ b/tests/test_security_tool.py
@@ -371,8 +371,7 @@ def test_server_security_tool_dispatches_scan(tmp_path: Path) -> None:
     from better_code_review_graph.server import security as security_tool
 
     root, _ = _make_repo_with_node(tmp_path)
-    raw = security_tool(action="scan", repo_root=str(root))
-    payload = json.loads(raw)
+    payload = security_tool(action="scan", repo_root=str(root))
     assert payload["engine"] == "heuristic"
     assert payload["total"] >= 1
 
@@ -382,8 +381,7 @@ def test_server_security_tool_dispatches_report(tmp_path: Path) -> None:
 
     root, _ = _make_repo_with_node(tmp_path)
     security_scan(repo_root=str(root))
-    sarif_raw = security_tool(action="report", repo_root=str(root), format="sarif")
-    sarif = json.loads(sarif_raw)
+    sarif = security_tool(action="report", repo_root=str(root), format="sarif")
     assert sarif["version"] == "2.1.0"
 
 
@@ -391,8 +389,7 @@ def test_server_security_tool_dispatches_suppress(tmp_path: Path) -> None:
     from better_code_review_graph.server import security as security_tool
 
     root, _ = _make_repo_with_node(tmp_path)
-    raw = security_tool(action="suppress", repo_root=str(root), rule_id="cwe-89")
-    payload = json.loads(raw)
+    payload = security_tool(action="suppress", repo_root=str(root), rule_id="cwe-89")
     assert payload["rule_id"] == "cwe-89"
     assert payload["suppressed"] is True
 
@@ -400,8 +397,7 @@ def test_server_security_tool_dispatches_suppress(tmp_path: Path) -> None:
 def test_server_security_tool_dispatches_rule_list(tmp_path: Path) -> None:
     from better_code_review_graph.server import security as security_tool
 
-    raw = security_tool(action="rule_list", engine="heuristic")
-    payload = json.loads(raw)
+    payload = security_tool(action="rule_list", engine="heuristic")
     assert payload["engine"] == "heuristic"
     assert payload["rules"]
 
@@ -409,7 +405,6 @@ def test_server_security_tool_dispatches_rule_list(tmp_path: Path) -> None:
 def test_server_security_tool_invalid_action_returns_error() -> None:
     from better_code_review_graph.server import security as security_tool
 
-    raw = security_tool(action="bogus")
-    payload = json.loads(raw)
+    payload = security_tool(action="bogus")
     assert "error" in payload
     assert "bogus" in payload["error"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,7 +55,7 @@ class TestGraphTool:
     @patch("better_code_review_graph.server.build_or_update_graph")
     def test_build_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "build_type": "full"}
-        result = json.loads(graph(action="build", full_rebuild=True, repo_root="/test"))
+        result = graph(action="build", full_rebuild=True, repo_root="/test")
         mock_fn.assert_called_once_with(
             full_rebuild=True, repo_root="/test", base="HEAD~1", roots=None
         )
@@ -64,7 +64,7 @@ class TestGraphTool:
     @patch("better_code_review_graph.server.build_or_update_graph")
     def test_update_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "build_type": "incremental"}
-        result = json.loads(graph(action="update", repo_root="/test"))
+        result = graph(action="update", repo_root="/test")
         mock_fn.assert_called_once_with(
             full_rebuild=False, repo_root="/test", base="HEAD~1"
         )
@@ -73,19 +73,19 @@ class TestGraphTool:
     @patch("better_code_review_graph.server.list_graph_stats")
     def test_stats_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "total_nodes": 42}
-        result = json.loads(graph(action="stats", repo_root="/test"))
+        result = graph(action="stats", repo_root="/test")
         mock_fn.assert_called_once_with(repo_root="/test")
         assert result["status"] == "ok"
 
     @patch("better_code_review_graph.server.embed_graph")
     def test_embed_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "newly_embedded": 10}
-        result = json.loads(graph(action="embed", repo_root="/test"))
+        result = graph(action="embed", repo_root="/test")
         mock_fn.assert_called_once_with(repo_root="/test")
         assert result["status"] == "ok"
 
     def test_unknown_action(self):
-        result = json.loads(graph(action="nonexistent"))
+        result = graph(action="nonexistent")
         assert "error" in result
         assert "valid_actions" in result
 
@@ -99,8 +99,8 @@ class TestQueryTool:
     @patch("better_code_review_graph.server.query_graph")
     def test_query_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "results": []}
-        result = json.loads(
-            query(action="query", pattern="callers_of", target="foo", repo_root="/test")
+        result = query(
+            action="query", pattern="callers_of", target="foo", repo_root="/test"
         )
         mock_fn.assert_called_once_with(
             pattern="callers_of",
@@ -113,26 +113,24 @@ class TestQueryTool:
         assert result["status"] == "ok"
 
     def test_query_missing_pattern(self):
-        result = json.loads(query(action="query", target="foo"))
+        result = query(action="query", target="foo")
         assert "error" in result
         assert "pattern" in result["error"]
 
     def test_query_missing_target(self):
-        result = json.loads(query(action="query", pattern="callers_of"))
+        result = query(action="query", pattern="callers_of")
         assert "error" in result
         assert "target" in result["error"]
 
     @patch("better_code_review_graph.server.semantic_search_nodes")
     def test_search_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "results": []}
-        result = json.loads(
-            query(
-                action="search",
-                search_query="auth",
-                kind="Class",
-                limit=5,
-                repo_root="/test",
-            )
+        result = query(
+            action="search",
+            search_query="auth",
+            kind="Class",
+            limit=5,
+            repo_root="/test",
         )
         mock_fn.assert_called_once_with(
             query="auth",
@@ -145,22 +143,20 @@ class TestQueryTool:
         assert result["status"] == "ok"
 
     def test_search_missing_query(self):
-        result = json.loads(query(action="search"))
+        result = query(action="search")
         assert "error" in result
         assert "search_query" in result["error"]
 
     @patch("better_code_review_graph.server.get_impact_radius")
     def test_impact_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok"}
-        result = json.loads(
-            query(
-                action="impact",
-                changed_files=["a.py"],
-                max_depth=3,
-                max_results=100,
-                repo_root="/test",
-                base="HEAD~3",
-            )
+        result = query(
+            action="impact",
+            changed_files=["a.py"],
+            max_depth=3,
+            max_results=100,
+            repo_root="/test",
+            base="HEAD~3",
         )
         mock_fn.assert_called_once_with(
             changed_files=["a.py"],
@@ -177,15 +173,13 @@ class TestQueryTool:
     @patch("better_code_review_graph.server.find_large_functions")
     def test_large_functions_action(self, mock_fn):
         mock_fn.return_value = {"status": "ok", "results": []}
-        result = json.loads(
-            query(
-                action="large_functions",
-                min_lines=100,
-                kind="Function",
-                file_path_pattern="src/",
-                limit=10,
-                repo_root="/test",
-            )
+        result = query(
+            action="large_functions",
+            min_lines=100,
+            kind="Function",
+            file_path_pattern="src/",
+            limit=10,
+            repo_root="/test",
         )
         mock_fn.assert_called_once_with(
             min_lines=100,
@@ -198,7 +192,7 @@ class TestQueryTool:
         assert result["status"] == "ok"
 
     def test_unknown_action(self):
-        result = json.loads(query(action="nonexistent"))
+        result = query(action="nonexistent")
         assert "error" in result
         assert "valid_actions" in result
 
@@ -212,15 +206,13 @@ class TestReviewTool:
     @patch("better_code_review_graph.server.get_review_context")
     def test_review(self, mock_fn):
         mock_fn.return_value = {"status": "ok"}
-        result = json.loads(
-            review(
-                changed_files=["b.py"],
-                max_depth=1,
-                include_source=False,
-                max_lines_per_file=50,
-                repo_root="/test",
-                base="main",
-            )
+        result = review(
+            changed_files=["b.py"],
+            max_depth=1,
+            include_source=False,
+            max_lines_per_file=50,
+            repo_root="/test",
+            base="main",
         )
         mock_fn.assert_called_once_with(
             changed_files=["b.py"],
@@ -237,7 +229,7 @@ class TestReviewTool:
     @patch("better_code_review_graph.server.get_review_context")
     def test_review_defaults(self, mock_fn):
         mock_fn.return_value = {"status": "ok"}
-        result = json.loads(review())
+        result = review()
         mock_fn.assert_called_once_with(
             changed_files=None,
             max_depth=2,
@@ -294,14 +286,14 @@ def _make_mini_repo(tmp_path):
 
 class TestConfigTool:
     async def test_unknown_action(self):
-        result = json.loads(await config(action="nonexistent"))
+        result = await config(action="nonexistent")
         assert "error" in result
         assert "valid_actions" in result
         assert "models" not in result["valid_actions"]
 
     async def test_models_action_removed(self):
         """The models catalog-listing action no longer exists."""
-        result = json.loads(await config(action="models"))
+        result = await config(action="models")
         assert "Unknown action 'models'" in result["error"]
         assert "models" not in result["valid_actions"]
 
@@ -318,7 +310,7 @@ class TestConfigTool:
             "better_code_review_graph.embeddings.init_backend",
             side_effect=AssertionError("status must not init the embedding backend"),
         ):
-            result = json.loads(await config(action="status", repo_root=str(repo)))
+            result = await config(action="status", repo_root=str(repo))
         assert result["status"] == "ok"
         assert "embeddings_count" in result
         assert result["embedding_backend"] in ("local", "cloud")
@@ -332,45 +324,43 @@ class TestConfigTool:
                 "cache_clear must not init the embedding backend"
             ),
         ):
-            result = json.loads(await config(action="cache_clear", repo_root=str(repo)))
+            result = await config(action="cache_clear", repo_root=str(repo))
         assert result["status"] == "cache cleared"
         assert "embeddings_removed" in result
 
     async def test_set_missing_key(self):
-        result = json.loads(await config(action="set"))
+        result = await config(action="set")
         assert result["error"] == "key is required for set action"
         assert result["valid_keys"] == ["log_level"]
         assert "error" in result
 
     async def test_set_missing_value(self):
-        result = json.loads(await config(action="set", key="log_level"))
+        result = await config(action="set", key="log_level")
         assert result["error"] == "value is required for set action"
         assert "error" in result
 
     async def test_set_invalid_key(self):
-        result = json.loads(await config(action="set", key="invalid_key", value="x"))
+        result = await config(action="set", key="invalid_key", value="x")
         assert "error" in result
         assert "valid_keys" in result
 
     async def test_set_log_level(self):
-        result = json.loads(await config(action="set", key="log_level", value="DEBUG"))
+        result = await config(action="set", key="log_level", value="DEBUG")
         assert result["status"] == "updated"
         assert result["value"] == "DEBUG"
 
     async def test_set_invalid_log_level(self):
-        result = json.loads(
-            await config(action="set", key="log_level", value="INVALID")
-        )
+        result = await config(action="set", key="log_level", value="INVALID")
         assert "error" in result
 
     async def test_status_no_graph(self):
-        result = json.loads(await config(action="status"))
+        result = await config(action="status")
         assert result["status"] == "ok"
         assert "version" in result
 
     async def test_status_with_repo(self, tmp_path):
         repo = _make_mini_repo(tmp_path)
-        result = json.loads(await config(action="status", repo_root=str(repo)))
+        result = await config(action="status", repo_root=str(repo))
         assert result["status"] == "ok"
         assert result["total_nodes"] > 0
         assert "embedding_backend" in result
@@ -380,13 +370,13 @@ class TestConfigTool:
             "better_code_review_graph.tools._get_store",
             side_effect=ValueError("No graph found"),
         ):
-            result = json.loads(await config(action="status"))
+            result = await config(action="status")
             assert result["status"] == "ok"
             assert result["graph_path"] is None
             assert "No graph found" in result["message"]
 
     async def test_cache_clear_no_graph(self):
-        result = json.loads(await config(action="cache_clear"))
+        result = await config(action="cache_clear")
         assert result["status"] == "cache cleared"
 
     async def test_cache_clear_error_handling(self):
@@ -394,18 +384,18 @@ class TestConfigTool:
             "better_code_review_graph.tools._get_store",
             side_effect=ValueError("No repo found"),
         ):
-            result = json.loads(await config(action="cache_clear"))
+            result = await config(action="cache_clear")
             assert result["status"] == "cache cleared"
             assert result["embeddings_removed"] == 0
 
     async def test_cache_clear_with_repo(self, tmp_path):
         repo = _make_mini_repo(tmp_path)
-        result = json.loads(await config(action="cache_clear", repo_root=str(repo)))
+        result = await config(action="cache_clear", repo_root=str(repo))
         assert result["status"] == "cache cleared"
 
     async def test_setup_status_action(self):
         """config setup_status dispatches to credential state status."""
-        result = json.loads(await config(action="setup_status"))
+        result = await config(action="setup_status")
         assert "unknown action" not in str(result).lower()
         assert "state" in result
 
@@ -421,7 +411,7 @@ class TestConfigTool:
         cs._state = cs.CredentialState.AWAITING_SETUP
         monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
 
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert "unknown action" not in str(result).lower()
         assert result.get("status") == "setup_started"
         assert result.get("setup_url") == "https://relay.example.com/authorize"

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -6,7 +6,6 @@ unknown action variants, and _maybe_include_setup_hint helper.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -123,7 +122,7 @@ class TestSetupStatus:
             "mcp_core.storage.per_plugin_store.PerPluginStore"
         ) as mock_store_cls:
             mock_store_cls.return_value.load.return_value = None
-            result = json.loads(await config(action="setup_status"))
+            result = await config(action="setup_status")
         assert result["state"] == "configured"
         assert "cloud_keys_in_env" in result
         assert "GEMINI_API_KEY" in result["cloud_keys_in_env"]
@@ -149,7 +148,7 @@ class TestSetupStatus:
             "mcp_core.storage.per_plugin_store.PerPluginStore"
         ) as mock_store_cls:
             mock_store_cls.return_value.load.return_value = None
-            result = json.loads(await config(action="setup_status"))
+            result = await config(action="setup_status")
         assert result["state"] == "awaiting_setup"
         assert result["setup_url"] == "https://relay.example.com/setup"
 
@@ -167,7 +166,7 @@ class TestSetupStart:
 
         cs._state = CredentialState.CONFIGURED
 
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert result["status"] == "already_configured"
         assert "force=true" in result["message"]
 
@@ -179,7 +178,7 @@ class TestSetupStart:
         cs._state = CredentialState.AWAITING_SETUP
         monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
 
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert result["status"] == "setup_started"
         assert result["setup_url"] == "https://relay.example.com/authorize"
 
@@ -193,7 +192,7 @@ class TestSetupStart:
         cs._state = CredentialState.AWAITING_SETUP
         monkeypatch.delenv("PUBLIC_URL", raising=False)
 
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert result["status"] == "stdio_mode"
         assert "GEMINI_API_KEY" in result["message"]
 
@@ -205,7 +204,7 @@ class TestSetupStart:
         cs._state = CredentialState.CONFIGURED
         monkeypatch.setenv("PUBLIC_URL", "https://relay.example.com")
 
-        result = json.loads(await config(action="setup_start", force=True))
+        result = await config(action="setup_start", force=True)
         assert result["status"] == "setup_started"
         assert result["setup_url"] == "https://relay.example.com/authorize"
 
@@ -221,7 +220,7 @@ class TestSetupSkip:
         from better_code_review_graph.server import config
 
         with patch("mcp_core.set_local_mode") as mock_local:
-            result = json.loads(await config(action="setup_skip"))
+            result = await config(action="setup_skip")
             assert result["status"] == "ok"
             assert "Local mode" in result["message"]
             mock_local.assert_called_once()
@@ -244,7 +243,7 @@ class TestSetupReset:
             patch("mcp_core.clear_mode"),
             patch("better_code_review_graph.credential_state.PerPluginStore"),
         ):
-            result = json.loads(await config(action="setup_reset"))
+            result = await config(action="setup_reset")
             assert result["status"] == "ok"
             assert cs._state == CredentialState.AWAITING_SETUP
 
@@ -263,7 +262,7 @@ class TestSetupComplete:
         cs._state = CredentialState.AWAITING_SETUP
         monkeypatch.setenv("GEMINI_API_KEY", "test-key")
 
-        result = json.loads(await config(action="setup_complete"))
+        result = await config(action="setup_complete")
         assert result["status"] == "ok"
         assert result["state"] == "configured"
 
@@ -278,7 +277,7 @@ class TestSetupUnknownAction:
         """Unknown action returns error with valid actions."""
         from better_code_review_graph.server import config
 
-        result = json.loads(await config(action="nonexistent_setup_action"))
+        result = await config(action="nonexistent_setup_action")
         assert "error" in result
         assert "valid_actions" in result
 
@@ -286,6 +285,6 @@ class TestSetupUnknownAction:
         """Typo in setup_ action returns a suggestion."""
         from better_code_review_graph.server import config
 
-        result = json.loads(await config(action="setup_statu"))
+        result = await config(action="setup_statu")
         assert "error" in result
         assert "setup_status" in result["error"]

--- a/tests/test_v17_coverage_gaps.py
+++ b/tests/test_v17_coverage_gaps.py
@@ -17,7 +17,6 @@ Covers under-tested code paths added by feat commits 14355be..3e1511c:
 
 from __future__ import annotations
 
-import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -490,13 +489,11 @@ class TestServerSpotCheckAndRenamedInDiff:
             "better_code_review_graph.server.spot_check_last_callers"
         ) as mock_fn:
             mock_fn.return_value = {"status": "ok", "samples": []}
-            result = json.loads(
-                query(
-                    action="spot_check",
-                    n=5,
-                    context_lines=4,
-                    repo_root="/test",
-                )
+            result = query(
+                action="spot_check",
+                n=5,
+                context_lines=4,
+                repo_root="/test",
             )
             mock_fn.assert_called_once_with(n=5, repo_root="/test", context_lines=4)
         assert result["status"] == "ok"
@@ -506,13 +503,11 @@ class TestServerSpotCheckAndRenamedInDiff:
 
         with patch("better_code_review_graph.server.renamed_in_diff") as mock_fn:
             mock_fn.return_value = {"status": "ok", "shifts": []}
-            result = json.loads(
-                query(
-                    action="renamed_in_diff",
-                    base="HEAD~3",
-                    changed_files=["a.py"],
-                    repo_root="/test",
-                )
+            result = query(
+                action="renamed_in_diff",
+                base="HEAD~3",
+                changed_files=["a.py"],
+                repo_root="/test",
             )
             mock_fn.assert_called_once_with(
                 base="HEAD~3",
@@ -546,6 +541,6 @@ class TestServerSpotCheckAndRenamedInDiff:
             patch.object(cs, "get_state", return_value=cs.CredentialState.LOCAL),
         ):
             mock_store.return_value.load.return_value = {}
-            result = json.loads(asyncio.run(config(action="setup_status")))
+            result = asyncio.run(config(action="setup_status"))
         assert result["state"] == "local"
         assert result["providers_configured"] == []


### PR DESCRIPTION
## S13 / WS-D X1 (crg)

`graph`/`query`/`review`/`config`/`security` tools now return `-> dict[str, Any]` (the `_json()` wrapper is dropped at the tool boundary — handlers already returned dicts), so FastMCP auto-derives `outputSchema` ({type:object, additionalProperties:true}) and emits `structuredContent` alongside the dual TextContent per MCP spec 2025-11-25.

`help` keeps its `-> str` contract (markdown by design; `_json()` survives only for its two error paths). No non-tool `json.dumps` touched (SQL params / cache / CLI output unchanged). Test json.loads plumbing removed where tools are called directly; every assertion preserved byte-identically.

Evidence: 1255 passed / 1 skipped / 47 deselected; ruff + ty clean. Task-reviewed: Approved (full 1892-line diff read, all 5 tool boundaries + 8 test files verified line-by-line).