### PR TITLE
feat: add graph import with a round-trip export format

### DIFF
--- a/src/better_code_review_graph/exporter.py
+++ b/src/better_code_review_graph/exporter.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -220,12 +221,13 @@ def export_cypher(store: GraphStore) -> str:
     return "\n".join(parts)
 
 
-def export_crg(store: GraphStore) -> str:
+def export_crg(store: GraphStore, root: Path | None = None) -> str:
     """Emit the full graph as round-trippable JSON (Task 6).
 
     Unlike the other formats (one-way interop with external tools), ``crg``
     dumps every column of the ``nodes`` / ``edges`` tables verbatim --
-    including ``source_text`` and the summarizer columns -- so
+    including ``source_text``, the summarizer columns, and the temporal
+    ``valid_from_sha``/``valid_to_sha`` columns -- so
     :func:`better_code_review_graph.importer.import_graph` can reconstruct
     an equivalent subgraph in a different store (e.g. built on a CI runner,
     imported on a laptop; the crg format is not used by the CF-hosted
@@ -233,14 +235,22 @@ def export_crg(store: GraphStore) -> str:
 
     ``repo_id`` identifies the exporting graph and becomes the namespace
     prefix an importer uses to keep re-imported ids from colliding with
-    locally-parsed nodes. It is derived from the store's db path the same
-    way :func:`better_code_review_graph.federation.derive_repo_id` derives
-    ids for federated repo roots, so it stays stable across repeated
-    exports of the same store.
+    locally-parsed nodes. It is derived via
+    :func:`better_code_review_graph.federation.derive_repo_id` from ``root``
+    when the caller supplies it (``export_graph_dispatch`` always does,
+    since it already resolves the repo root) -- this is the same id a
+    federated ``graph(action='build', roots=[...])`` would register for
+    that same root, so repo-scoped queries agree after either path. When
+    ``root`` is omitted (e.g. calling this function directly against a
+    store that isn't backed by a real repo checkout), falls back to the
+    store's own db directory so the id stays deterministic per store; note
+    that fallback is *not* guaranteed to match a federated id for a real
+    root, since ``store.db_path`` normally lives at
+    ``<root>/.code-review-graph/graph.db`` -- one directory below ``root``.
     """
     from .federation import derive_repo_id
 
