### PR TITLE
⚡ Bolt: Use executescript for GraphStore schema backfills

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,9 @@
 ## 2024-07-17 - Prevent N+1 queries when traversing graphs from multiple source nodes
 **Learning:** Resolving targets (e.g. callees, imports, children, inheritors) for graph visualization/traversal previously resulted in N+1 database roundtrips. When expanding multiple edges, executing `get_edges_by_source` or `get_edges_by_target` per original node generated excessive SQLite overhead, especially for dense repositories.
 **Action:** Replace looped individual lookups with batched SQLite queries utilizing `search_edges_by_source_names` or `search_edges_by_target_names` which process multiple node identifiers in a single roundtrip via `json_each`.
+
+## 2024-07-28 - Grouping Setup DDL Statements via executescript
+
+**Learning:** Running multiple `ALTER TABLE`, `CREATE TABLE`, and `CREATE INDEX` statements individually during component initialization creates unnecessary database roundtrip overhead. This slows down application startup, especially when checking or enforcing schema migrations.
+
+**Action:** When performing schema initialization or migrations, batch all DDL statements together into a single string (using semicolons to separate statements) and execute them via `self._conn.executescript()`. This consolidates the initialization process into a single transaction, significantly reducing SQLite execution time.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -491,34 +491,34 @@ class GraphStore:
           call unconditionally on every connect.
         """
         node_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(nodes)")}
-        if "repo_id" not in node_cols:
-            self._conn.execute(
-                "ALTER TABLE nodes ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
-            )
         edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
-        if "repo_id" not in edge_cols:
-            self._conn.execute(
-                "ALTER TABLE edges ADD COLUMN repo_id TEXT NOT NULL DEFAULT ''"
+
+        script = []
+        if "repo_id" not in node_cols:
+            script.append(
+                "ALTER TABLE nodes ADD COLUMN repo_id TEXT NOT NULL DEFAULT '';"
             )
+        if "repo_id" not in edge_cols:
+            script.append(
+                "ALTER TABLE edges ADD COLUMN repo_id TEXT NOT NULL DEFAULT '';"
+            )
+
         # Repos registry table — created by migration 003 on disk-backed
         # DBs. Mirror it here for in-memory connections so RepoRegistry
         # works against ``:memory:`` GraphStores too.
-        self._conn.execute(
-            """CREATE TABLE IF NOT EXISTS repos (
+        script.append("""
+            CREATE TABLE IF NOT EXISTS repos (
                 repo_id TEXT PRIMARY KEY NOT NULL,
                 path TEXT NOT NULL,
                 remote_url TEXT,
                 last_indexed_sha TEXT,
                 first_indexed_at INTEGER NOT NULL,
                 last_indexed_at INTEGER NOT NULL
-            )"""
-        )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_nodes_repo_kind ON nodes(repo_id, kind)"
-        )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_edges_repo ON edges(repo_id)"
-        )
+            );
+            CREATE INDEX IF NOT EXISTS idx_nodes_repo_kind ON nodes(repo_id, kind);
+            CREATE INDEX IF NOT EXISTS idx_edges_repo ON edges(repo_id);
+        """)
+        self._conn.executescript("\n".join(script))
         self._conn.commit()
 
     def _ensure_temporal_columns(self) -> None:
@@ -547,29 +547,27 @@ class GraphStore:
         downstream temporal queries treat the two paths identically.
         """
         node_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(nodes)")}
+        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+
+        script = []
         if "valid_from_sha" not in node_cols:
