### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection via Git CLI options

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -203,6 +203,9 @@ def is_valid_commit(repo_root: Path, sha: str) -> bool:
     """Return True if sha identifies a reachable commit object."""
     if not sha:
         return False
+    # SECURITY: Prevent argument injection to git cat-file
+    if sha.startswith("-"):
+        return False
     result = _run_git(repo_root, ["cat-file", "-e", f"{sha}^{{commit}}"])
     return result is not None and result.returncode == 0
 

--- a/tests/test_incremental_extra.py
+++ b/tests/test_incremental_extra.py
@@ -613,6 +613,12 @@ class TestGitHelpers:
 
         assert is_valid_commit(tmp_path, "") is False
 
+    def test_is_valid_commit_argument_injection(self, tmp_path):
+        from better_code_review_graph.incremental import is_valid_commit
+
+        # Should be rejected immediately without calling git
+        assert is_valid_commit(tmp_path, "--batch") is False
+
     @patch("better_code_review_graph.incremental.subprocess.run")
     @patch("better_code_review_graph.incremental.shutil.which", return_value="git")
     def test_run_git_handles_timeout(self, _which, mock_run, tmp_path):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Command/Argument Injection via Git CLI Options
🎯 **Impact:** An attacker could pass a malicious `sha` string starting with a hyphen (e.g., `--batch`) to `is_valid_commit` in `src/better_code_review_graph/incremental.py`. When interpolated into the `subprocess.run` list without `--` separators, `git cat-file` evaluates it as an option flag rather than a positional object identifier, leading to unintended behavior or potential execution of arbitrary option side-effects.
🔧 **Fix:** Added validation to explicitly reject `sha` strings that start with a hyphen (`-`) before invoking `subprocess.run`.
✅ **Verification:** Added `test_is_valid_commit_argument_injection` in `tests/test_incremental_extra.py` which passes and returns `False` safely. All existing tests and linters pass.

---
*PR created automatically by Jules for task [17597453951930267696](https://jules.google.com/task/17597453951930267696) started by @n24q02m*