### PR TITLE
feat: complete the plugin trinity with three skills and two lifecycle hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `__main__.py` -- `python -m` entry (calls cli.main)
   - `py.typed` -- PEP 561 marker
 - `tests/` -- Mirror source modules
-- `skills/` -- Claude Code skills (build-graph, review-delta, review-pr)
-- `hooks/` -- SessionStart + PostToolUse hooks
+- `skills/` -- Claude Code skills (impact-audit, onboard-repo, refactor-check, review-delta, review-pr, security-sweep)
+- `hooks/` -- SessionStart + UserPromptSubmit + PostToolUse hooks
 - `.claude-plugin/` -- Plugin manifest + marketplace metadata
 
 ## Lenh thuong dung

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `__main__.py` -- `python -m` entry (calls cli.main)
   - `py.typed` -- PEP 561 marker
 - `tests/` -- Mirror source modules
-- `skills/` -- Claude Code skills (build-graph, review-delta, review-pr)
-- `hooks/` -- SessionStart + PostToolUse hooks
+- `skills/` -- Claude Code skills (impact-audit, onboard-repo, refactor-check, review-delta, review-pr, security-sweep)
+- `hooks/` -- SessionStart + UserPromptSubmit + PostToolUse hooks
 - `.claude-plugin/` -- Plugin manifest + marketplace metadata
 
 ## Lenh thuong dung

--- a/hooks/_graph_state.py
+++ b/hooks/_graph_state.py
@@ -1,0 +1,110 @@
+"""Shared read-only helpers for the plugin hooks.
+
+The hooks run on the interactive path -- before every prompt and after every
+shell call -- so everything here is cheap, dependency-free, and read-only:
+no package import, no graph build, no writes. Every helper returns ``None``
+rather than raising when it cannot answer, because a hook that fails must
+degrade to silence instead of interrupting the session.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+GRAPH_DIR = ".code-review-graph"
+GRAPH_DB = "graph.db"
+PREFIX = "[better-code-review-graph]"
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Walk upward for the nearest directory holding a graph or a git dir."""
+    try:
+        candidates = (start, *start.parents)
+    except OSError:
+        return None
+    for candidate in candidates:
+        if (candidate / GRAPH_DIR / GRAPH_DB).is_file():
+            return candidate
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def graph_db_path(repo_root: Path) -> Path:
+    return repo_root / GRAPH_DIR / GRAPH_DB
+
+
+def git_dir(repo_root: Path) -> Path | None:
+    """Resolve the git directory, following a worktree pointer file."""
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return git_path
+    if not git_path.is_file():
+        return None
+    text = git_path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text.startswith("gitdir:"):
+        return None
+    target = Path(text.split(":", 1)[1].strip())
+    if not target.is_absolute():
+        target = (repo_root / target).resolve()
+    return target if target.is_dir() else None
+
+
+def _resolve_ref(gdir: Path, ref: str) -> str | None:
+    """Resolve a ref through loose files, then packed-refs, then commondir."""
+    loose = gdir / ref
+    if loose.is_file():
+        return loose.read_text(encoding="utf-8", errors="replace").strip() or None
+
+    packed = gdir / "packed-refs"
+    if packed.is_file():
+        for line in packed.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith(("#", "^")) or not line.strip():
+                continue
+            parts = line.split()
+            if len(parts) == 2 and parts[1] == ref:
+                return parts[0]
+
+    # Linked worktrees keep HEAD locally but share refs with the main git dir.
+    commondir = gdir / "commondir"
+    if commondir.is_file():
+        rel = commondir.read_text(encoding="utf-8", errors="replace").strip()
+        if rel:
+            common = Path(rel)
+            if not common.is_absolute():
+                common = (gdir / common).resolve()
+            if common.is_dir() and common != gdir:
+                return _resolve_ref(common, ref)
+    return None
+
+
+def read_head(gdir: Path) -> str | None:
+    """Return the commit HEAD points at, without spawning git."""
+    head_file = gdir / "HEAD"
+    if not head_file.is_file():
+        return None
+    head = head_file.read_text(encoding="utf-8", errors="replace").strip()
+    if not head:
+        return None
+    if not head.startswith("ref:"):
+        return head
+    return _resolve_ref(gdir, head.split(":", 1)[1].strip())
+
+
+def read_metadata(db_path: Path, key: str) -> str | None:
+    """Read one key from the graph metadata table, read-only."""
+    if not db_path.is_file():
+        return None
+    uri = f"file:{db_path.as_posix()}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=0.5)
+    except sqlite3.Error:
+        return None
+    try:
+        row = conn.execute("SELECT value FROM metadata WHERE key=?", (key,)).fetchone()
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+    return row[0] if row else None

