### PR TITLE
fix: bump mcp-core to 1.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,13 @@ dependencies = [
     "qwen3-embed>=1.12.1",
     "httpx",
     "pydantic-settings",
-    # 1.20.0 carries the build_cli `config`/`doctor` PerPluginStore key fix
-    # (#666) for servers whose plugin slug differs from server_name
-    # (this repo's slug == server_name already, so no CLI regression
-    # here -- kept for cascade parity with wet/mnemo).
-    "n24q02m-mcp-core[llm]>=1.20.0,<2",
+    # Floor tracks the current mcp-core stable for cascade parity with
+    # wet/mnemo. Carries the build_cli `config`/`doctor` PerPluginStore key
+    # fix (#666) for servers whose plugin slug differs from server_name
+    # (this repo's slug == server_name already, so no CLI regression here).
+    # Keep this on a stable release -- a prerelease floor such as 1.20.0b2
+    # sorts below its own stable under PEP 440 and does not require it.
+    "n24q02m-mcp-core[llm]>=1.21.0,<2",
     # litellm security floor (transitive via mcp-core[llm]). 1.83.x-1.87.x carry 4
     # advisories in litellm's PROXY server: GHSA-r75f-5x8p-qvmc (SQLi in proxy key
     # verify), GHSA-xqmj-j6mv-4862 (SSTI /prompts/test), GHSA-v4p8-mg3p-g94g (cmd-exec

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.93.0" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.21.0,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -585,11 +585,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.20.0"
+version = "1.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1161,9 +1161,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/99/a7e0e3c18bd5a4091dd8b6062b9277dd059de4d5e359ad4ee3735bbf572d/n24q02m_mcp_core-1.20.0.tar.gz", hash = "sha256:9050d6c2892dc931d82621e938dd2cb6e54091623414c914c6878d5d55c8c105", size = 345341, upload-time = "2026-07-18T09:08:59.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/30/590222f26ace6b3f4eb9d39f6338993a77a487056131e3b8e44cac1f3a01/n24q02m_mcp_core-1.21.0.tar.gz", hash = "sha256:0902edef3c11cae453b12054b5c86b01f2c44b340baa62ba20178913c5605e0c", size = 347475, upload-time = "2026-07-25T07:39:49.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/dd/d0e7ab1ce6e19a3049a55e393f98a43e9d838d431f3950f48df3acac7c11/n24q02m_mcp_core-1.20.0-py3-none-any.whl", hash = "sha256:f610bfb686c51c7c965842e7890d22c3a382a3957269c13858d17be5e9399841", size = 189453, upload-time = "2026-07-18T09:08:57.997Z" },
+    { url = "https://files.pythonhosted.org/packages/61/09/0777b67ea7e8fdf96294342bf6aa3b5d76a368a67f46a870a7e4a3bf7966/n24q02m_mcp_core-1.21.0-py3-none-any.whl", hash = "sha256:9f78057826aa32a752bed5d7512bc78f0574b4b56a619f4b1b6cfa12d22cfb89", size = 190145, upload-time = "2026-07-25T07:39:47.979Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #895. mcp-core cut 1.21.0 stable earlier today.

`uv lock` changed exactly two entries, and no packages were added or removed:

| Entry | Before | After |
|---|---|---|
| `n24q02m-mcp-core` | 1.20.0 | 1.21.0 |
| `filelock` (dependency of mcp-core) | 3.29.7 | 3.32.0 |

The pin comment now records why the floor has to name a stable release. The
floor this repo carried until earlier today was `>=1.20.0b2`, which under
PEP 440 sorts *below* `1.20.0` -- so it permitted the beta rather than requiring
the release, and `uv.lock` had duly resolved to `1.20.0b2`. Noting it inline so
the next bump does not reintroduce a prerelease floor.