### PR TITLE
feat: per-sub custom endpoint (api_base) in relay for gateway routing

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -40,6 +40,11 @@ CLOUD_KEYS = [
     "COHERE_API_KEY",
     "CO_API_KEY",
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
+    # Per-sub custom endpoints (SSRF-vetted in mcp_core.llm dispatch). Listed
+    # here so the per-sub bucket carries them and the os.environ filter in
+    # credentials_for_current_request keeps them, same as the provider keys.
+    "EMBEDDING_API_BASE",
+    "LLM_API_BASE",
 ]
 
 

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -340,18 +340,25 @@ class CloudEmbeddingBackend:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import embedding
 
+        from .credential_state import config_value_for_current_request
+
         kwargs: dict[str, Any] = {}
         if dimensions:
             kwargs["dimensions"] = dimensions
         if self._provider == "cohere":
             kwargs["input_type"] = "search_document"
 
+        # Resolve the custom endpoint request-scoped (per-sub bucket in HTTP
+        # multi-user, os.environ in stdio/single-user) via the same accessor
+        # as the key, so one sub's gateway URL never serves another. Reading
+        # os.getenv here would make the per-sub endpoint a silent no-op in
+        # multi-user mode. SSRF-vetted downstream in mcp_core.llm dispatch.
         # Normalise empty string to None: mcp_core.llm forwards a non-None
         # api_key to litellm, which suppresses provider env-var fallback (401).
         resp = embedding(
             model=self._litellm_model(),
             input=texts,
-            api_base=os.getenv("EMBEDDING_API_BASE") or None,
+            api_base=config_value_for_current_request("EMBEDDING_API_BASE") or None,
             api_key=self._resolve_api_key() or None,
             **kwargs,
         )

--- a/src/better_code_review_graph/relay_schema.py
+++ b/src/better_code_review_graph/relay_schema.py
@@ -39,6 +39,22 @@ def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
     }
 
 
+def _api_base_field(key: str, label: str, help_text: str) -> dict[str, Any]:
+    # Always-visible (not derived): the renderer only reveals a derived field
+    # when a model chip derives that exact provider ENV key, and no model
+    # derives *_API_BASE, so a derived endpoint field would stay hidden. The
+    # optional badge comes from required:false. Value is SSRF-vetted per-sub in
+    # mcp_core.llm dispatch before any request.
+    return {
+        "key": key,
+        "label": label,
+        "type": "url",
+        "placeholder": "https://gateway.example/…",
+        "helpText": help_text,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "better-code-review-graph",
     "displayName": "Code Review Graph",
@@ -57,6 +73,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": True,
             "placeholder": "add embedding model…",
         },
+        _api_base_field(
+            "EMBEDDING_API_BASE",
+            "Embedding endpoint",
+            "Custom endpoint / CF AI Gateway for embedding calls.",
+        ),
         {
             "key": "SUMMARY_MODELS",
             "label": "Summary models",
@@ -66,6 +87,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": False,
             "placeholder": "add summary model…",
         },
+        _api_base_field(
+            "LLM_API_BASE",
+            "Summary (LLM) endpoint",
+            "Custom endpoint / CF AI Gateway for summary LLM calls.",
+        ),
         _key_field(
             "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
         ),

