### PR TITLE
fix: run CodeQL on dependabot and renovate pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,14 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    # Runs for bot actors too. The "Main Ruleset" requires CodeQL results to
+    # merge, and this repo has code-scanning default setup disabled, so this
+    # job is the only producer of those results. Excluding dependabot and
+    # renovate left every dependency PR permanently blocked and merged only
+    # via --admin, which bypasses the whole ruleset rather than just CodeQL.
+    # Dependency changes are also the changes most worth scanning.
     if: >-
       (github.event_name == 'pull_request' || github.event_name == 'push')
-      && github.actor != 'dependabot[bot]'
-      && github.actor != 'renovate[bot]'
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## The gate contradicted itself

`ci.yml` skipped the `codeql` job for bot actors:

```yaml
if: >-
  (github.event_name == 'pull_request' || github.event_name == 'push')
  && github.actor != 'dependabot[bot]'
  && github.actor != 'renovate[bot]'
```

Meanwhile the "Main Ruleset" (`14177689`) carries a `code_scanning` rule
(`alerts_threshold: errors`, `security_alerts_threshold: high_or_higher`, tool
CodeQL), and this repo has code-scanning **default setup not configured** -- so
this job is the only thing that ever produces CodeQL results.

Skipping the scan and then requiring the scan's results leaves every bot
dependency PR permanently `BLOCKED`. The only way to land one is `--admin`,
which bypasses the *entire* ruleset, not merely CodeQL. That happened five times
earlier today clearing the Renovate backlog (#852, #853, #854, #857, #890).

## Change

Drops the two actor exclusions. The event-type condition is unchanged, so the
job still does not run for `pull_request_target` or `issues` events.

Dependency bumps are the changes most worth scanning, and Actions minutes are
free on public repositories, so the exclusion bought nothing in return.

The ruleset itself is untouched -- the fix makes the scan run rather than
relaxing the requirement for it.

## Verification

`codeql-action` v4.37.3 already runs clean on `main` (run `30149573544`,
`CodeQL Analysis: success`), so this does not interact with the v4 bump merged
earlier today.

End-to-end confirmation needs the next bot PR to open: there are currently zero
open PRs on this repo, so the bot-actor path cannot be exercised yet.