### PR TITLE
🛡️ Sentinel: [HIGH] Fix option injection in Git subcommand

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -201,7 +201,7 @@ def get_head_sha(repo_root: Path) -> str | None:
 
 def is_valid_commit(repo_root: Path, sha: str) -> bool:
     """Return True if sha identifies a reachable commit object."""
-    if not sha:
+    if not sha or sha.startswith("-"):
         return False
     result = _run_git(repo_root, ["cat-file", "-e", f"{sha}^{{commit}}"])
     return result is not None and result.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.19.1"
+version = "3.20.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential option/argument injection in Git subprocess calls. The `is_valid_commit` function passed a user-provided `sha` string directly to `_run_git(..., ["cat-file", "-e", f"{sha}^{{commit}}"])` without verifying if it started with a hyphen, which could cause Git to misinterpret the input as a command-line flag.
🎯 Impact: A malicious user could supply a string starting with a hyphen to inject arbitrary Git options, potentially altering command execution context or bypassing expected behavior.
🔧 Fix: Added a check `sha.startswith("-")` in `is_valid_commit` to return `False` immediately, neutralizing any injection attempt.
✅ Verification: Ran the full test suite (`uv run pytest`) and verified the fix introduced no regressions. Code passes linter checks (`uv run ruff check`).

---
*PR created automatically by Jules for task [4933240040208983773](https://jules.google.com/task/4933240040208983773) started by @n24q02m*