--- a/hooks/branch-sync-check.py
+++ b/hooks/branch-sync-check.py
@@ -1,0 +1,140 @@
+"""PostToolUse hook: ask for a rebuild when a branch move outran the graph.
+
+Runs after shell calls and reacts only to commands that move the branch
+(``git pull``, ``git merge``). It deliberately does **not** re-index anything.
+
+The bundled incremental hook already fires on the same event and widens its
+diff base from ``HEAD~1`` to the commit recorded at the last build, so an
+ordinary ``git pull`` -- however many commits it brings in -- is already
+covered. Re-indexing here would spend a second process spawn on every shell
+call for no additional coverage.
+
+What the incremental pass cannot do is recover when the recorded commit is no
+longer reachable. After a rebase, an amended history, or a force-pushed
+branch, that base fails validation and the pass silently falls back to
+``HEAD~1``, leaving everything else the branch move brought in unindexed. The
+graph then looks current while describing code that no longer exists.
+
+This hook detects exactly that case and asks for a full rebuild. Anything it
+cannot prove, it stays quiet about: a false alarm on every pull would train
+the reader to ignore it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from _graph_state import (
+    find_repo_root,
+    git_dir,
+    graph_db_path,
+    read_head,
+    read_metadata,
+)
+
+GIT_TIMEOUT = 5
+
+# ``git`` plus its repo-selecting options, then pull/merge as the subcommand.
+# Written to not fire on `git commit -m "merge the thing"` or `git log --merges`.
+BRANCH_MOVING = re.compile(
+    r"\bgit\b"
+    r"(?:\s+(?:-C\s+\S+|-c\s+\S+|--git-dir=\S+|--work-tree=\S+))*"
+    r"\s+(?:pull|merge)\b"
+)
+
+
+def is_valid_commit(repo_root: Path, sha: str) -> bool:
+    """Whether ``sha`` still resolves to a commit in this repository.
+
+    Returns ``True`` when the answer cannot be determined, so an unusual
+    environment produces silence rather than a spurious rebuild request.
+    """
+    git_bin = shutil.which("git")
+    if not git_bin:
+        return True
+    try:
+        result = subprocess.run(
+            [git_bin, "cat-file", "-e", f"{sha}^{{commit}}"],
+            cwd=str(repo_root),
+            capture_output=True,
+            timeout=GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    return result.returncode == 0
+
+
+def emit(text: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": text,
+        }
+    }
+    print(json.dumps(payload))
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_input = payload.get("tool_input")
+    command = ""
+    if isinstance(tool_input, dict):
+        command = str(tool_input.get("command") or "")
+    if not BRANCH_MOVING.search(command):
+        return 0
+
+    start = Path(str(payload.get("cwd") or os.getcwd()))
+    repo_root = find_repo_root(start)
+    if repo_root is None:
+        return 0
+
+    db_path = graph_db_path(repo_root)
+    last_built = read_metadata(db_path, "last_built_head")
+    if not last_built:
+        # No recorded build point: there is no incremental base to lose.
+        return 0
+
+    gdir = git_dir(repo_root)
+    head = read_head(gdir) if gdir is not None else None
+    if head and head == last_built:
+        # The graph already sits on the current commit.
+        return 0
+
+    if is_valid_commit(repo_root, last_built):
+        # The incremental pass can widen its base to this commit and catch up.
+        return 0
+
+    emit(
+        "[better-code-review-graph] The branch moved and the commit the graph "
+        f"was built from ({last_built[:8]}) no longer exists in this "
+        "repository, so the incremental update could not diff against it and "
+        "indexed only the last commit. Graph answers about anything else the "
+        "branch move brought in are unreliable until you run "
+        'graph(action="build", full_rebuild=true).'
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # A hook must never break the tool call it is attached to.
+        sys.exit(0)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,16 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/stale-graph-check.py\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|Bash",
@@ -17,6 +27,15 @@
           {
             "type": "command",
             "command": "uvx --from better-code-review-graph python -c \"from better_code_review_graph.incremental import incremental_update_from_hook; incremental_update_from_hook()\" 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/branch-sync-check.py\""
           }
         ]
       }

--- a/hooks/stale-graph-check.py
+++ b/hooks/stale-graph-check.py
@@ -1,0 +1,95 @@
+"""UserPromptSubmit hook: warn when the knowledge graph has fallen behind.
+
+Emits a single advisory line so the assistant refreshes the graph before
+trusting its answers. It warns, it never blocks: every path exits 0, and any
+unexpected failure exits 0 silently. A hook that interrupts a prompt is worse
+than no hook at all.
+
+Two independent staleness signals, either of which triggers the advisory:
+
+* HEAD drift -- the commit recorded at the last build is no longer the
+  checked-out commit, so the graph describes code other than the working tree.
+* Age -- the graph has not been rewritten for ``CRG_STALE_HOURS`` hours
+  (default 24). Set ``CRG_STALE_HOURS=0`` to disable the age signal and warn
+  on HEAD drift only.
+
+Nothing is printed when no graph exists; the SessionStart hook already covers
+that case, and repeating it on every prompt would be noise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from _graph_state import (
+    PREFIX,
+    find_repo_root,
+    git_dir,
+    graph_db_path,
+    read_head,
+    read_metadata,
+)
+
+DEFAULT_STALE_HOURS = 24.0
+
+
+def stale_hours() -> float:
+    raw = os.environ.get("CRG_STALE_HOURS", "").strip()
+    if not raw:
+        return DEFAULT_STALE_HOURS
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_STALE_HOURS
+
+
+def main() -> int:
+    repo_root = find_repo_root(Path.cwd())
+    if repo_root is None:
+        return 0
+
+    db_path = graph_db_path(repo_root)
+    if not db_path.is_file():
+        return 0
+
+    reasons: list[str] = []
+
+    gdir = git_dir(repo_root)
+    head = read_head(gdir) if gdir is not None else None
+    last_built = read_metadata(db_path, "last_built_head")
+    if head and last_built and head != last_built:
+        reasons.append(
+            f"HEAD is {head[:8]} but the graph was built at {last_built[:8]}"
+        )
+
+    threshold = stale_hours()
+    if threshold > 0:
+        try:
+            age_hours = (time.time() - db_path.stat().st_mtime) / 3600.0
+        except OSError:
+            age_hours = 0.0
+        if age_hours > threshold:
+            reasons.append(
+                f"last indexed {age_hours:.0f}h ago (threshold {threshold:.0f}h)"
+            )
+
+    if not reasons:
+        return 0
+
+    print(
+        f"{PREFIX} Knowledge graph may be stale: {'; '.join(reasons)}. "
+        'Run graph(action="update") before relying on graph queries -- or make '
+        "any edit, which lets the incremental hook refresh it."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # A hook must never break the prompt it is attached to.
+        sys.exit(0)

--- a/skills/impact-audit/SKILL.md
+++ b/skills/impact-audit/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: impact-audit
+description: Blast radius of a change you have not made yet -- traces a symbol across federated repositories, splits impact per repo, and reports what must ship together.
+argument-hint: "<symbol, file, or described change> [additional repo paths]"
+---
+
+# Impact Audit
+
+Scope a **planned** change before writing it. Answers "if I change this, what else has to change, and in which repositories" -- across a federation of repositories, not just the one you have open.
+
+Run this while the change is still a proposal. Once code is written, `review-delta` and `review-pr` review what actually changed.
+
+**Token optimization:** call `help(topic="query")` once for the actions reference rather than probing arguments by trial and error.
+
+## Steps
+
+1. **State the change under audit in one line** before querying anything -- for example "add a required `tenant_id` parameter to `create_session`". The audit is only meaningful against a specific proposed edit, because the risky part differs: adding a required parameter breaks callers, changing a return type breaks consumers, renaming breaks both plus anything resolving the name dynamically.
+
+2. **Make sure every repository that could be affected is in the graph.** A blast radius is only as wide as the graph:
+   - `config(action="status")` -- confirm the graph exists and note `files_count`.
+   - `graph(action="build", roots=["<path-a>", "<path-b>"])` -- federate the additional repositories into the same graph. Each root is registered and its files tagged with a `repo_id`.
+   - Without federation, a cross-repo audit will report a clean radius simply because the consumers were never indexed. Say so in the report rather than implying the change is contained.
+
+3. **Locate every definition of the symbol** with `query(action="search", search_query="<name>")`, leaving `repo` unset so the search spans all federated repositories. Two repositories may define the same name for unrelated purposes -- resolve which definition is actually the target before tracing, and note any same-named decoys so a later reader does not re-open the question.
+
+4. **Map direct consumers**, unscoped across the federation:
+   - `query(action="query", pattern="callers_of", target="<name>")` -- who calls it
+   - `query(action="query", pattern="importers_of", target="<file_path>")` -- which files import the module
+   - `query(action="query", pattern="inheritors_of", target="<name>")` and `children_of` when the target is a class -- subclasses inherit the change whether or not they call it
+
+5. **Measure the full radius** with `query(action="impact", changed_files=["<file>"], max_depth=2)`. Raise `max_depth` to 3 when step 4 shows the direct consumers are themselves widely used; leave it at 2 otherwise, since depth costs tokens and the tail is mostly noise.
+
+6. **Split the radius per repository.** Re-run the impact query with `repo="<repo_id>"` for each federated repository. The per-repo split is the deliverable: it converts "47 impacted files" into "3 repositories, one of which is published and consumed elsewhere", which is what determines release ordering.
+
+7. **Call out the boundaries the graph cannot cross.** Call and import edges are resolved per language (Python, TypeScript, Go, Java, Rust, plus a generic fallback). Edges do **not** exist for:
+   - calls that cross a network boundary (HTTP route, RPC, queue message)
+   - dynamic dispatch by string name, reflection, or plugin registries
+   - generated clients and schema-derived code, unless the generated files are indexed
+
+   These are exactly the places a cross-repo change breaks silently. List them as unverified rather than reporting a radius that looks complete.
+
+8. **Check the radius is tested** with `query(action="query", pattern="tests_for", target="<name>")` for the target and its direct consumers. An impacted call site with no test is a site that will not tell you when the change is wrong.
+
+9. **Report**:
+
+    ```
+    ## Impact Audit: <change in one line>
+
+    ### Target
+    - **Symbol**: <name> (<file>:<line>)
+    - **Kind**: function / class / method / module
+    - **Also defined as**: <same-named decoys, or none>
+
+    ### Radius by Repository
+    | Repository | Impacted files | Impacted symbols | Tested | Notes |
+    |---|---|---|---|---|
+    | <repo_id> | N | M | K/M | <published? consumed elsewhere?> |
+
+    ### Direct Consumers Requiring Edits
+    - `<caller>` (<repo>/<file>:<line>) -- <what breaks>
+
+    ### Unverified Boundaries
+    - <HTTP route / dynamic dispatch / generated client the graph cannot trace>
+
+    ### Verdict: CONTAINED / MULTI-REPO / CROSS-BOUNDARY
+
+    **CONTAINED** -- one repository, no published surface. Make the change directly.
+
+    **MULTI-REPO** -- more than one repository impacted. Ship in dependency order:
+    1. <repo> -- <change, released first>
+    2. <repo> -- <consume the new version>
+    Add a compatibility window if the repositories cannot release together.
+
+    **CROSS-BOUNDARY** -- impact crosses a network, dynamic, or generated boundary
+    the graph cannot verify. Enumerate consumers by other means before proceeding.
+
+    ### Recommended Sequence
+    1. <step>
+    ```
+
+## Verdict Criteria
+
+| Condition | Verdict |
+|---|---|
+| Single repository, no published or exported surface | CONTAINED |
+| More than one federated repository impacted | MULTI-REPO |
+| Consumers reached only via HTTP/RPC/queue, reflection, or generated code | CROSS-BOUNDARY |
+| Any consumer repository not indexed in the graph | CROSS-BOUNDARY (radius is unproven) |
+
+## Difference from refactor-check
+
+| Aspect | refactor-check | impact-audit |
+|---|---|---|
+| Question | Is changing this symbol safe here? | What else must change, and where? |
+| Scope | One repository | Federated repositories |
+| Output | Safety verdict plus mitigation | Per-repo radius plus release ordering |
+| Timing | Immediately before editing | While the change is still a proposal |
+
+## When to Use
+
+- Before changing a signature, return type, or name in shared or published code
+- Before removing or renaming anything exported from a library consumed elsewhere
+- When estimating the cost of a change across services during planning
+- Before a migration that touches a data model or contract used by several repositories

--- a/skills/onboard-repo/SKILL.md
+++ b/skills/onboard-repo/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: onboard-repo
+description: Index an unfamiliar codebase into the knowledge graph, then produce a first orientation map -- entry points, most-depended-upon modules, hotspots, test topology.
+argument-hint: "[repo path] [area of interest]"
+---
+
+# Onboard Repo
+
+Take a codebase you have never seen and turn it into a queryable graph, then read the graph to produce an orientation map. Use this on first contact with a repository, before answering questions about it or changing anything in it.
+
+**Scope:** this skill builds and reads a knowledge graph. It does not modify source files, CI configuration, or project conventions. The only files it creates are the graph database under `.code-review-graph/` (already self-ignored) and, when you choose to add one, a `.code-review-graphignore`.
+
+## Steps
+
+1. **Check what already exists** by calling `config(action="status")`. It returns `graph_path`, `total_nodes`, `total_edges`, `files_count`, `languages`, `embedding_backend`, `embeddings_count`, and `last_updated`.
+   - `total_nodes > 0` means a graph is already built -- skip to step 5 instead of rebuilding.
+   - `graph_path: null` or a missing status means no graph yet -- continue.
+
+2. **Decide the indexing scope before building**:
+   - Single repository: no extra arguments needed.
+   - A repository that vendors or embeds others: add a `.code-review-graphignore` at the repo root (one `fnmatch` pattern per line, `#` for comments) so vendored trees, build output, and fixtures do not inflate the graph. Common additions: `vendor/*`, `third_party/*`, `**/generated/*`, `**/*.min.js`.
+   - Several sibling repositories that call each other: federate them in one graph with the `roots` argument in step 3, then use `impact-audit` for cross-repo questions.
+
+3. **Build the graph** by calling `graph(action="build")`.
+   - For a federated build: `graph(action="build", roots=["<path-a>", "<path-b>"])`. Each root is registered in the repo registry and its files are tagged with a `repo_id`, which later lets you scope any query with `repo="<repo_id>"`.
+   - Parsing is Tree-sitter based and needs no language servers, toolchains, or compilation -- an unbuildable checkout still indexes.
+
+4. **Enable semantic search** by calling `graph(action="embed")`. Without embeddings, `query(action="search")` falls back to name and keyword matching, which will miss "where is authentication handled" style questions.
+   - The default backend is local and requires no credentials. `config(action="status")` reports which backend resolved under `embedding_backend`.
+   - If a cloud embedding chain is expected but `embedding_backend` shows local, check `config(action="setup_status")` before assuming the model list is wrong.
+   - Optional: `graph(action="summarize")` adds generated summaries for function nodes, but only when a summarizer model chain is configured. It is a no-op otherwise -- do not report it as a failure.
+
+5. **Read the shape of the codebase** by calling `graph(action="stats")`. Record the language mix, file count, and node/edge counts. The language mix decides which conventions to expect in later steps -- do not assume the dominant language from the repository name.
+
+6. **Locate the entry points**. Use `query(action="search", search_query=...)` with terms that suit the language mix -- `main`, `cli`, `handler`, `route`, `server`, `worker`, `command`. Then confirm each candidate is genuinely an entry point by checking it has few or no callers:
+   - `query(action="query", pattern="callers_of", target="<name>")` -- an entry point is typically called by nothing inside the repo.
+
+7. **Find the load-bearing modules** -- the files everything else depends on:
+   - `query(action="query", pattern="importers_of", target="<file_path>")` for candidate core files; the ones with the most importers are where a newcomer should start reading.
+   - `query(action="query", pattern="file_summary", target="<file_path>")` for a structural digest of a file without reading it in full.
+
+8. **Trace one representative flow end to end.** Pick a single entry point from step 6 and walk outward with `query(action="query", pattern="callees_of", target="<name>")`, two or three hops deep. One traced flow teaches the layering faster than reading ten files.
+
+9. **Check the test topology**:
+   - `query(action="query", pattern="tests_for", target="<name>")` on the core modules from step 7.
+   - Modules with many importers and no tests are the risky parts of the codebase, and worth stating explicitly in the report.
+
+10. **Report the orientation map**:
+
+    ```
+    ## Codebase Orientation: <repo>
+
+    ### Graph
+    - **Nodes / edges**: N / M across K files
+    - **Languages**: <language: file count, ...>
+    - **Semantic search**: enabled (<backend>) / name-matching only
+
+    ### Entry Points
+    - `<name>` (<file>:<line>) -- <what starts here>
+
+    ### Core Modules (most depended upon)
+    | Module | Importers | Tested |
+    |---|---|---|
+    | <file> | N | yes / no |
+
+    ### Traced Flow: <entry point>
+    <entry> -> <callee> -> <callee> -- <one line on what the layering implies>
+
+    ### Hotspots
+    - <file or function> -- <many dependents / oversized / untested>
+
+    ### Suggested Reading Order
+    1. <file> -- <why first>
+    2. <file> -- <why next>
+
+    ### Open Questions
+    - <what the graph could not answer and where to look instead>
+    ```
+
+## Interpreting the Result
+
+| Observation | What it means |
+|---|---|
+| Many nodes, few edges | Mostly leaf code, or a language whose call edges resolve poorly -- lean on `search` over `callers_of` |
+| A file with very high importer count | Core abstraction; changes there need `impact-audit` before editing |
+| Entry point with no `tests_for` result | Integration behaviour is unverified; treat changes as high risk |
+| `languages` shows a language you did not expect | Generated or vendored code is likely in scope; add it to `.code-review-graphignore` and rebuild |
+
+## When to Use
+
+- First time working in a repository, before answering questions about it
+- Taking over an unfamiliar service or an abandoned codebase
+- After cloning a repository whose structure is not documented
+- Before planning a change in a codebase whose layering you cannot yet describe
+
+## Related Skills
+
+- `impact-audit` -- once oriented, to scope a planned change across repositories
+- `refactor-check` -- safety verdict for changing one specific symbol
+- `security-sweep` -- risk-ranked security posture of the newly indexed code

--- a/skills/security-sweep/SKILL.md
+++ b/skills/security-sweep/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: security-sweep
+description: Graph-driven security sweep -- scan for dangerous sinks, then rank each finding by whether an entry point can actually reach it, and triage the rest into suppressions.
+argument-hint: "[path, rule id, or severity floor]"
+---
+
+# Security Sweep
+
+Scan the codebase for dangerous constructs, then use the graph to answer the question a flat scanner cannot: **can untrusted input actually reach this?** A medium-severity finding in a request handler outranks a critical one in dead code, and only the call graph can tell them apart.
+
+## Steps
+
+1. **Make the graph current** by calling `graph(action="update")`. Findings are attached to graph nodes, so anything unindexed is unscanned.
+
+2. **Read the active ruleset** with `security(action="rule_list", engine="heuristic")` before scanning, and check which languages each rule declares. This determines what a clean result is worth -- see Coverage Limits below.
+
+3. **Run the Tier 1 scan**: `security(action="scan", engine="heuristic")`. It returns `total`, `by_severity`, `by_rule`, `tags_by_node`, and `suppressed_count`. Tier 1 is regex matching over the source of function, class, and method nodes -- fast, no external tool, no data-flow analysis.
+
+4. **Run Tier 2 when it is available**: `security(action="scan", engine="semgrep")`. Semgrep is an opt-in extra and is not installed by default.
+   - When the CLI is missing the call returns `{"error": ..., "engine": "semgrep"}`.
+   - Treat that as **not run**, never as **clean**. Report Tier 2 as unavailable instead of silently reporting Tier 1 numbers as the whole picture.
+
+5. **Rank findings by reachability** -- the step that makes this a graph sweep rather than a grep. For each tagged node, walk backwards toward the entry points:
+   - `query(action="query", pattern="callers_of", target="<node>")`
+   - Repeat on the callers, two or three hops, until you reach either an entry point (route handler, CLI command, worker, event consumer) or nothing.
+   - A node with no callers is either dead code or an entry point itself. Distinguish the two before ranking: an unreferenced HTTP handler is the *most* exposed code in the repository, not the least.
+
+6. **Confirm the source-to-sink path before filing anything.** Tier 1 matches text, not data flow, so a match proves a dangerous construct exists, not that untrusted input reaches it. For each candidate:
+   - Read the matched line and the parameters of the enclosing function.
+   - Establish where the tainted value originates. A `subprocess` call built from a hardcoded constant is not an injection; the same call built from a request field is.
+   - `query(action="query", pattern="callees_of", target="<node>")` helps confirm what the function actually invokes when the match is ambiguous.
+
+7. **Triage the residue into suppressions.** For rules that are structurally inapplicable to this codebase, or findings confirmed as false positives:
+   - `security(action="suppress", rule_id="<rule_id>")` -- persists to `.code-review-graph/security-suppressions.json`
+   - `security(action="suppress", rule_id="<rule_id>", remove=true)` -- reverses it
+   - Suppression is per rule, not per finding, so suppressing a rule hides every current and future match. Record the justification in the report; a suppressed rule that later becomes relevant is a silent regression.
+
+8. **Export when the result feeds another system**: `security(action="report", format="sarif")` returns SARIF v2.1.0 for code-scanning ingestion; `format="json"` re-emits the cached payload. Both replay the last scan rather than rescanning.
+
+9. **Report**:
+
+    ```
+    ## Security Sweep: <repo>
+
+    ### Coverage
+    - **Tier 1 (heuristic)**: N rules active, applicable to <languages>
+    - **Tier 2 (semgrep)**: run / not installed
+    - **Unscanned**: <languages present in the repo with no applicable rules>
+    - **Suppressed rules**: <rule_id -- justification>
+
+    ### Priority 1 -- Reachable from an entry point
+    - **<rule_id>** (<severity>) at `<file>:<line>` in `<node>`
+      - Reached by: <entry point> -> <caller> -> <node>
+      - Tainted input: <where the value comes from>
+      - Fix: <specific change>
+
+    ### Priority 2 -- Reachable, input not confirmed untrusted
+    - <finding, and what would have to be true for it to matter>
+
+    ### Priority 3 -- Not reachable from any entry point
+    - <finding, plus whether the code is dead or merely unreferenced here>
+
+    ### Dismissed
+    - <finding> -- <why it is not a vulnerability>
+
+    ### Recommendation
+    1. <ordered, actionable>
+    ```
+
+## Priority Matrix
+
+Rank on reachability first, severity second. Severity alone over-reports.
+
+| Reachability | CRITICAL / HIGH | MEDIUM | LOW |
+|---|---|---|---|
+| Entry point reaches it with untrusted input | Priority 1 | Priority 1 | Priority 2 |
+| Reachable, input provenance unconfirmed | Priority 2 | Priority 2 | Priority 3 |
+| No caller path from any entry point | Priority 3 | Priority 3 | Dismiss with note |
+| Test fixture or example code | Dismiss with note | Dismiss | Dismiss |
+
+## Coverage Limits
+
+State these in the report whenever they apply -- a sweep that hides them is worse than no sweep.
+
+- **Tier 1 is not uniformly multi-language.** Most shipped rules declare a specific language; only the hardcoded-secret rule applies to every language. On a codebase whose main language has no applicable rules, a zero-finding result means *not covered*, not *no vulnerabilities*.
+- **No data-flow analysis.** Tier 1 cannot distinguish a constant from user input; step 6 is mandatory, not optional.
+- **Only indexed code is scanned.** Anything excluded by `.code-review-graphignore`, or in a repository not federated into the graph, is invisible.
+- **Findings attach to function, class, and method nodes.** Dangerous constructs at module top level or in configuration files are outside this scan.
+- **Reachability is graph reachability.** Call sites reached over HTTP, RPC, a queue, reflection, or a plugin registry produce no edge, so a finding can be reachable in production while the graph shows no path.
+
+## When to Use
+
+- Reviewing unfamiliar or inherited code before putting it in front of untrusted input
+- Before exposing an internal service to a public network
+- Auditing a dependency or vendored subtree that has been indexed into the graph
+- Periodically on a service that handles user-supplied data, to catch newly introduced sinks
+
+## Related Skills
+
+- `onboard-repo` -- index the codebase and identify entry points first
+- `impact-audit` -- scope the blast radius of the fix once a finding is confirmed
+- `review-delta` / `review-pr` -- catch a new sink at review time rather than in a later sweep

--- a/tests/test_plugin_assets.py
+++ b/tests/test_plugin_assets.py
@@ -1,0 +1,328 @@
+"""Tests for the shipped plugin assets: skills, the hook manifest, and the
+behaviour of the two hook scripts.
+
+The hooks run on the interactive path, so the properties that matter most are
+negative ones: never block, never crash the session, and never cry wolf. Each
+scenario below asserts a return code of 0 alongside the expected output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = REPO_ROOT / "hooks"
+SKILLS_DIR = REPO_ROOT / "skills"
+HOOKS_MANIFEST = HOOKS_DIR / "hooks.json"
+
+EXPECTED_SKILLS = {
+    "impact-audit",
+    "onboard-repo",
+    "refactor-check",
+    "review-delta",
+    "review-pr",
+    "security-sweep",
+}
+
+FAKE_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+DEAD_SHA = "deadbeef" * 5
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(script: str, cwd: Path, stdin_text: str = "", **env_extra):
+    env = dict(os.environ)
+    env.pop("CRG_STALE_HOURS", None)
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HOOKS_DIR / script)],
+        cwd=str(cwd),
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        check=False,
+    )
+
+
+def _make_graph_db(repo_root: Path, last_built_head: str | None = None) -> Path:
+    crg_dir = repo_root / ".code-review-graph"
+    crg_dir.mkdir(parents=True, exist_ok=True)
+    db_path = crg_dir / "graph.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        if last_built_head is not None:
+            conn.execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+                ("last_built_head", last_built_head),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _fake_git_head(repo_root: Path, sha: str) -> None:
+    """Write a minimal git dir so HEAD resolves without invoking git."""
+    refs = repo_root / ".git" / "refs" / "heads"
+    refs.mkdir(parents=True, exist_ok=True)
+    (repo_root / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    (refs / "main").write_text(f"{sha}\n")
+
+
+def _age_file(path: Path, hours: float) -> None:
+    old = time.time() - hours * 3600
+    os.utime(path, (old, old))
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True, capture_output=True, timeout=30
+    )
+
+
+def _real_repo(tmp_path: Path) -> str:
+    """Init a real repo with one commit; return that commit's sha."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "a.py").write_text("x = 1\n")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-q", "-m", "first")
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def _post_tool_use(command: str, cwd: Path) -> str:
+    return json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": str(cwd),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Skills
+# ---------------------------------------------------------------------------
+
+
+class TestSkills:
+    def test_expected_skills_are_present(self):
+        found = {p.name for p in SKILLS_DIR.iterdir() if p.is_dir()}
+        assert found == EXPECTED_SKILLS
+
+    @pytest.mark.parametrize("skill", sorted(EXPECTED_SKILLS))
+    def test_frontmatter_name_matches_directory(self, skill):
+        text = (SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        frontmatter = text.split("---", 2)[1]
+        fields = {}
+        for line in frontmatter.strip().splitlines():
+            if ":" in line:
+                key, value = line.split(":", 1)
+                fields[key.strip()] = value.strip()
+        assert fields.get("name") == skill
+        assert fields.get("description")
+
+
+# ---------------------------------------------------------------------------
+# Hook manifest
+# ---------------------------------------------------------------------------
+
+
+class TestHookManifest:
+    def _manifest(self) -> dict:
+        return json.loads(HOOKS_MANIFEST.read_text(encoding="utf-8"))
+
+    def _commands(self) -> list[str]:
+        commands = []
+        for groups in self._manifest()["hooks"].values():
+            for group in groups:
+                for hook in group["hooks"]:
+                    commands.append(hook["command"])
+        return commands
+
+    def test_declares_the_three_lifecycle_events(self):
+        assert set(self._manifest()["hooks"]) == {
+            "SessionStart",
+            "UserPromptSubmit",
+            "PostToolUse",
+        }
+
+    def test_incremental_update_hook_is_preserved(self):
+        groups = self._manifest()["hooks"]["PostToolUse"]
+        matchers = [g.get("matcher") for g in groups]
+        assert "Write|Edit|Bash" in matchers
+        assert "Bash" in matchers
+
+    def test_no_bare_script_command(self):
+        """A bare .sh/.ps1 command opens an editor on Windows instead of running."""
+        for command in self._commands():
+            first = command.split()[0].strip('"')
+            assert not first.endswith((".sh", ".ps1", ".py")), command
+
+    def test_referenced_scripts_exist(self):
+        for command in self._commands():
+            if "CLAUDE_PLUGIN_ROOT" not in command:
+                continue
+            rel = command.split("${CLAUDE_PLUGIN_ROOT}/", 1)[1].strip('"')
+            assert (REPO_ROOT / rel).is_file(), rel
+
+
+# ---------------------------------------------------------------------------
+# UserPromptSubmit -- stale graph warning
+# ---------------------------------------------------------------------------
+
+
+class TestStaleGraphCheck:
+    SCRIPT = "stale-graph-check.py"
+
+    def test_silent_without_a_graph(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_silent_when_current(self, tmp_path):
+        _make_graph_db(tmp_path, FAKE_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_warns_when_head_moved(self, tmp_path):
+        _make_graph_db(tmp_path, FAKE_SHA)
+        _fake_git_head(tmp_path, OTHER_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+        assert "HEAD is" in result.stdout
+        assert OTHER_SHA[:8] in result.stdout
+
+    def test_warns_when_index_is_old(self, tmp_path):
+        db_path = _make_graph_db(tmp_path, FAKE_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        _age_file(db_path, hours=48)
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+        assert "last indexed" in result.stdout
+
+    def test_age_threshold_is_configurable(self, tmp_path):
+        db_path = _make_graph_db(tmp_path, FAKE_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        _age_file(db_path, hours=48)
+
+        quiet = _run_hook(self.SCRIPT, tmp_path, CRG_STALE_HOURS="72")
+        assert quiet.stdout == ""
+
+        loud = _run_hook(self.SCRIPT, tmp_path, CRG_STALE_HOURS="1")
+        assert "last indexed" in loud.stdout
+
+    def test_age_signal_can_be_disabled(self, tmp_path):
+        db_path = _make_graph_db(tmp_path, FAKE_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        _age_file(db_path, hours=999)
+        result = _run_hook(self.SCRIPT, tmp_path, CRG_STALE_HOURS="0")
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_survives_an_unreadable_graph(self, tmp_path):
+        crg_dir = tmp_path / ".code-review-graph"
+        crg_dir.mkdir()
+        (crg_dir / "graph.db").write_text("not a database")
+        _fake_git_head(tmp_path, FAKE_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# PostToolUse -- branch move outran the graph
+# ---------------------------------------------------------------------------
+
+
+class TestBranchSyncCheck:
+    SCRIPT = "branch-sync-check.py"
+
+    def test_silent_on_empty_stdin(self, tmp_path):
+        result = _run_hook(self.SCRIPT, tmp_path)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_silent_on_unrelated_command(self, tmp_path):
+        _make_graph_db(tmp_path, DEAD_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use("ls -la", tmp_path))
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    @pytest.mark.parametrize(
+        "command",
+        ['git commit -m "merge the thing"', "git log --merges", "git status"],
+    )
+    def test_does_not_fire_on_lookalike_commands(self, tmp_path, command):
+        _make_graph_db(tmp_path, DEAD_SHA)
+        _fake_git_head(tmp_path, FAKE_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use(command, tmp_path))
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_silent_when_graph_is_on_current_commit(self, tmp_path):
+        head = _real_repo(tmp_path)
+        _make_graph_db(tmp_path, head)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use("git pull", tmp_path))
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_silent_when_incremental_can_catch_up(self, tmp_path):
+        """Recorded commit still exists -- the incremental pass widens to it."""
+        first = _real_repo(tmp_path)
+        (tmp_path / "b.py").write_text("y = 2\n")
+        _git(tmp_path, "add", "b.py")
+        _git(tmp_path, "commit", "-q", "-m", "second")
+        _make_graph_db(tmp_path, first)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use("git pull", tmp_path))
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    @pytest.mark.parametrize("command", ["git pull", "git merge origin/main"])
+    def test_asks_for_rebuild_when_base_is_gone(self, tmp_path, command):
+        _real_repo(tmp_path)
+        _make_graph_db(tmp_path, DEAD_SHA)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use(command, tmp_path))
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        assert payload["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert "full_rebuild=true" in context
+
+    def test_silent_without_a_recorded_build(self, tmp_path):
+        _real_repo(tmp_path)
+        _make_graph_db(tmp_path, None)
+        result = _run_hook(self.SCRIPT, tmp_path, _post_tool_use("git pull", tmp_path))
+        assert result.returncode == 0
+        assert result.stdout == ""


### PR DESCRIPTION
Completes the plugin composition: MCP server + skills + hooks. The server and three skills already shipped; this adds the three remaining skills and the two remaining lifecycle hooks.

## Skills

| Skill | Purpose |
|---|---|
| `onboard-repo` | Index an unfamiliar codebase, then report an orientation map: entry points, most-depended-upon modules, hotspots, test topology. |
| `impact-audit` | Blast radius of a change before it is written, traced across federated repositories and split per repo so release ordering is visible. |
| `security-sweep` | Scan findings ranked by whether an entry point can actually reach them, plus suppression triage. |

Each drives the graph tools (`graph`, `query`, `review`, `security`, `config`) rather than manual file scanning, and each states its own coverage limits so a clean result is not mistaken for a safe one. `security-sweep` in particular notes that most Tier 1 rules declare a single language, so zero findings on a codebase outside that set means *not covered*, not *no vulnerabilities*.

## Hooks

**`UserPromptSubmit` -- stale graph warning.** Fires when the graph has fallen behind HEAD, or has not been reindexed for `CRG_STALE_HOURS` hours (default 24; `0` disables the age signal and warns on HEAD drift only). Advisory only. It reads the graph metadata read-only and resolves HEAD from the git directory without spawning a subprocess, so it adds no meaningful latency to a prompt.

**`PostToolUse` -- branch move outran the graph.** Reacts to `git pull` and `git merge`, and deliberately does **not** re-index.

The existing incremental hook already fires on the same event and widens its diff base from `HEAD~1` to the commit recorded at the last build (`test_incremental_widens_base_to_last_built_head`), so an ordinary pull is already covered however many commits it brings in. Re-indexing again would cost a second process spawn on every shell call for no extra coverage.

What the incremental pass cannot do is recover when that recorded commit is no longer reachable. After a rebase or a force-push the base fails validation and the pass falls back to `HEAD~1`, silently leaving everything else the branch move brought in unindexed -- the graph then looks current while describing code that no longer exists. This hook detects exactly that case and asks for a full rebuild. Anything it cannot prove, it stays quiet about.

Both hooks exit 0 on every path, including unexpected failures.

## Deviations from the original design note

- **No LSP backend branch in `onboard-repo`.** The note describes "Tree-sitter default vs LSP if available", but no LSP backend exists in the codebase. The skill covers the backend choice that is real -- local versus cloud embeddings -- instead of documenting a code path that does not exist.
- **The `git pull` hook advises rather than re-indexes**, for the reason above. The note asked to "auto-trigger full re-index"; the incremental hook already provides that behaviour for every case except the unreachable-base one, which a re-index would not fix either.
- `SessionEnd`/`Stop` and `Notification` hooks remain deliberately unimplemented, as originally decided.

## Verification

`tests/test_plugin_assets.py` (28 cases) covers the skill frontmatter, the hook manifest, and both hook scripts end to end as subprocesses:

- silence when the graph is current, when there is no graph, and on unrelated or lookalike commands (`git commit -m "merge ..."`, `git log --merges`)
- warnings on HEAD drift and on an aged index, with the threshold honoured and disablable
- the rebuild request emitted only when the recorded base is unreachable
- exit code 0 in every scenario, including a corrupted graph file
- no hook command is a bare `.sh`/`.ps1`/`.py` path, which on Windows opens an editor instead of executing

Both hooks were also run against a real repository on Windows using the exact command form from the manifest.

Full suite green; ruff lint and format clean.

## Also

`AGENTS.md` and `CLAUDE.md` listed a `build-graph` skill that no longer exists and omitted `refactor-check`. Both inventories now match the directories they describe.
