### PR TITLE
fix: pin rangeStrategy on delayed packageRules (renovate artifacts)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,8 @@
       "groupSlug": "non-major-dev",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "rangeStrategy": "pin"
     },
     {
       "description": "Auto-merge patch updates after cooldown",
@@ -57,7 +58,8 @@
       "groupSlug": "all-patch",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "rangeStrategy": "pin"
     },
     {
       "description": "Auto-merge GitHub Actions digest updates after cooldown",


### PR DESCRIPTION
## Root cause

This repo's `renovate.json` carries the same misconfiguration that caused Renovate's `artifacts` check to fail on 6 sibling repos in the MCP stack (mcp-core#647, better-telegram-mcp#911, wet-mcp#1532, mnemo-mcp#973, imagine-mcp#434, web-core#636 — all copy-pasted from the same template):

`renovate.json` sets a global `rangeStrategy: "bump"` (keeps an open-ended version range in the manifest) together with `minimumReleaseAge: "7 days"` on the `non-major-dev` and `all-patch` packageRules. Renovate only *proposes* a version that has aged 7 days, but when it then runs the package manager to regenerate the lockfile, that step independently re-resolves the still-open range against the live registry — and can pick an even newer version that has NOT yet passed the 7-day gate. Renovate then fails the artifact-update step for its own safety, since the lockfile now contains a version it never vetted.

This is a known Renovate limitation: `minimumReleaseAge` does not constrain package-manager resolution while the written range stays open (renovatebot/renovate#41624). This repo hasn't hit the failure yet only because no patch/dev-minor Renovate PR here has coincided with a same-window upstream release — it will recur on the next one without this fix.

## Fix

Add `rangeStrategy: "pin"` as a local override on exactly the packageRules that carry `minimumReleaseAge: "7 days"` (`non-major-dev`, `all-patch`). Pinning makes Renovate write the exact vetted version into the manifest, so the lockfile step resolves to that same version instead of re-opening the range. The global `rangeStrategy: "bump"` is left untouched for every other dependency.

`gha-digests` also carries `minimumReleaseAge` but is intentionally left as-is: GitHub Actions are SHA-pinned directly with no separate package-manager lockfile-resolution step, so it isn't subject to this failure mode.