-    repo_id = derive_repo_id(store.db_path.parent)
+    repo_id = derive_repo_id(root if root is not None else store.db_path.parent)
     nodes = [dict(row) for row in store._conn.execute("SELECT * FROM nodes")]
     edges = [dict(row) for row in store._conn.execute("SELECT * FROM edges")]
     return json.dumps(
@@ -255,13 +265,20 @@ _FORMATTERS = {
     "jsonld": export_jsonld,
     "dot": export_dot,
     "cypher": export_cypher,
-    "crg": export_crg,
 }
 
 
-def export_graph(store: GraphStore, format: str = "graphml") -> str:
-    """Dispatch to the per-format formatter. Raises ValueError on unknown format."""
+def export_graph(
+    store: GraphStore, format: str = "graphml", root: Path | None = None
+) -> str:
+    """Dispatch to the per-format formatter. Raises ValueError on unknown format.
+
+    ``root`` is only consumed by the ``crg`` format (see :func:`export_crg`);
+    the other formatters ignore it.
+    """
     fmt = format.lower()
+    if fmt == "crg":
+        return export_crg(store, root=root)
     if fmt not in _FORMATTERS:
         valid = sorted({"graphml", "json-ld", "dot", "cypher", "crg"})
         raise ValueError(f"Unknown export format '{format}'. Valid: {valid}")

--- a/src/better_code_review_graph/exporter.py
+++ b/src/better_code_review_graph/exporter.py
@@ -8,6 +8,8 @@ Formats:
     - json-ld: JSON, supported by JSON-LD consumers + arbitrary JSON tooling
     - dot: Graphviz DOT, supported by Graphviz + dot2tex + xdot
     - cypher: Neo4j Cypher CREATE statements, replay-able into a Neo4j database
+    - crg: JSON, the only format that round-trips back into a GraphStore via
+      ``better_code_review_graph.importer.import_graph`` (see Task 6)
 
 Streaming uses iter helpers on the GraphStore. Output is a single string
 return value; callers wanting file output write the string to disk.
@@ -218,12 +220,42 @@ def export_cypher(store: GraphStore) -> str:
     return "\n".join(parts)
 
 
+def export_crg(store: GraphStore) -> str:
+    """Emit the full graph as round-trippable JSON (Task 6).
+
+    Unlike the other formats (one-way interop with external tools), ``crg``
+    dumps every column of the ``nodes`` / ``edges`` tables verbatim --
+    including ``source_text`` and the summarizer columns -- so
+    :func:`better_code_review_graph.importer.import_graph` can reconstruct
+    an equivalent subgraph in a different store (e.g. built on a CI runner,
+    imported on a laptop; the crg format is not used by the CF-hosted
+    deployment).
+
+    ``repo_id`` identifies the exporting graph and becomes the namespace
+    prefix an importer uses to keep re-imported ids from colliding with
+    locally-parsed nodes. It is derived from the store's db path the same
+    way :func:`better_code_review_graph.federation.derive_repo_id` derives
+    ids for federated repo roots, so it stays stable across repeated
+    exports of the same store.
+    """
+    from .federation import derive_repo_id
+
+    repo_id = derive_repo_id(store.db_path.parent)
+    nodes = [dict(row) for row in store._conn.execute("SELECT * FROM nodes")]
+    edges = [dict(row) for row in store._conn.execute("SELECT * FROM edges")]
+    return json.dumps(
+        {"schema_version": 1, "repo_id": repo_id, "nodes": nodes, "edges": edges},
+        indent=2,
+    )
+
+
 _FORMATTERS = {
     "graphml": export_graphml,
     "json-ld": export_jsonld,
     "jsonld": export_jsonld,
     "dot": export_dot,
     "cypher": export_cypher,
+    "crg": export_crg,
 }
 
 
@@ -231,6 +263,6 @@ def export_graph(store: GraphStore, format: str = "graphml") -> str:
     """Dispatch to the per-format formatter. Raises ValueError on unknown format."""
     fmt = format.lower()
     if fmt not in _FORMATTERS:
-        valid = sorted({"graphml", "json-ld", "dot", "cypher"})
+        valid = sorted({"graphml", "json-ld", "dot", "cypher", "crg"})
         raise ValueError(f"Unknown export format '{format}'. Valid: {valid}")
     return _FORMATTERS[fmt](store)

--- a/src/better_code_review_graph/importer.py
+++ b/src/better_code_review_graph/importer.py
@@ -1,0 +1,169 @@
+"""Import a `crg`-format export back into a GraphStore (Task 6).
+
+Pairs with :func:`better_code_review_graph.exporter.export_crg`: a graph
+built and exported on one machine (e.g. a CI runner) can be merged into a
+store on another (e.g. a laptop) without its ids colliding with whatever
+that store already has, by namespacing every id with the exporting
+``repo_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+from .parser import EdgeInfo, NodeInfo
+
+if TYPE_CHECKING:
+    from .federation import RepoRegistry
+    from .graph import GraphStore
+
+_SUPPORTED_SCHEMA_VERSION = 1
+
+
+def _namespace(value: str, prefix: str) -> str:
+    """Prefix ``value`` with ``prefix`` unless it is already prefixed.
+
+    The "already prefixed" guard keeps re-importing an already-namespaced
+    payload (e.g. re-exporting an import result) from stacking prefixes.
+    """
+    return value if value.startswith(prefix) else f"{prefix}{value}"
+
+
+def _register_repo_if_absent(
+    store: GraphStore, registry: RepoRegistry, repo_id: str
+) -> None:
+    """Record the imported repo as a known participant for repo-scoped queries.
+
+    ``RepoRegistry.add`` always re-derives the id from a filesystem path, so
+    it cannot be told to keep the exact incoming ``repo_id`` -- an import has
+    no meaningful local path to derive from in the first place. This writes
+    the ``repos`` row directly (same shape ``RepoRegistry`` itself reads),
+    guarded by ``INSERT OR IGNORE`` so re-importing the same payload is a
+    no-op here regardless of whether ``registry``'s in-memory cache is stale.
+    """
+    if repo_id in {entry.repo_id for entry in registry.entries()}:
+        return
+    now = int(time.time())
+    store._conn.execute(
+        "INSERT OR IGNORE INTO repos "
+        "(repo_id, path, remote_url, last_indexed_sha, first_indexed_at, last_indexed_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (repo_id, f"<imported:{repo_id}>", None, None, now, now),
+    )
+    store._conn.commit()
+
+
+def import_graph(
+    store: GraphStore, registry: RepoRegistry, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge a ``crg``-format payload into ``store``.
+
+    Args:
+        store: Target graph store to write into.
+        registry: Registry bound to the same ``store``, used to record the
+            imported repo as a known participant (see
+            :func:`_register_repo_if_absent`).
+        payload: Parsed JSON produced by
+            :func:`better_code_review_graph.exporter.export_crg`.
+
+    Returns:
+        Dict with ``nodes_added``, ``nodes_updated``, ``edges_added``, and
+        ``repo_id``.
+
+    Raises:
+        ValueError: If ``payload["schema_version"]`` is not the version this
+            importer understands.
+    """
+    schema_version = payload.get("schema_version")
+    if schema_version != _SUPPORTED_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported crg schema_version {schema_version!r}; "
+            f"this importer only understands schema_version={_SUPPORTED_SCHEMA_VERSION}."
+        )
+
+    repo_id = payload["repo_id"]
+    prefix = f"{repo_id}::"
+    _register_repo_if_absent(store, registry, repo_id)
+
+    nodes_added = 0
+    nodes_updated = 0
+    for node in payload["nodes"]:
+        new_qualified_name = _namespace(node["qualified_name"], prefix)
+        pre_existing = store.get_node(new_qualified_name) is not None
+
+        node_id = store.upsert_node(
+            NodeInfo(
+                kind=node["kind"],
+                name=node["name"],
+                # _make_qualified() derives qualified_name from file_path, so
+                # namespacing file_path here reproduces new_qualified_name
+                # exactly (file_path is always a prefix of qualified_name).
+                file_path=_namespace(node["file_path"], prefix),
+                line_start=node["line_start"],
+                line_end=node["line_end"],
+                language=node["language"] or "",
+                parent_name=node["parent_name"],
+                params=node["params"],
+                return_type=node["return_type"],
+                modifiers=node["modifiers"],
+                is_test=bool(node["is_test"]),
+                extra=json.loads(node["extra"]) if node["extra"] else {},
+                source_text=node["source_text"],
+                repo_id=repo_id,
+            ),
+            file_hash=node["file_hash"] or "",
+        )
+        if pre_existing:
+            nodes_updated += 1
+        else:
+            nodes_added += 1
+
+        if node.get("summary") is not None:
+            store.update_summary(
+                node_id,
+                summary=node["summary"],
+                provider=node.get("summary_provider") or "",
+                source_hash=node.get("source_hash") or "",
+            )
+
+    edges_added = 0
+    for edge in payload["edges"]:
+        new_source = _namespace(edge["source_qualified"], prefix)
+        new_target = _namespace(edge["target_qualified"], prefix)
+        # Mirrors GraphStore.upsert_edge's own natural-key match so we can
+        # tell insert from update here -- upsert_edge only returns the row
+        # id either way, and graph.py is out of scope for this task.
+        pre_existing = (
+            store._conn.execute(
+                "SELECT 1 FROM edges WHERE kind=? AND source_qualified=? "
+                "AND target_qualified=? AND file_path=? AND line=?",
+                (edge["kind"], new_source, new_target, edge["file_path"], edge["line"]),
+            ).fetchone()
+            is not None
+        )
+
+        store.upsert_edge(
+            EdgeInfo(
+                kind=edge["kind"],
+                source=new_source,
+                target=new_target,
+                file_path=edge["file_path"],
+                line=edge["line"],
+                extra=json.loads(edge["extra"]) if edge["extra"] else {},
+                repo_id=repo_id,
+            )
+        )
+        if not pre_existing:
+            edges_added += 1
+
+    store.commit()
+    store._invalidate_cache()
+
+    return {
+        "nodes_added": nodes_added,
+        "nodes_updated": nodes_updated,
+        "edges_added": edges_added,
+        "repo_id": repo_id,
+    }

--- a/src/better_code_review_graph/importer.py
+++ b/src/better_code_review_graph/importer.py
@@ -9,17 +9,15 @@ that store already has, by namespacing every id with the exporting
 
 from __future__ import annotations
 
-import json
 import time
 from typing import TYPE_CHECKING, Any
-
-from .parser import EdgeInfo, NodeInfo
 
 if TYPE_CHECKING:
     from .federation import RepoRegistry
     from .graph import GraphStore
 
 _SUPPORTED_SCHEMA_VERSION = 1
+_ZERO_SHA = "0" * 40
 
 
 def _namespace(value: str, prefix: str) -> str:
