### PR TITLE
fix: move the fork guard to the job condition

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -12,6 +12,32 @@ permissions:
 jobs:
   governance:
     name: Bot PR Rate Limit & Duplicate Check
+    # Govern only branches pushed to this repository. This repo is public, so it
+    # receives pull requests from forks; the private original this workflow was
+    # ported from never saw one.
+    #
+    # Product reason: a fork pull request is an outside contribution. Its branch
+    # name is not ours to read as a bot signature, and closing someone's first
+    # contribution because our own bots spent the day's rate limit is the wrong
+    # outcome.
+    #
+    # Technical reason: on the pull_request trigger a fork gets a read-only
+    # GITHUB_TOKEN, and the permissions block above cannot raise it -- that is a
+    # ceiling, not a grant. Of the writing gh calls below, the --add-label ones
+    # end in `|| true`, but `gh pr close` and `gh pr comment` do not, so under
+    # `set -e` they would fail the job rather than the pull request.
+    #
+    # Kept at job level rather than as the first statement of the script: an
+    # in-script guard is only correct while it stays first, and an ordering
+    # assumption is the very bug being fixed here -- a later edit adding a gh
+    # call above it would reintroduce this silently. A job condition cannot be
+    # stepped over, and it skips without starting a runner.
+    #
+    # Compares full_name rather than testing head.repo.fork, because `fork`
+    # describes the source repository: were this repository itself ever made a
+    # fork, head.repo.fork would be true for our own branches too and governance
+    # would switch off permanently while the workflow still reported green.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Detect and govern bot PRs
@@ -22,7 +48,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           REPO: ${{ github.repository }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           set -e
 
@@ -41,27 +66,6 @@ jobs:
 
           if [ "$IS_BOT_PR" = "false" ]; then
             echo "Not a bot PR ($BRANCH), skipping governance checks."
-            exit 0
-          fi
-
-          # Never govern a pull request opened from a fork. Two reasons, and
-          # either one alone is sufficient:
-          #
-          #   1. On a public repository the pull_request event hands forks a
-          #      read-only GITHUB_TOKEN no matter what the permissions block
-          #      above requests, so every gh write below would fail anyway --
-          #      and `gh pr close` runs under `set -e`, so it would fail the job
-          #      rather than the PR.
-          #   2. More importantly, the bots this job exists to throttle push
-          #      their branches into this repository, never from a fork. So a
-          #      fork branch that happens to match the patterns above is far
-          #      more likely to be an outside contributor whose branch name ends
-          #      in digits. Auto-closing that is the worst outcome this workflow
-          #      could produce on a public repo.
-          #
-          # This must stay ahead of every gh write below.
-          if [ "$IS_FORK" = "true" ]; then
-            echo "Fork PR ($BRANCH) -- governance skipped; forks are never auto-governed."
             exit 0
           fi
 


### PR DESCRIPTION
Follow-up to #900, which introduced the guard inside the script. The behaviour it produces is already correct — the guard sits ahead of all four writing `gh` calls, and the 7-case branch × fork matrix in #900 passed. This changes where it lives, not what it does.

## Why move it

An in-script guard is correct only while it remains the first statement. That is the same class of defect the guard was written to handle: `gh pr close` and `gh pr comment` have no `|| true`, and the reason that was easy to miss is precisely that it depends on what runs before them. A later edit inserting a `gh` call above the guard would reintroduce the failure with nothing to catch it.

A job condition cannot be stepped over. It also skips without starting a runner, rather than starting one in order to `exit 0`.

## Why `full_name`, not `head.repo.fork`

`fork` describes the source repository, not the relationship between the two. If this repository were ever itself made a fork, `head.repo.fork` would read `true` for its own branches, governance would switch off permanently, and the workflow would still report green — a silent failure with no red check to expose it.

`head.repo.full_name == github.repository` asks the question that actually matters: did this pull request come from this repository. Both forms behave identically today (`repos/n24q02m/better-code-review-graph` → `fork: false`); this is choosing the more durable one.

## Consistency

The `if:` line is now byte-identical to the one on wet-mcp, mnemo-mcp and imagine-mcp, so the four workflows read the same and a reader does not have to work out whether the differences were deliberate.

## Verified

- YAML parses; one job, one step, `permissions` unchanged
- `IS_FORK` removed from both the `env` block and the script body
- All four writing `gh` calls still present
- `if:` line matches imagine-mcp exactly