### PR TITLE
feat: derive a stable subject from the workspace username

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,24 @@ setup form (`config(action="setup_start")` returns the browser URL). See the
 [modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) and
 [multi-user setup](https://mcp.n24q02m.com/get-started/multi-user/).
 
+### Workspace username (HTTP setup form)
+
+The relay setup form has an optional **workspace username** field. Entering the
+same username always lands you in the same per-`sub` bucket, so your keys and
+graph stay reachable across a re-authorization and across devices, instead of
+being tied to the one-off subject minted for each `/authorize` round-trip.
+Leaving it blank keeps the previous per-authorize behaviour.
+
+Trust boundary: when the form is gated by a *shared* `MCP_RELAY_PASSWORD`, the
+username is a partition key, not a secret -- anyone who knows that password can
+type any username and reach that bucket. That is fine for a trusted group; an
+untrusted multi-tenant deployment needs a per-user secret or delegated OAuth
+instead.
+
+**One-time migration:** existing users must re-enter their credentials once after
+this change. Nothing is deleted; credentials stored under the old random subject
+are simply no longer addressed.
+
 ## Tools
 
 Seven tools, each grouping related actions to keep the tool surface small.

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -965,6 +965,7 @@ async def run_http(port: int = 0) -> None:
         host=host,
         on_credentials_saved=save_credentials,
         auth_scope=_per_request_sub_scope if public_url else None,
+        stable_sub_enabled=True,
     )
 
 


### PR DESCRIPTION
Part of n24q02m/mcp-core#676. Enables the existing core-py stable-sub mechanism so credentials entered in a later authorize round-trip reach the same per-sub bucket, instead of the one-off subject minted per /authorize.

The browser setup form now shows an optional workspace-username field. Same username -> same per-sub bucket across re-auth and devices; blank keeps the previous random-subject behaviour.

WARNING -- one-time credential re-entry required: enabling this changes how the subject is computed, so credentials already stored under a random subject are no longer addressed (not deleted). Every existing user must re-enter credentials once at their next setup.

Trust boundary: with a SHARED relay password the username is a partition key, NOT a secret -- anyone who knows the password can submit any username and reach that bucket. Suitable for a trusted group; untrusted multi-tenant needs per-user secrets or delegated OAuth.

Gate run locally: ruff check + ruff format --check + pytest, all green.