### PR TITLE
🛡️ Sentinel: [HIGH] Fix command argument injection in _get_git_content

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1823,6 +1823,9 @@ def spot_check_last_callers(
 
 def _get_git_content(root: Path, base: str, rel_path: str) -> bytes | None:
     """Fetch file content from a specific git ref."""
+    if base.startswith("-"):
+        return None
+
     import shutil
     import subprocess
 

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.20.0"
+version = "3.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.21.0"
+version = "3.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `_get_git_content` function in `src/better_code_review_graph/tools.py` passed the `base` argument directly to `subprocess.run` without checking if it started with a hyphen, which could allow a malicious actor to perform command argument injection when constructing the git ref (`f"{base}:{rel_path}"`).
🎯 Impact: Attackers could inject arbitrary command-line arguments to the `git show` subprocess by supplying a git ref string starting with `-`.
🔧 Fix: Added a validation check `if base.startswith("-"): return None` to early-exit if a malicious argument is supplied, preventing option injection.
✅ Verification: Ran `uv run pytest`, `uv run ruff check`, `uv run ty check`, and `uv run bandit -r src/` to verify tests pass and no regressions were introduced.

---
*PR created automatically by Jules for task [788118476930672810](https://jules.google.com/task/788118476930672810) started by @n24q02m*