--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -204,13 +203,20 @@ def summarize_node(
     # Lazy import: litellm costs ~1-2s on first import.
     from mcp_core.llm import completion
 
+    from .credential_state import config_value_for_current_request
+
     try:
+        # Resolve the custom endpoint request-scoped (per-sub bucket in HTTP
+        # multi-user, os.environ in stdio/single-user) via the same accessor
+        # the caller uses for the key, so one sub's gateway URL never serves
+        # another. Reading os.environ here would make the per-sub endpoint a
+        # silent no-op in multi-user mode. SSRF-vetted downstream in dispatch.
         # Normalise empty string to None: mcp_core.llm forwards a non-None
         # api_key to litellm, which suppresses provider env-var fallback (401).
         response = completion(
             model=model,
             messages=[{"role": "user", "content": prompt}],
-            api_base=os.environ.get("LLM_API_BASE") or None,
+            api_base=config_value_for_current_request("LLM_API_BASE") or None,
             api_key=api_key or None,
         )
     except Exception as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from better_code_review_graph.parser import EdgeInfo, NodeInfo  # noqa: E402
 
 @pytest.fixture(scope="session", autouse=True)
 def _isolate_global_git_config() -> None:
-    """Strip global git config so test-created repos commit deterministically.
+    """Isolate test-created git repos from the ambient git environment.
 
     Without this, tests that ``git init`` a throwaway repo and run
     ``git commit`` inherit the developer/CI ``commit.gpgsign``,
@@ -28,8 +28,26 @@ def _isolate_global_git_config() -> None:
     sandboxed test environment (e.g. inside a CI runner image that
     pre-configures SSH signing), the commit aborts with a confusing
     "signing failed" error unrelated to the test logic.
+
+    We also strip the per-invocation ``GIT_*`` location vars that ``git``
+    injects into hook processes (``GIT_DIR`` / ``GIT_INDEX_FILE`` /
+    ``GIT_WORK_TREE`` / ``GIT_PREFIX`` / ``GIT_OBJECT_DIRECTORY`` /
+    ``GIT_COMMON_DIR``). Otherwise, when the suite runs as the ``pytest``
+    pre-commit hook, those vars point every ``git`` subprocess in
+    ``test_temporal_migration`` back at the parent repo's (locked) index
+    instead of the tmp repo it just created -> ``git commit`` exits 1 and
+    the tests error. Popping them makes the git-subprocess tests hermetic.
     """
     os.environ.setdefault("GIT_CONFIG_GLOBAL", "/dev/null")
+    for var in (
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_WORK_TREE",
+        "GIT_PREFIX",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_COMMON_DIR",
+    ):
+        os.environ.pop(var, None)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_multi_user_dispatch.py
+++ b/tests/test_multi_user_dispatch.py
@@ -276,3 +276,193 @@ def test_summarizer_dispatch_second_sub_isolated(
     assert call_kwargs["api_key"] != "sk-a"
     assert os.environ.get("GEMINI_API_KEY") is None
     assert os.environ.get("OPENAI_API_KEY") is None
+
+
+# ---------------------------------------------------------------------------
+# Per-sub custom endpoint (api_base): EMBEDDING_API_BASE / LLM_API_BASE reach
+# the dispatch per request. Reading os.getenv instead would make the per-sub
+# relay endpoint a silent no-op in multi-user mode (it only lives in the sub
+# bucket, never the shared process env).
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_dispatch_uses_per_sub_api_base(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """The per-sub EMBEDDING_API_BASE reaches mcp_core.llm.embedding."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+    store_for_sub(
+        "sub-a",
+        {
+            "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+            "GEMINI_API_KEY": "gm-a",
+            "EMBEDDING_API_BASE": "https://gw-a/v1",
+        },
+    )
+
+    _current_sub.set("sub-a")
+    backend = CloudEmbeddingBackend()
+    with patch("mcp_core.llm.embedding") as mock_embed:
+        mock_embed.return_value = _embedding_response(1)
+        backend.embed_texts(["hello"], dimensions=768)
+
+    call_kwargs = mock_embed.call_args.kwargs
+    assert call_kwargs["api_base"] == "https://gw-a/v1"
+    assert call_kwargs["api_key"] == "gm-a"
+    # Per-sub endpoint must NOT have leaked into the process environment.
+    assert os.environ.get("EMBEDDING_API_BASE") is None
+
+
+def test_embedding_dispatch_api_base_second_sub_isolated(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """A second sub drives its own EMBEDDING_API_BASE -- never sub-a's."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+    store_for_sub(
+        "sub-a",
+        {
+            "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+            "GEMINI_API_KEY": "gm-a",
+            "EMBEDDING_API_BASE": "https://gw-a/v1",
+        },
+    )
+    store_for_sub(
+        "sub-b",
+        {
+            "EMBEDDING_MODELS": "openai/text-embedding-3-large",
+            "OPENAI_API_KEY": "sk-b",
+            "EMBEDDING_API_BASE": "https://gw-b/v1",
+        },
+    )
+
+    _current_sub.set("sub-b")
+    backend = CloudEmbeddingBackend()
+    with patch("mcp_core.llm.embedding") as mock_embed:
+        mock_embed.return_value = _embedding_response(1)
+        backend.embed_texts(["hello"], dimensions=768)
+
+    call_kwargs = mock_embed.call_args.kwargs
+    assert call_kwargs["api_base"] == "https://gw-b/v1"
+    assert call_kwargs["api_base"] != "https://gw-a/v1"
+
+
+def test_summarizer_dispatch_uses_per_sub_api_base(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """The per-sub LLM_API_BASE reaches mcp_core.llm.completion."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+    store_for_sub(
+        "sub-a",
+        {
+            "SUMMARY_MODELS": "openai/gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-a",
+            "LLM_API_BASE": "https://gw-a/llm",
+        },
+    )
+
+    store = GraphStore(str(tmp_path / "graph_a.db"))
+    _seed_function_node(store)
+
+    _current_sub.set("sub-a")
+    with patch("mcp_core.llm.completion") as mock_completion:
+        mock_completion.return_value = _completion_response("does a thing")
+        result = batch_summarize(store)
+    store.close()
+
+    assert result.generated == 1
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["api_base"] == "https://gw-a/llm"
+    assert call_kwargs["api_key"] == "sk-a"
+    assert os.environ.get("LLM_API_BASE") is None
+
+
+def test_summarizer_dispatch_api_base_second_sub_isolated(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """sub-b's LLM_API_BASE never bleeds sub-a's endpoint."""
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+    store_for_sub(
+        "sub-a",
+        {
+            "SUMMARY_MODELS": "openai/gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-a",
+            "LLM_API_BASE": "https://gw-a/llm",
+        },
+    )
+    store_for_sub(
+        "sub-b",
+        {
+            "SUMMARY_MODELS": "gemini/gemini-2.5-flash",
+            "GEMINI_API_KEY": "gm-b",
+            "LLM_API_BASE": "https://gw-b/llm",
+        },
+    )
+
+    store = GraphStore(str(tmp_path / "graph_b.db"))
+    _seed_function_node(store)
+
+    _current_sub.set("sub-b")
+    with patch("mcp_core.llm.completion") as mock_completion:
+        mock_completion.return_value = _completion_response("does b thing")
+        batch_summarize(store)
+    store.close()
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["api_base"] == "https://gw-b/llm"
+    assert call_kwargs["api_base"] != "https://gw-a/llm"
+
+
+def test_api_base_falls_back_to_env_when_no_sub(monkeypatch, _clean_cloud_env):
+    """Stdio / single-user (sub is None): *_API_BASE comes from os.environ.
+
+    Unlike provider keys, litellm does not know crg's own ``*_API_BASE``
+    names, so the single-user path must surface the env value or the
+    configured endpoint would be dropped.
+    """
+    monkeypatch.setenv("EMBEDDING_API_BASE", "https://env-embed/v1")
+    monkeypatch.setenv("LLM_API_BASE", "https://env-llm/v1")
+
+    from better_code_review_graph.credential_state import (
+        config_value_for_current_request,
+    )
+
+    assert _current_sub.get() is None
+    assert (
+        config_value_for_current_request("EMBEDDING_API_BASE") == "https://env-embed/v1"
+    )
+    assert config_value_for_current_request("LLM_API_BASE") == "https://env-llm/v1"
+
+
+def test_per_sub_api_base_ssrf_rejected_in_multi_user(
+    tmp_path, monkeypatch, _clean_cloud_env
+):
+    """A per-sub loopback EMBEDDING_API_BASE is blocked by the SSRF vet.
+
+    The resolved endpoint flows into the REAL mcp_core.llm dispatch, which
+    vets it (``_prep_api_base`` -> ``vet_api_base``) before any network call.
+    ``PUBLIC_URL`` set => multi-user => loopback/private blocked
+    unconditionally. Proves the per-sub endpoint stays on the vetted path.
+    """
+    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://crg.example")  # multi-user mode
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+
+    from mcp_core.http import SSRFBlockedError
+
+    store_for_sub(
+        "sub-a",
+        {
+            "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+            "GEMINI_API_KEY": "gm-a",
+            "EMBEDDING_API_BASE": "http://127.0.0.1:9000",
+        },
+    )
+
+    _current_sub.set("sub-a")
+    backend = CloudEmbeddingBackend()
+    with pytest.raises(SSRFBlockedError):
+        backend.embed_texts(["hello"], dimensions=768)


### PR DESCRIPTION
## What

Adds `EMBEDDING_API_BASE` / `LLM_API_BASE` to the relay form so each JWT `sub` can route litellm through its own CF AI Gateway (or any custom endpoint), instead of a single server-wide env shared across all users. crg has no reranker, so only the embedding + summary (LLM) tasks get an endpoint field.

## Why per-sub resolution (not `os.getenv`)

crg already resolves the provider **key** per request via `config_value_for_current_request` (reads the bound sub's bucket for HTTP multi-user, falls back to `os.environ` single-user). If `api_base` only read `os.getenv`, the per-sub endpoint field would be a **silent no-op** in multi-user mode — those endpoints only ever live in the sub bucket, never the shared process env, so every sub would fall back to the same server-wide value (or `None`).

`embeddings._call_provider` and `summarizer.summarize_node` now read `config_value_for_current_request("EMBEDDING_API_BASE" / "LLM_API_BASE")` — the same request-scoped accessor already used for the key. Single-user / stdio is unchanged (the accessor returns `os.environ.get(...)`, and litellm does not know crg's own `*_API_BASE` names, so surfacing the env value here is required).

## SSRF

The resolved endpoint stays on the vetted path: it flows into `mcp_core.llm` dispatch (sync `embedding` / `completion` -> `_prep_api_base` -> `vet_api_base`), which blocks loopback/private targets **unconditionally** when `PUBLIC_URL` is set (multi-user). No bypass. Covered by a test that drives a per-sub loopback endpoint through the real dispatch and asserts `SSRFBlockedError`.

## Relay field shape

The `*_API_BASE` fields are **always-visible** (not `derived`) + `required: false`. The renderer only reveals a `derived` field when a model chip derives that exact provider ENV key, and no model derives `*_API_BASE`, so a derived endpoint field would stay hidden forever. Added to `CLOUD_KEYS` so the per-sub bucket carries them and the single-user `os.environ` filter keeps them, same as the provider keys.

## Tests

Per-sub isolation (the crux): two subs with different `EMBEDDING_API_BASE` / `LLM_API_BASE` each drive their own endpoint through the embedding + summarizer dispatch — no bleed. Plus the single-user env fallback and the SSRF reject. All green (1295 passed).

## Note: harness fix commit

The first commit (`fix: make git-subprocess tests hermetic under the pre-commit hook`) is a prerequisite: `test_temporal_migration` git-inits a throwaway repo, and when the suite runs as the `pytest` pre-commit hook, git injects `GIT_DIR` / `GIT_INDEX_FILE` into the hook env, pointing those subprocess git calls at the parent repo's locked index -> the tests error only during an actual commit. The session-autouse git-isolation fixture now pops the per-invocation `GIT_*` location vars so the git-subprocess tests are hermetic. Unrelated to the feature, but the feature could not be committed through the mandatory hook without it.