### PR TITLE
feat: add bot PR governance workflow

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -1,0 +1,90 @@
+name: Bot PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  governance:
+    name: Bot PR Rate Limit & Duplicate Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and govern bot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+          ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          # Detect if this is a bot-created PR by branch name pattern.
+          # Two signals:
+          #   1. Explicit bot-tool prefixes (Bolt, Palette, Jules, fix/web-scraper)
+          #   2. Any branch ending with a long numeric task/trace ID (-[0-9]{14,})
+          IS_BOT_PR=false
+          if echo "$BRANCH" | grep -qE \
+              '^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])'; then
+            IS_BOT_PR=true
+          elif echo "$BRANCH" | grep -qE -- \
+              '-[0-9]{14,}$'; then
+            IS_BOT_PR=true
+          fi
+
+          if [ "$IS_BOT_PR" = "false" ]; then
+            echo "Not a bot PR ($BRANCH), skipping governance checks."
+            exit 0
+          fi
+
+          echo "Bot PR detected on branch: $BRANCH"
+          gh pr edit "$PR_NUMBER" --add-label "bot-generated" --repo "$REPO" || true
+
+          # --- Rate limit: max 5 bot PRs/actor/day ---
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                  date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh pr list --repo "$REPO" --state open \
+                   --json createdAt,headRefName,author \
+                   --jq "[.[] |
+                          select(.author.login == \"$ACTOR\") |
+                          select(.createdAt > \"$SINCE\") |
+                          select(.headRefName | test(
+                            \"^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])\" +
+                            \"|-[0-9]{14,}$\"
+                          ))] | length" 2>/dev/null || echo 0)
+
+          echo "Bot PRs by $ACTOR in last 24h: $COUNT"
+
+          if [ "${COUNT:-0}" -gt 5 ]; then
+            gh pr close "$PR_NUMBER" --repo "$REPO" \
+              --comment "**Bot rate limit exceeded**: $COUNT PRs created in the last 24 hours (limit: 5/day). This PR has been automatically closed to reduce PR backlog and CI resource waste. Please consolidate related fixes."
+            echo "PR #$PR_NUMBER closed: rate limit exceeded ($COUNT/5 today)"
+            exit 0
+          fi
+
+          # --- Duplicate detection by title keyword ---
+          KEYWORD=$(echo "$PR_TITLE" | sed 's/[^a-zA-Z0-9 _-]//g' | \
+                    tr '[:upper:]' '[:lower:]' | cut -c1-50 | xargs)
+          if [ -z "$KEYWORD" ]; then
+            echo "No keyword extracted, skipping duplicate check."
+            exit 0
+          fi
+
+          DUPES=$(gh pr list --repo "$REPO" --state open --search "$KEYWORD" \
+                   --json number \
+                   --jq "[.[] | select(.number != $PR_NUMBER)] | length" \
+                   2>/dev/null || echo 0)
+
+          echo "Similar open PRs for '$KEYWORD': $DUPES"
+          if [ "${DUPES:-0}" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" \
+              --add-label "possible-duplicate" || true
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "**Possible duplicate**: found ${DUPES} open PR(s) with similar title ('${KEYWORD}'). Check before merging: \`gh pr list --search '${KEYWORD}' --state open\`"
+          fi


### PR DESCRIPTION
Rate-limits bot PRs to 5 per actor per 24h, labels them `bot-generated`, and
flags likely duplicates on open.

## Why the ledger alone is not enough

Six of the eight bot PRs cleared today were two ideas restated: the
`search_nodes` word-count subquery arrived five times (#884, #885, #887, #891,
#892) and the `executescript` DDL batching once (#882). `.jules/bolt.md` now
carries a `Rejected` section with the measurements, but a ledger only steers
where the instruction is "do X instead of Y". Where the right outcome is
"propose nothing at all", there is no positive instruction to record -- so the
churn has to be absorbed at the repo edge instead.

## Provenance

Copied from `Aiora/.github/workflows/bot-governance.yml`, which is running in
production there (runs `30149371301`, `30147718822`, `30144511028` all green).

**Exactly one line differs from the template:**

```diff
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ubuntu-latest
```

Self-hosted runners are for private repos; this one is public. Detection
patterns are left untouched.

## Detection checked against this repo's real branches

| Branch | Matches | Intended |
|---|---|---|
| `bolt/optimize-search-nodes-4324878999568336161` | yes (`^bolt[-/]`, `-[0-9]{14,}$`) | yes |
| `bolt-optimize-subquery-4504501948816886263` | yes | yes |
| `fix/git-argument-injection-788118476930672810` (Sentinel) | yes (`-[0-9]{14,}$`) | yes |
| `renovate/python-3.13-slim-bookworm` | no | correct, Renovate is not throttled |
| `fix/bump-mcp-core-1.21.0`, `fix/jules-ledger-hygiene` | no | correct, human PRs untouched |

## Two notes on fit, not changed here

1. **Labels did not exist in this repo.** The workflow calls
   `gh pr edit --add-label "bot-generated"` and `"possible-duplicate"`, both
   guarded by `|| true`, so on a repo without those labels the labelling half
   fails silently. I created both labels rather than edit the template, so the
   workflow works from its first run.

2. **`gh pr close` is not guarded by `|| true` while `set -e` is active.** For
   same-repo bot branches -- which is how Bolt and Sentinel push here -- the
   token has write access and this is fine. A fork PR that tripped the rate
   limit would fail the step instead of closing, because `pull_request` grants
   a read-only token to forks on public repos. Left as-is to keep the template
   identical; flagging it since this repo is public and Aiora is not.