-            self._conn.execute(
-                "ALTER TABLE nodes ADD COLUMN valid_from_sha TEXT NOT NULL "
-                "DEFAULT '0000000000000000000000000000000000000000'"
+            script.append(
+                "ALTER TABLE nodes ADD COLUMN valid_from_sha TEXT NOT NULL DEFAULT '0000000000000000000000000000000000000000';"
             )
         if "valid_to_sha" not in node_cols:
-            self._conn.execute("ALTER TABLE nodes ADD COLUMN valid_to_sha TEXT")
-        edge_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+            script.append("ALTER TABLE nodes ADD COLUMN valid_to_sha TEXT;")
         if "valid_from_sha" not in edge_cols:
-            self._conn.execute(
-                "ALTER TABLE edges ADD COLUMN valid_from_sha TEXT NOT NULL "
-                "DEFAULT '0000000000000000000000000000000000000000'"
+            script.append(
+                "ALTER TABLE edges ADD COLUMN valid_from_sha TEXT NOT NULL DEFAULT '0000000000000000000000000000000000000000';"
             )
         if "valid_to_sha" not in edge_cols:
-            self._conn.execute("ALTER TABLE edges ADD COLUMN valid_to_sha TEXT")
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_nodes_temporal "
-            "ON nodes(valid_from_sha, valid_to_sha)"
-        )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_edges_temporal "
-            "ON edges(valid_from_sha, valid_to_sha)"
-        )
+            script.append("ALTER TABLE edges ADD COLUMN valid_to_sha TEXT;")
+
+        script.append("""
+            CREATE INDEX IF NOT EXISTS idx_nodes_temporal ON nodes(valid_from_sha, valid_to_sha);
+            CREATE INDEX IF NOT EXISTS idx_edges_temporal ON edges(valid_from_sha, valid_to_sha);
+        """)
+        self._conn.executescript("\n".join(script))
         self._conn.commit()
 
     def _ensure_summary_columns(self) -> None:
@@ -584,17 +582,20 @@ class GraphStore:
         """
         existing = {row[1] for row in self._conn.execute("PRAGMA table_info(nodes)")}
         column_sqls = {
-            "summary": "ALTER TABLE nodes ADD COLUMN summary TEXT",
-            "summary_provider": "ALTER TABLE nodes ADD COLUMN summary_provider TEXT",
-            "source_hash": "ALTER TABLE nodes ADD COLUMN source_hash TEXT",
-            "source_text": "ALTER TABLE nodes ADD COLUMN source_text TEXT",
+            "summary": "ALTER TABLE nodes ADD COLUMN summary TEXT;",
+            "summary_provider": "ALTER TABLE nodes ADD COLUMN summary_provider TEXT;",
+            "source_hash": "ALTER TABLE nodes ADD COLUMN source_hash TEXT;",
+            "source_text": "ALTER TABLE nodes ADD COLUMN source_text TEXT;",
         }
+
+        script = []
         for column in _SUMMARY_COLUMNS:
             if column not in existing and column in column_sqls:
-                self._conn.execute(column_sqls[column])
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_nodes_source_hash ON nodes(source_hash)"
+                script.append(column_sqls[column])
+        script.append(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_source_hash ON nodes(source_hash);"
         )
+        self._conn.executescript("\n".join(script))
         self._conn.commit()
 
     def _invalidate_cache(self) -> None:


### PR DESCRIPTION
💡 **What:** Modified `_ensure_federation_columns`, `_ensure_temporal_columns`, and `_ensure_summary_columns` in `src/better_code_review_graph/graph.py` to batch their respective `ALTER TABLE`, `CREATE TABLE`, and `CREATE INDEX` statements into a single `self._conn.executescript()` call.

🎯 **Why:** Running multiple DDL statements individually during component initialization creates unnecessary database roundtrip overhead. Batching them eliminates Python-level loop overhead and multiple `.execute()` API calls, improving startup performance.

📊 **Impact:** Reduces database API call roundtrips during server startup by batching all initialization DDL into a single script block per column group.

🔬 **Measurement:** Verified that the startup initialization succeeds and all unit tests continue to pass correctly.

---
*PR created automatically by Jules for task [15233856132981464591](https://jules.google.com/task/15233856132981464591) started by @n24q02m*