### PR TITLE
fix: make the decision logs a declared exception to the AI-traces ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,23 @@ medium/
 docs/superpowers/
 
 # AI traces (public repo hygiene)
-.jules/
-.Jules/
+# Conversation traces and scratch output from automated contributors stay out
+# of the repo. The two decision logs below are the deliberate exception: they
+# are instruction input that those tools read from a checkout, so they only
+# work if they live here, and they are written as technical documentation
+# (commit anchors, measurements, query plans) rather than as a record of any
+# conversation. Listed by name so new files under .jules/ stay ignored by
+# default.
+#
+# Both patterns end in `/*` rather than `/` because git cannot re-include a
+# file whose parent directory is itself excluded. `.Jules/*` needs the same
+# treatment as `.jules/*`: on a case-insensitive filesystem (Windows, macOS)
+# core.ignorecase makes `.Jules/` match this same directory, which would
+# re-exclude it after the negations and silently break the exception.
+.jules/*
+.Jules/*
+!.jules/bolt.md
+!.jules/sentinel.md
 .superpower/
 clean.ps1
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,7 +1,8 @@
-# Bolt ledger
+# Performance decision log
 
 Performance changes that have already landed, and proposals that were evaluated
-and rejected. Read both sections before opening a PR.
+and rejected. Read both sections before opening a performance PR, so that work
+already done is not repeated and work already ruled out is not re-proposed.
 
 Every landed entry is anchored to a commit. If an entry cannot be located in
 `git log`, treat the anchor as authoritative over the date.
@@ -76,13 +77,14 @@ Subquery 2 is not correlated, so SQLite already hoists it behind an `OP_Once` gu
 
 **Proposal:** batch the `ALTER TABLE` / `CREATE TABLE` / `CREATE INDEX` statements in `_ensure_federation_columns`, `_ensure_temporal_columns` and `_ensure_summary_columns` into one `self._conn.executescript()` call each.
 
-**Why it was rejected:** the measured saving is 46 microseconds per `GraphStore` init (median of 200 runs: 358.9 us individual vs 312.7 us batched), and these helpers run once per connection from `GraphStore.__init__` (`graph.py:258-260`). Against that, `sqlite3.Connection.executescript()` issues an implicit `COMMIT` before running its script — an uncommitted `INSERT` was observed surviving a subsequent `rollback()`. The patch turns three ordinary helpers into calls that silently end whatever transaction is open, and that is invisible at the call site.
+**Why it was rejected:** the measured saving is 46 microseconds per `GraphStore` init (median of 200 runs: 358.9 us individual vs 312.7 us batched), and these helpers run once per connection from `GraphStore.__init__`. Against that, `sqlite3.Connection.executescript()` issues an implicit `COMMIT` before running its script — an uncommitted `INSERT` was observed surviving a subsequent `rollback()`. The patch turns three ordinary helpers into calls that silently end whatever transaction is open, and that is invisible at the call site.
 
 **Action:** keep schema backfills as individual `execute()` calls. Reserve `executescript()` for migration scripts that already run outside a transaction, where the implicit commit is intended.
 
-## Conventions for this ledger
+## Conventions for this log
 
 - Date every entry with the date of the commit that landed it, taken from `git log`, not from the wall clock of the run writing the entry. Entries in this file dated 2024 were corrected to their real 2026 dates on 2026-07-25 after cross-checking with `git log -S`; an entry misfiled by two years cannot be matched against history and reads as absent.
 - Anchor every landed entry to a commit SHA.
+- Cite file and symbol names rather than line numbers, which drift as the file changes.
 - PR titles in this repo must start with `fix:` or `feat:`. `perf:` is not accepted — the gate in `ci.yml` enforces the narrower set deliberately, and widening that list to make a title pass is not an acceptable change.
 - Performance PRs must carry a reproducible measurement. Correctness tests and "expected impact" prose are not measurements.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,63 @@
+# Security finding log
+
+Security findings that have been addressed, and reports that were evaluated and
+rejected as false positives. Read both sections before opening a security PR, so
+that a guarantee already in place is not reported as missing.
+
+Every landed entry is anchored to a commit. If an entry cannot be located in
+`git log`, treat the anchor as authoritative over the date.
+
+## Landed
+
+### 2026-06-07 - Git subprocess calls hardened against option injection
+
+**Anchor:** `fb33ce8`
+
+**Learning:** A `git` invocation that interpolates a caller-supplied ref into an argument can have that ref parsed as an option when the ref begins with `-`.
+
+**Action:** every `git` invocation that accepts a caller-supplied ref passes `--end-of-options` before the ref, which makes git treat everything after it as a non-option operand. Current coverage:
+
+| Call site | Caller-supplied input | Guard |
+|---|---|---|
+| `tools.py` `git show` | `base`, `rel_path` | `--end-of-options` |
+| `incremental.py` `git diff --name-only` | `base` | `--end-of-options` |
+| `incremental.py` `git status` / `git ls-files` | none (literal args) | n/a |
+| `federation.py` `git log` | none | terminates with `--` |
+
+All subprocess calls pass a list argv. There is no `shell=True` anywhere in `src/`, so no shell metacharacter path exists either.
+
+## Rejected
+
+Reports that were evaluated against the running code and declined. The reasoning
+is recorded here so that it carries forward instead of being rediscovered.
+
+### 2026-07-25 - Do not add startswith("-") checks to git ref arguments
+
+**Rejected PR:** #888, reported as HIGH severity command argument injection in `_get_git_content`.
+
+**Proposal:** add `if base.startswith("-"): return None` to `_get_git_content`.
+
+**Why it was rejected:** the hole was already closed by `fb33ce8`, the entry directly above. The call site already reads:
+
+```python
+[git_bin, "show", "--end-of-options", f"{base}:{rel_path}"]
+```
+
+Verified against a real git binary rather than assumed:
+
+```
+$ git show --end-of-options "--upload-pack=whoami:f.txt"
+fatal: option '--upload-pack=whoami:f.txt' must come before non-option arguments
+```
+
+With the guard present git refuses to parse the value as an option at all. A `startswith("-")` test rejects a subset of what `--end-of-options` already neutralises, at a different layer, and landing it would leave the repo looking as though it needed a second defence for a hole that is shut.
+
+**Action — how to check this class of finding before reporting it.** Read the complete argv at the call site first. If `--end-of-options` or a `--` terminator is already present, the finding is closed and no PR is warranted. To protect the guarantee against regression, the durable form is a test asserting that `--end-of-options` appears in the argv of every git invocation that takes a ref, not a string check repeated at each call site.
+
+## Conventions for this log
+
+- Read the complete argv at a call site before reporting an injection finding, and check for an existing `--end-of-options` or `--` terminator.
+- Verify the claimed attack against the real binary and include the output. A finding asserted from pattern matching alone is not actionable.
+- Before calling a baked-in identifier a leaked secret, check whether it is public by design.
+- Cite file and symbol names rather than line numbers, which drift as the file changes.
+- PR titles in this repo must start with `fix:` or `feat:`.


### PR DESCRIPTION
Three related changes to make the ignore rules match reality and give the second
decision log a home.

## 1. `.gitignore` said one thing, the repo did another

`.jules/` sat under "AI traces (public repo hygiene)" while `.jules/bolt.md` was
tracked. That contradiction is not cosmetic -- it is what allowed the file to be
re-added unintentionally in `c9741ab` after `bdbd69d` had untracked it, and it
would invite the next contributor to "fix" it in the opposite direction.

The two decision logs are now a named exception, with the reasoning inline:
they are instruction input read from a checkout, so they only work if they live
in the repo, and they read as technical documentation rather than as a record of
any conversation. Everything else under `.jules/` stays ignored.

## Both patterns needed `/*`, and that is not incidental

```
.jules/*
.Jules/*
!.jules/bolt.md
!.jules/sentinel.md
```

Git cannot re-include a file whose parent directory is itself excluded, so a
bare `.jules/` makes the negations dead. `.Jules/` needed the same treatment for
a less obvious reason: on a case-insensitive filesystem, `core.ignorecase` makes
`.Jules/` match this same directory, so leaving it in the bare form re-excluded
everything *after* the negations and silently broke the exception. It looked
correct and did not work.

Verified both directions:

| Check | Result |
|---|---|
| `git add .jules/bolt.md .jules/sentinel.md` without `-f` | succeeds |
| `git add` a new stray `.jules/scratch.md` | still refused as ignored |

## 2. `bolt.md` retitled to describe its contents

`# Bolt ledger` becomes `# Performance decision log`, with the opening sentence
adjusted to match. The `## Landed` / `## Rejected` / `## Conventions` structure
and every entry are unchanged, and **the path stays `.jules/bolt.md`** -- that is
where the tooling reads it, so renaming the file would defeat the purpose.

## 3. `sentinel.md` added

Same structure and conventions. Records the `--end-of-options` hardening from
`fb33ce8` with a table of every git call site and which of them take
caller-supplied input, plus the rejection of #888 as a duplicate of a guard that
was already in place, with the verification output against a real git binary.

## Self-review before commit

Both files were re-read end to end and scanned for machine paths, hostnames,
internal identifiers, credentials, emails and model names. No hits. The tool
names no longer appear in either body at all. One consistency fix fell out of
it: a `graph.py:258-260` citation was reduced to the symbol name, and both files
now carry a convention to cite symbols rather than line numbers, which drift.