@@ -41,7 +39,8 @@ def _register_repo_if_absent(
     no meaningful local path to derive from in the first place. This writes
     the ``repos`` row directly (same shape ``RepoRegistry`` itself reads),
     guarded by ``INSERT OR IGNORE`` so re-importing the same payload is a
-    no-op here regardless of whether ``registry``'s in-memory cache is stale.
+    no-op here regardless of whether ``registry``'s in-memory cache is
+    stale. Left uncommitted -- ``import_graph`` commits everything together.
     """
     if repo_id in {entry.repo_id for entry in registry.entries()}:
         return
@@ -52,7 +51,140 @@ def _register_repo_if_absent(
         "VALUES (?, ?, ?, ?, ?, ?)",
         (repo_id, f"<imported:{repo_id}>", None, None, now, now),
     )
-    store._conn.commit()
+
+
+def _upsert_imported_node(
+    store: GraphStore, qualified_name: str, node: dict[str, Any], repo_id: str
+) -> tuple[int, bool]:
+    """Insert/update a ``nodes`` row with an explicit, already-namespaced id.
+
+    ``GraphStore.upsert_node`` always derives ``qualified_name`` from
+    ``file_path`` via ``_make_qualified`` -- it has no way to accept an
+    explicit qualified_name, so the only way to produce a namespaced id
+    through it is to namespace ``file_path`` itself. That corrupts
+    ``file_path`` into a non-path (`get_nodes_by_file` can no longer find
+    the node by its real path, and it stops matching the corresponding
+    edges' un-namespaced ``file_path``). This mirrors ``upsert_node``'s own
+    ``INSERT ... ON CONFLICT(qualified_name) DO UPDATE`` shape (graph.py is
+    out of scope for this task) but takes ``qualified_name`` and the
+    temporal columns explicitly, leaving ``file_path`` as the real source
+    path -- matching how federated multi-root builds already disambiguate
+    files (via the separate ``repo_id`` column + naturally-distinct
+    filesystem paths), not by mangling ``file_path``.
+
+    Returns ``(node_id, pre_existing)``.
+    """
+    now = time.time()
+    pre_existing = (
+        store._conn.execute(
+            "SELECT 1 FROM nodes WHERE qualified_name = ?", (qualified_name,)
+        ).fetchone()
+        is not None
+    )
+    store._conn.execute(
+        """INSERT INTO nodes
+           (kind, name, qualified_name, file_path, line_start, line_end,
+            language, parent_name, params, return_type, modifiers, is_test,
+            file_hash, extra, updated_at, source_text, repo_id,
+            valid_from_sha, valid_to_sha)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(qualified_name) DO UPDATE SET
+             kind=excluded.kind, name=excluded.name,
+             file_path=excluded.file_path, line_start=excluded.line_start,
+             line_end=excluded.line_end, language=excluded.language,
+             parent_name=excluded.parent_name, params=excluded.params,
+             return_type=excluded.return_type, modifiers=excluded.modifiers,
+             is_test=excluded.is_test, file_hash=excluded.file_hash,
+             extra=excluded.extra, updated_at=excluded.updated_at,
+             source_text=excluded.source_text, repo_id=excluded.repo_id,
+             valid_from_sha=excluded.valid_from_sha,
+             valid_to_sha=excluded.valid_to_sha
+        """,
+        (
+            node["kind"],
+            node["name"],
+            qualified_name,
+            node["file_path"],
+            node["line_start"],
+            node["line_end"],
+            node["language"] or "",
+            node["parent_name"],
+            node["params"],
+            node["return_type"],
+            node["modifiers"],
+            node["is_test"],
+            node["file_hash"] or "",
+            node["extra"] if node["extra"] else "{}",
+            now,
+            node["source_text"],
+            repo_id,
+            node.get("valid_from_sha") or _ZERO_SHA,
+            node.get("valid_to_sha"),
+        ),
+    )
+    row = store._conn.execute(
+        "SELECT id FROM nodes WHERE qualified_name = ?", (qualified_name,)
+    ).fetchone()
+    return row["id"], pre_existing
+
+
+def _upsert_imported_edge(
+    store: GraphStore,
+    new_source: str,
+    new_target: str,
+    edge: dict[str, Any],
+    repo_id: str,
+) -> bool:
+    """Insert/update an ``edges`` row, carrying the temporal columns through.
+
+    Mirrors ``GraphStore.upsert_edge``'s natural-key match (kind + source +
+    target + file_path + line) and insert/update shape, extended with the
+    ``valid_from_sha``/``valid_to_sha`` columns ``upsert_edge`` doesn't set
+    (same graph.py-out-of-scope reasoning as :func:`_upsert_imported_node`).
+    ``edge["file_path"]`` is passed through untouched -- consistent with
+    leaving node ``file_path`` real (see :func:`_upsert_imported_node`).
+
+    Returns ``True`` if a new row was inserted, ``False`` if an existing
+    one was updated.
+    """
+    now = time.time()
+    extra_str = edge["extra"] if edge["extra"] else "{}"
+    valid_from_sha = edge.get("valid_from_sha") or _ZERO_SHA
+    valid_to_sha = edge.get("valid_to_sha")
+
+    existing = store._conn.execute(
+        "SELECT id FROM edges WHERE kind=? AND source_qualified=? "
+        "AND target_qualified=? AND file_path=? AND line=?",
+        (edge["kind"], new_source, new_target, edge["file_path"], edge["line"]),
+    ).fetchone()
+
+    if existing:
+        store._conn.execute(
+            "UPDATE edges SET extra=?, updated_at=?, repo_id=?, "
+            "valid_from_sha=?, valid_to_sha=? WHERE id=?",
+            (extra_str, now, repo_id, valid_from_sha, valid_to_sha, existing["id"]),
+        )
+        return False
+
+    store._conn.execute(
+        """INSERT INTO edges
+           (kind, source_qualified, target_qualified, file_path, line,
+            extra, updated_at, repo_id, valid_from_sha, valid_to_sha)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            edge["kind"],
+            new_source,
+            new_target,
+            edge["file_path"],
+            edge["line"],
+            extra_str,
+            now,
+            repo_id,
+            valid_from_sha,
+            valid_to_sha,
+        ),
+    )
+    return True
 
 
 def import_graph(
@@ -85,80 +217,40 @@ def import_graph(
 
     repo_id = payload["repo_id"]
     prefix = f"{repo_id}::"
-    _register_repo_if_absent(store, registry, repo_id)
 
-    nodes_added = 0
-    nodes_updated = 0
-    for node in payload["nodes"]:
-        new_qualified_name = _namespace(node["qualified_name"], prefix)
-        pre_existing = store.get_node(new_qualified_name) is not None
+    # Single transaction for the whole merge: a failure partway through
+    # (e.g. a malformed node dict) rolls back rather than leaving a
+    # partially-imported graph committed.
+    with store._conn:
+        _register_repo_if_absent(store, registry, repo_id)
 
-        node_id = store.upsert_node(
-            NodeInfo(
-                kind=node["kind"],
-                name=node["name"],
-                # _make_qualified() derives qualified_name from file_path, so
-                # namespacing file_path here reproduces new_qualified_name
-                # exactly (file_path is always a prefix of qualified_name).
-                file_path=_namespace(node["file_path"], prefix),
-                line_start=node["line_start"],
-                line_end=node["line_end"],
-                language=node["language"] or "",
-                parent_name=node["parent_name"],
-                params=node["params"],
-                return_type=node["return_type"],
-                modifiers=node["modifiers"],
-                is_test=bool(node["is_test"]),
-                extra=json.loads(node["extra"]) if node["extra"] else {},
-                source_text=node["source_text"],
-                repo_id=repo_id,
-            ),
-            file_hash=node["file_hash"] or "",
-        )
-        if pre_existing:
-            nodes_updated += 1
-        else:
-            nodes_added += 1
-
-        if node.get("summary") is not None:
-            store.update_summary(
-                node_id,
-                summary=node["summary"],
-                provider=node.get("summary_provider") or "",
-                source_hash=node.get("source_hash") or "",
+        nodes_added = 0
+        nodes_updated = 0
+        for node in payload["nodes"]:
+            new_qualified_name = _namespace(node["qualified_name"], prefix)
+            node_id, pre_existing = _upsert_imported_node(
+                store, new_qualified_name, node, repo_id
             )
+            if pre_existing:
+                nodes_updated += 1
+            else:
+                nodes_added += 1
 
-    edges_added = 0
-    for edge in payload["edges"]:
-        new_source = _namespace(edge["source_qualified"], prefix)
-        new_target = _namespace(edge["target_qualified"], prefix)
-        # Mirrors GraphStore.upsert_edge's own natural-key match so we can
-        # tell insert from update here -- upsert_edge only returns the row
-        # id either way, and graph.py is out of scope for this task.
-        pre_existing = (
-            store._conn.execute(
-                "SELECT 1 FROM edges WHERE kind=? AND source_qualified=? "
-                "AND target_qualified=? AND file_path=? AND line=?",
-                (edge["kind"], new_source, new_target, edge["file_path"], edge["line"]),
-            ).fetchone()
-            is not None
-        )
+            if node.get("summary") is not None:
+                store.update_summary(
+                    node_id,
+                    summary=node["summary"],
+                    provider=node.get("summary_provider") or "",
+                    source_hash=node.get("source_hash") or "",
+                )
 
-        store.upsert_edge(
-            EdgeInfo(
-                kind=edge["kind"],
-                source=new_source,
-                target=new_target,
-                file_path=edge["file_path"],
-                line=edge["line"],
-                extra=json.loads(edge["extra"]) if edge["extra"] else {},
-                repo_id=repo_id,
-            )
-        )
-        if not pre_existing:
-            edges_added += 1
+        edges_added = 0
+        for edge in payload["edges"]:
+            new_source = _namespace(edge["source_qualified"], prefix)
+            new_target = _namespace(edge["target_qualified"], prefix)
+            if _upsert_imported_edge(store, new_source, new_target, edge, repo_id):
+                edges_added += 1
 
-    store.commit()
     store._invalidate_cache()
 
     return {

--- a/src/better_code_review_graph/importer.py
+++ b/src/better_code_review_graph/importer.py
@@ -55,7 +55,7 @@ def _register_repo_if_absent(
 
 def _upsert_imported_node(
     store: GraphStore, qualified_name: str, node: dict[str, Any], repo_id: str
-) -> tuple[int, bool]:
+) -> bool:
     """Insert/update a ``nodes`` row with an explicit, already-namespaced id.
 
     ``GraphStore.upsert_node`` always derives ``qualified_name`` from
@@ -72,7 +72,19 @@ def _upsert_imported_node(
     files (via the separate ``repo_id`` column + naturally-distinct
     filesystem paths), not by mangling ``file_path``.
 
-    Returns ``(node_id, pre_existing)``.
+    ``summary``/``summary_provider``/``source_hash`` are folded into the
+    same statement rather than calling ``GraphStore.update_summary``
+    afterward -- that method does its own ``commit()``, which would end
+    the transaction ``import_graph`` wraps the whole merge in, making a
+    partial-import rollback silently not roll back whenever a node carries
+    a summary. The ``COALESCE(excluded.x, x)`` pattern keeps a locally
+    generated summary intact when the imported payload doesn't carry one
+    (e.g. the source repo was never summarized) instead of clobbering it
+    with NULL on every re-import -- the same behavior the previous
+    ``if node.get("summary") is not None`` guard produced.
+
+    Returns ``True`` if ``qualified_name`` already existed (row updated),
+    ``False`` if it was newly inserted.
     """
     now = time.time()
     pre_existing = (
@@ -86,8 +98,8 @@ def _upsert_imported_node(
            (kind, name, qualified_name, file_path, line_start, line_end,
             language, parent_name, params, return_type, modifiers, is_test,
             file_hash, extra, updated_at, source_text, repo_id,
-            valid_from_sha, valid_to_sha)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            valid_from_sha, valid_to_sha, summary, summary_provider, source_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(qualified_name) DO UPDATE SET
              kind=excluded.kind, name=excluded.name,
              file_path=excluded.file_path, line_start=excluded.line_start,
@@ -98,7 +110,10 @@ def _upsert_imported_node(
              extra=excluded.extra, updated_at=excluded.updated_at,
              source_text=excluded.source_text, repo_id=excluded.repo_id,
              valid_from_sha=excluded.valid_from_sha,
-             valid_to_sha=excluded.valid_to_sha
+             valid_to_sha=excluded.valid_to_sha,
+             summary=COALESCE(excluded.summary, summary),
+             summary_provider=COALESCE(excluded.summary_provider, summary_provider),
+             source_hash=COALESCE(excluded.source_hash, source_hash)
         """,
         (
             node["kind"],
@@ -120,12 +135,12 @@ def _upsert_imported_node(
             repo_id,
             node.get("valid_from_sha") or _ZERO_SHA,
             node.get("valid_to_sha"),
+            node.get("summary"),
+            node.get("summary_provider"),
+            node.get("source_hash"),
         ),
     )
-    row = store._conn.execute(
-        "SELECT id FROM nodes WHERE qualified_name = ?", (qualified_name,)
-    ).fetchone()
-    return row["id"], pre_existing
+    return pre_existing
 
 
 def _upsert_imported_edge(
@@ -220,7 +235,10 @@ def import_graph(
 
     # Single transaction for the whole merge: a failure partway through
     # (e.g. a malformed node dict) rolls back rather than leaving a
-    # partially-imported graph committed.
+    # partially-imported graph committed. (Summary columns are written by
+    # _upsert_imported_node itself rather than a separate
+    # store.update_summary() call, since that method commits on its own
+    # and would end this transaction early.)
     with store._conn:
         _register_repo_if_absent(store, registry, repo_id)
 
@@ -228,21 +246,13 @@ def import_graph(
         nodes_updated = 0
         for node in payload["nodes"]:
             new_qualified_name = _namespace(node["qualified_name"], prefix)
-            node_id, pre_existing = _upsert_imported_node(
+            pre_existing = _upsert_imported_node(
                 store, new_qualified_name, node, repo_id
             )
             if pre_existing:
                 nodes_updated += 1
             else:
                 nodes_added += 1
-
-            if node.get("summary") is not None:
-                store.update_summary(
-                    node_id,
-                    summary=node["summary"],
-                    provider=node.get("summary_provider") or "",
-                    source_hash=node.get("source_hash") or "",
-                )
 
         edges_added = 0
         for edge in payload["edges"]:

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -29,6 +29,7 @@ from .tools import (
     get_docs_section,
     get_impact_radius,
     get_review_context,
+    import_graph_dispatch,
     list_graph_stats,
     query_graph,
     renamed_in_diff,
@@ -102,6 +103,7 @@ mcp = FastMCP(
         "Actions: build (full_rebuild, base, repo_root), update (base, repo_root), "
         "stats (repo_root), embed (repo_root), "
         "export (format, output_path, repo_root), "
+        "import (import_path, repo_root), "
         "summarize (max_nodes, repo_root). "
         "Use `help` tool for full docs."
     ),
@@ -120,6 +122,7 @@ def graph(
     repo_root: str | None = None,
     format: str = "graphml",
     output_path: str | None = None,
+    import_path: str | None = None,
     max_nodes: int = 500,
     roots: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -136,8 +139,15 @@ def graph(
     - stats (-> repo_root): Node/edge counts, languages, embedding status
     - embed (-> repo_root): Compute vector embeddings for semantic search
     - export (-> format='graphml', output_path=None, repo_root): Export graph
-        in graphml | json-ld | dot | cypher format. Writes to output_path when
-        provided, otherwise returns payload inline.
+        in graphml | json-ld | dot | cypher | crg format. Writes to output_path
+        when provided, otherwise returns payload inline. ``crg`` (Task 6) is
+        the only format that round-trips back into a store via ``import``.
+    - import (-> import_path, repo_root): Merge a `crg`-format export (from
+        ``export`` action, ``format='crg'``) into the current repo's graph.
+        Imported node/edge ids are namespaced by the exporting repo_id so
+        they never collide with locally-parsed nodes; re-importing the same
+        file is idempotent. Built for artifact portability (build+export on
+        a CI runner, import on a laptop).
     - summarize (-> max_nodes=500, repo_root): Generate LLM summaries for
         Function nodes. Models come from the SUMMARY_MODELS chain (provider
         inferred from the model prefix); when unset a key-gated default
@@ -165,6 +175,8 @@ def graph(
             return export_graph_dispatch(
                 repo_root=repo_root, format=format, output_path=output_path
             )
+        case "import":
+            return import_graph_dispatch(repo_root=repo_root, import_path=import_path)
         case "summarize":
             return summarize_graph_dispatch(repo_root=repo_root, max_nodes=max_nodes)
         case _:
@@ -174,6 +186,7 @@ def graph(
                 "build",
                 "embed",
                 "export",
+                "import",
                 "stats",
                 "summarize",
                 "update",

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -26,7 +26,7 @@ from .embeddings import (
     resolve_backend,
     semantic_search,
 )
-from .graph import GraphStore, edge_to_dict, node_to_dict
+from .graph import GraphStore, _sanitize_name, edge_to_dict, node_to_dict
 from .incremental import (
     collect_all_files,
     find_project_root,
@@ -2602,13 +2602,15 @@ def export_graph_dispatch(
 ) -> dict[str, Any]:
     """Export the code knowledge graph in an interoperable format.
 
-    Phase 1 v1.6.x feature. Supported formats: graphml, json-ld, dot, cypher.
-    GraphML imports into Gephi/Cytoscape/networkx; Cypher replays into Neo4j;
-    JSON-LD drives JSON-aware tooling; DOT renders via Graphviz.
+    Phase 1 v1.6.x feature. Supported formats: graphml, json-ld, dot, cypher,
+    crg. GraphML imports into Gephi/Cytoscape/networkx; Cypher replays into
+    Neo4j; JSON-LD drives JSON-aware tooling; DOT renders via Graphviz; crg
+    (Task 6) is the only format that round-trips back into a GraphStore via
+    `graph(action='import')`.
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
-        format: One of graphml | json-ld | dot | cypher (case-insensitive).
+        format: One of graphml | json-ld | dot | cypher | crg (case-insensitive).
         output_path: When provided, payload is written to this path and only
             metadata is returned. When None, payload is returned inline.
 
@@ -2649,6 +2651,75 @@ def export_graph_dispatch(
         "bytes": byte_count,
         "payload": payload,
     }
+
+
+def import_graph_dispatch(
+    repo_root: str | None = None,
+    import_path: str | None = None,
+) -> dict[str, Any]:
+    """Import a `crg`-format export produced by `graph(action='export', format='crg')`.
+
+    Task 6 feature: merges a graph built and exported elsewhere (e.g. a CI
+    runner) into the current repo's graph store. Every imported node/edge id
+    is namespaced with the exporting repo_id so it never collides with
+    locally-parsed nodes; re-importing the same file is idempotent.
+
+    Args:
+        repo_root: Repository root path. Auto-detected if omitted.
+        import_path: Path to a JSON file previously written via
+            `graph(action='export', format='crg', output_path=...)`. Must
+            resolve inside repo_root. Required.
+
+    Returns:
+        Dict with status='ok' + nodes_added/nodes_updated/edges_added +
+        repo_id + summary on success, or status='error' + error message.
+    """
+    from .federation import RepoRegistry
+    from .importer import import_graph
+
+    if not import_path:
+        return {
+            "status": "error",
+            "error": "import_path is required for action='import'.",
+        }
+
+    store, root = _get_store(repo_root)
+    try:
+        in_p = Path(import_path).resolve()
+        if not in_p.is_relative_to(root.resolve()):
+            return {
+                "status": "error",
+                "error": f"Import path {import_path} must be relative to repo root {root}",
+            }
+        try:
+            payload = json.loads(in_p.read_text(encoding="utf-8"))
+        except OSError as e:
+            return {"status": "error", "error": f"Failed to read import payload: {e}"}
+        except json.JSONDecodeError as e:
+            return {"status": "error", "error": f"Malformed import payload: {e}"}
+
+        registry = RepoRegistry(store)
+        try:
+            result = import_graph(store, registry, payload)
+        except (ValueError, KeyError) as e:
+            return {"status": "error", "error": str(e)}
+
+        # repo_id came from an on-disk JSON file that may originate anywhere
+        # (a downloaded CI artifact, a colleague's export); sanitize before
+        # it flows into a free-text summary, mirroring node_to_dict's
+        # control-character stripping for names surfaced in tool responses.
+        safe_repo_id = _sanitize_name(result["repo_id"])
+        return {
+            "status": "ok",
+            **result,
+            "summary": (
+                f"Imported {result['nodes_added']} new node(s) "
+                f"({result['nodes_updated']} updated) and "
+                f"{result['edges_added']} new edge(s) from repo '{safe_repo_id}'."
+            ),
+        }
+    finally:
+        store.close()
 
 
 def summarize_graph_dispatch(

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2622,7 +2622,7 @@ def export_graph_dispatch(
 
     store, root = _get_store(repo_root)
     try:
-        payload = export_graph(store, format=format)
+        payload = export_graph(store, format=format, root=root)
     except ValueError as e:
         return {"status": "error", "error": str(e)}
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from better_code_review_graph.exporter import (
+    export_crg,
     export_cypher,
     export_dot,
     export_graph,
@@ -120,6 +121,51 @@ def test_export_graph_dispatch_routes_to_formatter(populated_store):
     assert json.loads(out)["nodes"]
     out = export_graph(populated_store, format="JSONLD")  # case-insensitive alias
     assert json.loads(out)["nodes"]
+    out = export_graph(populated_store, format="crg")
+    assert json.loads(out)["schema_version"] == 1
+
+
+def test_export_crg_emits_schema_version_and_repo_id(populated_store):
+    payload = json.loads(export_crg(populated_store))
+    assert payload["schema_version"] == 1
+    assert isinstance(payload["repo_id"], str)
+    assert payload["repo_id"] != ""
+    assert {n["qualified_name"] for n in payload["nodes"]} == {
+        "src/x.py::foo",
+        "src/x.py::bar",
+    }
+    assert len(payload["edges"]) == 1
+    assert payload["edges"][0]["source_qualified"] == "src/x.py::foo"
+    assert payload["edges"][0]["target_qualified"] == "src/x.py::bar"
+
+
+def test_export_crg_is_stable_across_repeated_exports(populated_store):
+    """Same store -> same repo_id every time (importer relies on this)."""
+    first = json.loads(export_crg(populated_store))
+    second = json.loads(export_crg(populated_store))
+    assert first["repo_id"] == second["repo_id"]
+
+
+def test_export_crg_includes_source_text(tmp_path):
+    db_path = tmp_path / "with_source.db"
+    store = GraphStore(str(db_path))
+    try:
+        store.upsert_node(
+            NodeInfo(
+                kind="Function",
+                name="f",
+                file_path="x.py",
+                line_start=1,
+                line_end=2,
+                language="python",
+                source_text="def f():\n    pass\n",
+            ),
+            file_hash="h",
+        )
+        payload = json.loads(export_crg(store))
+        assert payload["nodes"][0]["source_text"] == "def f():\n    pass\n"
+    finally:
+        store.close()
 
 
 def test_export_graph_unknown_format_raises(populated_store):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -168,6 +168,68 @@ def test_export_crg_includes_source_text(tmp_path):
         store.close()
 
 
+def test_export_crg_repo_id_matches_federation_for_same_root(tmp_path):
+    """repo_id must be derived from the repo root, not the .code-review-graph
+    subdir the db file happens to live in (they hash to different ids)."""
+    from better_code_review_graph.federation import RepoRegistry, derive_repo_id
+
+    root = tmp_path / "myrepo"
+    (root / ".code-review-graph").mkdir(parents=True)
+    db_path = root / ".code-review-graph" / "graph.db"
+
+    store = GraphStore(str(db_path))
+    try:
+        store.upsert_node(
+            NodeInfo(
+                kind="Function",
+                name="f",
+                file_path="x.py",
+                line_start=1,
+                line_end=2,
+                language="python",
+            ),
+            file_hash="h",
+        )
+
+        payload_with_root = json.loads(export_crg(store, root=root))
+        expected_repo_id = derive_repo_id(root)
+        assert payload_with_root["repo_id"] == expected_repo_id
+
+        # Must match what a federated `graph build --roots` would register
+        # for this exact root -- the whole point of a stable namespace.
+        registry = RepoRegistry(store)
+        federated_id = registry.add(root)
+        assert payload_with_root["repo_id"] == federated_id
+
+        # Sanity: proves the bug this test guards against -- deriving from
+        # the .code-review-graph subdir gives a DIFFERENT id.
+        wrong_id = derive_repo_id(db_path.parent)
+        assert wrong_id != expected_repo_id
+    finally:
+        store.close()
+
+
+def test_export_graph_dispatch_passes_root_for_crg_repo_id(tmp_path):
+    """export_graph(format='crg') without root falls back to the db dir --
+    export_graph_dispatch always supplies root so production callers get
+    the correct (root-derived) repo_id."""
+    from better_code_review_graph.federation import derive_repo_id
+
+    root = tmp_path / "myrepo"
+    (root / ".code-review-graph").mkdir(parents=True)
+    db_path = root / ".code-review-graph" / "graph.db"
+    store = GraphStore(str(db_path))
+    try:
+        with_root = json.loads(export_graph(store, format="crg", root=root))
+        without_root = json.loads(export_graph(store, format="crg"))
+
+        assert with_root["repo_id"] == derive_repo_id(root)
+        assert without_root["repo_id"] == derive_repo_id(store.db_path.parent)
+        assert with_root["repo_id"] != without_root["repo_id"]
+    finally:
+        store.close()
+
+
 def test_export_graph_unknown_format_raises(populated_store):
     with pytest.raises(ValueError, match="Unknown export format"):
         export_graph(populated_store, format="rdf-xml")

--- a/tests/test_import_graph_dispatch.py
+++ b/tests/test_import_graph_dispatch.py
@@ -1,0 +1,140 @@
+"""Task 6: graph(action='import') MCP wiring tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+from better_code_review_graph.tools import export_graph_dispatch, import_graph_dispatch
+
+
+def _populate_store(store: GraphStore) -> None:
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="alpha",
+            file_path="src/x.py",
+            line_start=1,
+            line_end=2,
+            language="python",
+        ),
+        file_hash="h",
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="beta",
+            file_path="src/x.py",
+            line_start=4,
+            line_end=5,
+            language="python",
+        ),
+        file_hash="h",
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS",
+            source="src/x.py::alpha",
+            target="src/x.py::beta",
+            file_path="src/x.py",
+            line=1,
+        )
+    )
+
+
+def test_import_dispatch_missing_import_path_returns_error(tmp_path):
+    result = import_graph_dispatch(repo_root=str(tmp_path), import_path=None)
+    assert result["status"] == "error"
+    assert "import_path is required" in result["error"]
+
+
+def test_import_dispatch_reads_export_file_and_merges(tmp_path):
+    """Full round trip through the dispatch layer: export to a file, import it."""
+    export_file = tmp_path / "export.json"
+
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        source_store = GraphStore(str(tmp_path / "source.db"))
+        try:
+            _populate_store(source_store)
+            mock_get_store.return_value = (source_store, tmp_path)
+            export_result = export_graph_dispatch(
+                repo_root=str(tmp_path), format="crg", output_path=str(export_file)
+            )
+        finally:
+            source_store.close()
+    assert export_result["status"] == "ok"
+
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        target_store = GraphStore(str(tmp_path / "target.db"))
+        try:
+            mock_get_store.return_value = (target_store, tmp_path)
+            result = import_graph_dispatch(
+                repo_root=str(tmp_path), import_path=str(export_file)
+            )
+        finally:
+            target_store.close()
+
+    assert result["status"] == "ok"
+    assert result["nodes_added"] == 2
+    assert result["nodes_updated"] == 0
+    assert result["edges_added"] == 1
+    assert "repo_id" in result
+    assert "Imported 2 new node" in result["summary"]
+
+
+def test_import_dispatch_malformed_json_returns_error(tmp_path):
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{not valid json", encoding="utf-8")
+
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        store = GraphStore(str(tmp_path / "test.db"))
+        try:
+            mock_get_store.return_value = (store, tmp_path)
+            result = import_graph_dispatch(
+                repo_root=str(tmp_path), import_path=str(bad_file)
+            )
+        finally:
+            store.close()
+
+    assert result["status"] == "error"
+    assert "Malformed import payload" in result["error"]
+
+
+def test_import_dispatch_bad_schema_version_returns_error(tmp_path):
+    payload_file = tmp_path / "bad_schema.json"
+    payload_file.write_text(
+        json.dumps({"schema_version": 99, "repo_id": "x", "nodes": [], "edges": []}),
+        encoding="utf-8",
+    )
+
+    with patch("better_code_review_graph.tools._get_store") as mock_get_store:
+        store = GraphStore(str(tmp_path / "test.db"))
+        try:
+            mock_get_store.return_value = (store, tmp_path)
+            result = import_graph_dispatch(
+                repo_root=str(tmp_path), import_path=str(payload_file)
+            )
+        finally:
+            store.close()
+
+    assert result["status"] == "error"
+    assert "schema_version" in result["error"]
+
+
+def test_import_dispatch_path_traversal_blocked(
+    tmp_path, _allow_temporal_migration_without_git
+):
+    (tmp_path / ".code-review-graph").mkdir()
+    outside_file = tmp_path.parent / "outside_import.json"
+    outside_file.write_text(
+        json.dumps({"schema_version": 1, "repo_id": "x", "nodes": [], "edges": []}),
+        encoding="utf-8",
+    )
+    import_path = str(tmp_path / "../outside_import.json")
+
+    result = import_graph_dispatch(repo_root=str(tmp_path), import_path=import_path)
+
+    assert result["status"] == "error"
+    assert "must be relative to repo root" in result["error"]

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -239,3 +239,97 @@ def test_import_registers_repo_in_registry(tmp_path, seeded_store):
         assert row is not None
     finally:
         fresh.close()
+
+
+def test_import_preserves_temporal_columns(tmp_path, seeded_store):
+    """valid_from_sha/valid_to_sha must round-trip, not reset to defaults."""
+    seeded_store._conn.execute(
+        "UPDATE nodes SET valid_from_sha=?, valid_to_sha=? WHERE qualified_name=?",
+        ("a" * 40, "b" * 40, "src/x.py::foo"),
+    )
+    seeded_store._conn.execute(
+        "UPDATE edges SET valid_from_sha=?, valid_to_sha=? WHERE source_qualified=?",
+        ("a" * 40, "b" * 40, "src/x.py::foo"),
+    )
+    seeded_store._conn.commit()
+
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        node_row = fresh._conn.execute(
+            "SELECT valid_from_sha, valid_to_sha FROM nodes WHERE qualified_name=?",
+            (f"{repo_id}::src/x.py::foo",),
+        ).fetchone()
+        assert node_row["valid_from_sha"] == "a" * 40
+        assert node_row["valid_to_sha"] == "b" * 40
+
+        edge_row = fresh._conn.execute(
+            "SELECT valid_from_sha, valid_to_sha FROM edges WHERE source_qualified=?",
+            (f"{repo_id}::src/x.py::foo",),
+        ).fetchone()
+        assert edge_row["valid_from_sha"] == "a" * 40
+        assert edge_row["valid_to_sha"] == "b" * 40
+    finally:
+        fresh.close()
+
+
+def test_import_does_not_resurrect_tombstoned_node(tmp_path, seeded_store):
+    """A node marked no-longer-live (valid_to_sha set) must NOT come back live."""
+    seeded_store._conn.execute(
+        "UPDATE nodes SET valid_to_sha=? WHERE qualified_name=?",
+        ("deadbeef" * 5, "src/x.py::foo"),
+    )
+    seeded_store._conn.commit()
+
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        qn = f"{repo_id}::src/x.py::foo"
+        # get_node() defaults to as_of="" (currently-valid only) -- a
+        # resurrected node would wrongly show up here.
+        assert fresh.get_node(qn) is None
+
+        row = fresh._conn.execute(
+            "SELECT valid_to_sha FROM nodes WHERE qualified_name=?", (qn,)
+        ).fetchone()
+        assert row is not None
+        assert row["valid_to_sha"] == "deadbeef" * 5
+    finally:
+        fresh.close()
+
+
+def test_import_preserves_file_path_for_nodes_and_edges(tmp_path, seeded_store):
+    """file_path stays the real source path (not namespaced) for nodes AND
+    edges, so get_nodes_by_file still finds imported nodes and node/edge
+    file_path still match for the same originating file."""
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        nodes = fresh.get_nodes_by_file("src/x.py")
+        assert {n.qualified_name for n in nodes} == {
+            f"{repo_id}::src/x.py::foo",
+            f"{repo_id}::src/x.py::bar",
+        }
+        for n in nodes:
+            assert n.file_path == "src/x.py"
+
+        edges = fresh.get_all_edges()
+        assert len(edges) == 1
+        assert edges[0].file_path == "src/x.py"
+    finally:
+        fresh.close()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -200,6 +200,42 @@ def test_import_preserves_summary_metadata(tmp_path, seeded_store):
         fresh.close()
 
 
+def test_import_rolls_back_fully_when_a_later_node_is_malformed(tmp_path, seeded_store):
+    """A malformed node AFTER a summary-carrying node must roll back to 0/0.
+
+    Regression guard: GraphStore.update_summary() commits on its own, which
+    used to end import_graph's `with store._conn:` transaction early --
+    the summary-carrying node (and its `repos` row) stayed committed even
+    when a later node in the same payload was malformed. Summary columns
+    are now folded into the same INSERT as everything else, so nothing
+    should survive a mid-loop failure.
+    """
+    node = seeded_store.get_node("src/x.py::foo")
+    seeded_store.update_summary(
+        node.id, summary="Returns bar().", provider="gemini", source_hash="abc123"
+    )
+
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    # Guarantee processing order regardless of SQL row order: the
+    # summary-carrying node ("foo") first, the corrupted one ("bar") second.
+    nodes_by_name = {n["name"]: n for n in payload["nodes"]}
+    payload["nodes"] = [nodes_by_name["foo"], nodes_by_name["bar"]]
+    del payload["nodes"][1]["qualified_name"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        with pytest.raises(KeyError):
+            import_graph(fresh, reg, payload)
+
+        node_count = fresh._conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+        repo_count = fresh._conn.execute("SELECT COUNT(*) FROM repos").fetchone()[0]
+        assert node_count == 0
+        assert repo_count == 0
+    finally:
+        fresh.close()
+
+
 def test_import_idempotent_with_fresh_registry_each_call(tmp_path, seeded_store):
     """import_graph_dispatch builds a new RepoRegistry per call in practice --
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,241 @@
+"""Task 6: round-trip `crg` export format + `graph import` action.
+
+Covers :mod:`better_code_review_graph.importer`:
+
+* Full round trip -- export a populated store as ``crg``, import into an
+  empty store, get back the same node/edge counts.
+* Idempotent re-import -- importing the same payload a second time updates
+  rather than duplicates.
+* Node/edge id namespacing by ``repo_id`` (and avoiding double-prefixing).
+* ``source_text`` and summary metadata travel with the node.
+* ``schema_version`` validation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from better_code_review_graph.exporter import export_graph
+from better_code_review_graph.federation import RepoRegistry
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.importer import import_graph
+from better_code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+@pytest.fixture
+def seeded_store(tmp_path):
+    """A small graph: 2 functions (one with source_text) + 1 CALLS edge."""
+    db_path = tmp_path / "seeded.db"
+    store = GraphStore(str(db_path))
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="foo",
+            file_path="src/x.py",
+            line_start=1,
+            line_end=3,
+            language="python",
+            source_text="def foo():\n    return bar()\n",
+        ),
+        file_hash="hash1",
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="bar",
+            file_path="src/x.py",
+            line_start=5,
+            line_end=6,
+            language="python",
+            source_text="def bar():\n    return 1\n",
+        ),
+        file_hash="hash1",
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS",
+            source="src/x.py::foo",
+            target="src/x.py::bar",
+            file_path="src/x.py",
+            line=2,
+        )
+    )
+    yield store
+    store.close()
+
+
+def test_crg_export_import_round_trip(tmp_path, seeded_store):
+    """Export `crg`, import into an EMPTY store, get back the same counts.
+
+    Re-importing the same payload must be idempotent: 0 added, N updated.
+    """
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    assert payload["schema_version"] == 1
+    assert len(payload["nodes"]) == 2
+    assert len(payload["edges"]) == 1
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+
+        r1 = import_graph(fresh, reg, payload)
+        assert r1["nodes_added"] == len(payload["nodes"])
+        assert r1["nodes_updated"] == 0
+        assert r1["edges_added"] == len(payload["edges"])
+        assert r1["repo_id"] == payload["repo_id"]
+
+        r2 = import_graph(fresh, reg, payload)
+        assert r2["nodes_added"] == 0
+        assert r2["nodes_updated"] == len(payload["nodes"])
+        assert r2["edges_added"] == 0
+    finally:
+        fresh.close()
+
+
+def test_import_rejects_unknown_schema_version(tmp_path, seeded_store):
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    payload["schema_version"] = 2
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        with pytest.raises(ValueError, match="schema_version"):
+            import_graph(fresh, reg, payload)
+    finally:
+        fresh.close()
+
+
+def test_import_namespaces_node_and_edge_ids(tmp_path, seeded_store):
+    """Imported qualified names/edge endpoints are prefixed with repo_id::."""
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        expected_foo_qn = f"{repo_id}::src/x.py::foo"
+        expected_bar_qn = f"{repo_id}::src/x.py::bar"
+        assert fresh.get_node(expected_foo_qn) is not None
+        assert fresh.get_node(expected_bar_qn) is not None
+
+        edges = fresh.get_edges_by_source(expected_foo_qn)
+        assert len(edges) == 1
+        assert edges[0].target_qualified == expected_bar_qn
+    finally:
+        fresh.close()
+
+
+def test_import_avoids_double_prefixing_already_namespaced_payload(
+    tmp_path, seeded_store
+):
+    """If the payload's ids already carry the repo_id:: prefix, don't re-prefix."""
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+    prefix = f"{repo_id}::"
+    for node in payload["nodes"]:
+        node["qualified_name"] = f"{prefix}{node['qualified_name']}"
+        node["file_path"] = f"{prefix}{node['file_path']}"
+    for edge in payload["edges"]:
+        edge["source_qualified"] = f"{prefix}{edge['source_qualified']}"
+        edge["target_qualified"] = f"{prefix}{edge['target_qualified']}"
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        # Must NOT be double-prefixed (repo_id::repo_id::...).
+        assert fresh.get_node(f"{prefix}src/x.py::foo") is not None
+        assert fresh.get_node(f"{prefix}{prefix}src/x.py::foo") is None
+    finally:
+        fresh.close()
+
+
+def test_import_preserves_source_text(tmp_path, seeded_store):
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        row = fresh._conn.execute(
+            "SELECT source_text FROM nodes WHERE qualified_name = ?",
+            (f"{repo_id}::src/x.py::foo",),
+        ).fetchone()
+        assert row is not None
+        assert row["source_text"] == "def foo():\n    return bar()\n"
+    finally:
+        fresh.close()
+
+
+def test_import_preserves_summary_metadata(tmp_path, seeded_store):
+    """Summary/source_hash generated by graph(action='summarize') survive the round trip."""
+    node = seeded_store.get_node("src/x.py::foo")
+    seeded_store.update_summary(
+        node.id, summary="Returns bar().", provider="gemini", source_hash="abc123"
+    )
+
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        row = fresh._conn.execute(
+            "SELECT summary, summary_provider, source_hash FROM nodes WHERE qualified_name = ?",
+            (f"{repo_id}::src/x.py::foo",),
+        ).fetchone()
+        assert row["summary"] == "Returns bar()."
+        assert row["summary_provider"] == "gemini"
+        assert row["source_hash"] == "abc123"
+    finally:
+        fresh.close()
+
+
+def test_import_idempotent_with_fresh_registry_each_call(tmp_path, seeded_store):
+    """import_graph_dispatch builds a new RepoRegistry per call in practice --
+
+    re-importing with a FRESHLY constructed registry (which reloads the
+    already-registered repo_id from the `repos` table) must stay idempotent.
+    """
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        r1 = import_graph(fresh, RepoRegistry(fresh), payload)
+        assert r1["nodes_added"] == len(payload["nodes"])
+
+        # A brand-new registry reloads repos from the store, so this
+        # exercises the "already registered" branch (not the stale-cache
+        # INSERT OR IGNORE fallback the same-registry test above hits).
+        r2 = import_graph(fresh, RepoRegistry(fresh), payload)
+        assert r2["nodes_added"] == 0
+        assert r2["nodes_updated"] == len(payload["nodes"])
+    finally:
+        fresh.close()
+
+
+def test_import_registers_repo_in_registry(tmp_path, seeded_store):
+    """The imported repo_id becomes a known participant for repo-scoped queries."""
+    payload = json.loads(export_graph(seeded_store, format="crg"))
+    repo_id = payload["repo_id"]
+
+    fresh = GraphStore(tmp_path / "fresh.db")
+    try:
+        reg = RepoRegistry(fresh)
+        import_graph(fresh, reg, payload)
+
+        row = fresh._conn.execute(
+            "SELECT repo_id FROM repos WHERE repo_id = ?", (repo_id,)
+        ).fetchone()
+        assert row is not None
+    finally:
+        fresh.close()


### PR DESCRIPTION
## Feature (S14 Task 6, Wave 3)

crg's four export formats (graphml/json-ld/dot/cypher) are all one-way interop — you couldn't move a graph off the machine that built it. This adds a round-trip `crg` JSON format + a `graph import` action, so a graph built on a CI runner (`graph build && graph export --format crg`) can be imported on a laptop (`graph import`) — the "artifact portability" story, with no always-on infrastructure and no source egress beyond what the artifact already carries.

## Design

- **export `crg`**: dumps the full node/edge SQLite columns (via `SELECT *` + `dict(row)`, not the trimmed dataclasses — so source_text, summaries, repo_id, and the temporal columns all survive), plus `schema_version` and a `repo_id` derived from the repo **root** (threaded through the dispatch layer so it matches what federation registers for the same root).
- **`graph import`**: namespaces incoming node ids by repo_id (idempotent — `startswith` guard prevents `repoA::repoA::foo`), remaps edge endpoints consistently, and writes via a raw `INSERT ... ON CONFLICT(qualified_name) DO UPDATE` that mirrors `upsert_node`/`upsert_edge` column-for-column while keeping `file_path` a real path and preserving the temporal columns and summaries. The whole import runs in one transaction — a malformed node rolls the entire import back. `federation.py`/`graph.py` are untouched.
- `schema_version != 1` → clear error, no partial write.

## Tests

Full suite green, importer.py 100% covered: round-trip (export→import empty store→same counts + exact temporal/summary values), idempotent second import (0 added/N updated, no double-prefix), edge-endpoint remap correctness, repo_id matches `derive_repo_id(root)` and federation, real file_path preserved (`get_nodes_by_file` finds imported nodes), and full rollback when a later node is malformed.

Reviewed (opus, adversarial, three rounds): namespace/idempotency correct from round 1; round 2 fixed temporal-column drop + repo_id-from-wrong-dir + file_path asymmetry; round 3 made the import truly atomic by folding summaries into the raw insert. Raw-SQL mirror verified column-by-column against the real upserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)