### PR TITLE
fix: never run bot governance on pull requests from forks

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -22,6 +22,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           REPO: ${{ github.repository }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           set -e
 
@@ -40,6 +41,27 @@ jobs:
 
           if [ "$IS_BOT_PR" = "false" ]; then
             echo "Not a bot PR ($BRANCH), skipping governance checks."
+            exit 0
+          fi
+
+          # Never govern a pull request opened from a fork. Two reasons, and
+          # either one alone is sufficient:
+          #
+          #   1. On a public repository the pull_request event hands forks a
+          #      read-only GITHUB_TOKEN no matter what the permissions block
+          #      above requests, so every gh write below would fail anyway --
+          #      and `gh pr close` runs under `set -e`, so it would fail the job
+          #      rather than the PR.
+          #   2. More importantly, the bots this job exists to throttle push
+          #      their branches into this repository, never from a fork. So a
+          #      fork branch that happens to match the patterns above is far
+          #      more likely to be an outside contributor whose branch name ends
+          #      in digits. Auto-closing that is the worst outcome this workflow
+          #      could produce on a public repo.
+          #
+          # This must stay ahead of every gh write below.
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Fork PR ($BRANCH) -- governance skipped; forks are never auto-governed."
             exit 0
           fi
 


### PR DESCRIPTION
Adds an early exit for fork PRs, positioned ahead of every `gh` write in the step.

## Why not just `|| true`

Wrapping `gh pr close` would stop the job going red, but it treats the symptom.
Two independent reasons to skip forks entirely:

1. **The token cannot do the work.** On a public repo the `pull_request` event
   gives forks a read-only `GITHUB_TOKEN` no matter what the `permissions:`
   block requests, so every `gh` write below would fail regardless.
2. **Forks are the wrong target.** The bots this job throttles push branches
   *into this repository*; they never open PRs from forks. So a fork branch that
   matches the detection patterns is far more likely to be an outside
   contributor whose branch name happens to end in a long digit run.
   Auto-closing that contribution is the worst thing this workflow could do on a
   public repo — and `|| true` would have hidden the failure rather than
   prevented the close.

## Placement, verified rather than eyeballed

The guard must precede every `gh` write. Confirmed by parsing the YAML and
comparing line positions:

```
fork guard at line 36
  [OK] line 42: gh pr edit ... --add-label "bot-generated"
  [OK] line 47: COUNT=$(gh pr list ...
  [OK] line 60: gh pr close ...
  [OK] line 74: DUPES=$(gh pr list ...
  [OK] line 81: gh pr edit ... --add-label "possible-duplicate"
  [OK] line 83: gh pr comment ...
ALL gh calls after fork guard: True
```

## Behaviour, tested across the matrix

The step's script was extracted and driven directly with the two inputs that
decide the path:

| Branch | fork | Result |
|---|---|---|
| `bolt/optimize-search-nodes-4324878999568336161` | false | reaches governance writes |
| `fix/git-argument-injection-788118476930672810` | false | reaches governance writes |
| `bolt/optimize-search-nodes-4324878999568336161` | true | stops at fork guard |
| `fix/git-argument-injection-788118476930672810` | true | stops at fork guard |
| `renovate/python-3.13-slim-bookworm` | false | stops at existing bot check |
| `fix/bump-mcp-core-1.21.0` | false | stops at existing bot check |
| `feature/my-change-20260725123456` | true | stops at fork guard |

The last row is the case the guard exists for: an outside contributor whose
branch name ends in a long digit run, which the pattern would otherwise treat as
a bot.

`bash -n` passes on the extracted script and the workflow YAML parses.

## Note on style

`github.event.pull_request.head.repo.fork` is passed through the step's existing
`env:` block as `IS_FORK` rather than interpolated straight into `run:`, matching
how `BRANCH`, `ACTOR`, `PR_NUMBER` and the rest are already handled in this file.