### PR TITLE
fix: pin dev-group tooling so the lockfile cannot outrun the cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,16 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "Pin dev-group tooling so the lockfile cannot outrun the cooldown. minimumReleaseAge governs when Renovate opens a PR, not what the resolver picks: with the global rangeStrategy:bump and an open-ended floor, `uv lock` resolves the newest release regardless. Observed 2026-07-25 on PR #901 — a patch update intended for ruff 0.15.22 locked 0.16.0, a minor, and Renovate reported 'a pending version that has not yet passed the Minimum Release Age threshold'. The 7-day supply-chain wait above was being bypassed silently on every dependency PR. Pinning is correct here and ONLY here: dev-group tools never reach the published wheel metadata. Do not copy this to a runtime dependency of a published library — an `==` pin there propagates into every consumer's resolve (see mcp-core #684/#692, where pinning pydantic broke the whole stack).",
+      "matchDepTypes": [
+        "devDependencies",
+        "dependency-groups",
+        "tool.uv.dev-dependencies",
+        "tool.pdm.dev-dependencies"
+      ],
+      "rangeStrategy": "pin"
+    },
+    {
       "description": "Auto-merge GitHub Actions digest updates after cooldown",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
## What this fixes

`minimumReleaseAge: "7 days"` decides when Renovate *opens* a pull request. It places no constraint on what the resolver picks when the lockfile is regenerated. With the global `rangeStrategy: "bump"` and an open-ended floor like `ruff>=0.15.20`, `uv lock` resolves whatever is newest on PyPI — so the seven-day supply-chain wait is bypassed on every dependency update, and nothing reports that it happened.

## How it surfaced

PR #901 is the first one where it became visible, because Renovate refused to finish:

```
Artifact update for ruff resolved to version 0.16.0, which is a pending version
that has not yet passed the Minimum Release Age threshold.
Renovate was attempting to update to 0.15.22
```

`ty` behaved identically — intended `0.0.61`, locked `0.0.63`. The update was grouped as *patch dependencies*; `0.15.22 → 0.16.0` is a minor.

What makes this worth fixing rather than waving through: #901 failed loudly only because Renovate happened to check. The same mechanism was in effect on earlier dependency PRs that completed without complaint.

## Why `pin` and not `in-range-only`

`in-range-only` stops Renovate from rewriting the declared range. It does not stop the resolver from reaching the top of a range with no ceiling. It works for `semgrep` because `allowedVersions: "<1.162"` supplies that ceiling; `ruff>=0.15.20` has none.

`pin` writes the exact version into `pyproject.toml`, so `uv lock` has nothing left to choose.

## Why pinning is safe here

The rule matches dev dependency types only. `ruff` and `ty` are declared under `[dependency-groups]` and never reach the published wheel metadata, so the pin stays inside this repository.

It is deliberately not applied more widely. An `==` pin on a runtime dependency of a published library propagates into every consumer's resolve — mcp-core #684 did exactly that with pydantic and had to be undone in #692. The rule description records that distinction so the next reader does not generalise it.

## Placement

Inserted before the package-specific rules, so `semgrep`'s `rangeStrategy: in-range-only` continues to win for that package. Verified: pin rule at index 3, semgrep at index 7.

## After this lands

Renovate regenerates #901's artifacts against pinned versions. That PR carries `automerge: true`, so if it then merges on its own, it doubles as the first merge in this repository performed by an actor without bypass permission.