### PR TITLE
fix: negotiate a supported output_dimension for Cohere embeddings

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -251,12 +251,36 @@ class Qwen3EmbedBackend:
 
 
 # Explicit provider prefixes -> unambiguous key detection + litellm routing.
+#
+# The cohere leg pins v4 deliberately. Its predecessors (embed-*-v3.0) emit a
+# fixed 1024-wide vector and are not Matryoshka-trained, so there is no way to
+# reach the 768 storage width from them: they reject a narrower request, and
+# slicing their output would discard dimensions that carry meaning. v4 is
+# Matryoshka, so a prefix of its vector remains a valid embedding.
 _DEFAULT_EMBEDDING_CHAIN = (
     "jina_ai/jina-embeddings-v5-text-small",
     "gemini/gemini-embedding-001",
     "openai/text-embedding-3-large",
-    "cohere/embed-multilingual-v3.0",
+    "cohere/embed-v4.0",
 )
+
+# Cohere validates the requested width against this fixed set and rejects
+# anything else outright ("<n> is not a valid output_dimension", HTTP 422).
+# _DEFAULT_DIMS is not a member, so the width has to be negotiated rather than
+# passed straight through -- see _cohere_output_dimension.
+# Source: https://docs.cohere.com/docs/cohere-embed
+_COHERE_OUTPUT_DIMENSIONS = (256, 512, 1024, 1536)
+
+
+def _cohere_output_dimension(dimensions: int) -> int | None:
+    """Narrowest Cohere width that ``dimensions`` fits inside.
+
+    Returns ``None`` when no supported width is wide enough; the caller then
+    omits the parameter entirely and takes Cohere's own default width.
+    """
+    return next((d for d in _COHERE_OUTPUT_DIMENSIONS if d >= dimensions), None)
+
+
 _KEY_ALIASES = {"GEMINI_API_KEY": "GOOGLE_API_KEY", "COHERE_API_KEY": "CO_API_KEY"}
 
 
@@ -319,8 +343,7 @@ class CloudEmbeddingBackend:
         api_key: str | None = None,
     ):
         self.model = (
-            model
-            or (resolve_embedding_chain() or ["cohere/embed-multilingual-v3.0"])[0]
+            model or (resolve_embedding_chain() or [_DEFAULT_EMBEDDING_CHAIN[-1]])[0]
         )
         self.api_key = api_key
         self._provider = _detect_embedding_provider(self.model)
@@ -385,6 +408,17 @@ class CloudEmbeddingBackend:
             kwargs["dimensions"] = dimensions
         if self._provider == "cohere":
             kwargs["input_type"] = "search_document"
+            # litellm forwards ``dimensions`` to Cohere as ``output_dimension``,
+            # which only accepts _COHERE_OUTPUT_DIMENSIONS. Requesting the
+            # storage width directly is rejected before any vector is returned,
+            # so ask for the next supported width up and let the truncation at
+            # the end of this method trim it back down.
+            if dimensions:
+                negotiated = _cohere_output_dimension(dimensions)
+                if negotiated is None:
+                    del kwargs["dimensions"]
+                else:
+                    kwargs["dimensions"] = negotiated
 
         # Resolve the custom endpoint request-scoped (per-sub bucket in HTTP
         # multi-user, os.environ in stdio/single-user) via the same accessor
@@ -417,8 +451,11 @@ class CloudEmbeddingBackend:
         data = sorted(resp.data or [], key=_idx)
         embeddings = [_vec(item) for item in data]
 
-        # Truncate locally if server returned more dims than requested (Cohere
-        # and other providers that ignore ``dimensions`` server-side).
+        # Truncate locally when the server returned more dims than requested:
+        # Cohere is deliberately asked for the next supported width up (see
+        # above), and some providers ignore ``dimensions`` server-side. Slicing
+        # a prefix preserves meaning only on Matryoshka-trained models, which is
+        # why the default chain pins models that are.
         if dimensions and embeddings and len(embeddings[0]) > dimensions:
             embeddings = [e[:dimensions] for e in embeddings]
         return embeddings

--- a/src/better_code_review_graph/relay_schema.py
+++ b/src/better_code_review_graph/relay_schema.py
@@ -19,7 +19,7 @@ _EMBEDDING_SUGGESTED = [
     "jina_ai/jina-embeddings-v5-text-small",
     "gemini/gemini-embedding-001",
     "openai/text-embedding-3-large",
-    "cohere/embed-multilingual-v3.0",
+    "cohere/embed-v4.0",
 ]
 _SUMMARY_SUGGESTED = [
     "gemini/gemini-2.5-flash",

--- a/tests/test_cohere_dimensions.py
+++ b/tests/test_cohere_dimensions.py
@@ -1,0 +1,149 @@
+"""Cohere output_dimension negotiation.
+
+Cohere validates the requested embedding width against a fixed set and rejects
+anything outside it before returning any vector, so the storage width (768) has
+to be widened to a supported value on the way out and trimmed on the way back.
+Sending 768 straight through produced ``768 is not a valid output_dimension``
+and made the whole cohere leg of the fallback chain dead.
+
+The trimming is only meaning-preserving on a Matryoshka model, which is why the
+default chain pins embed-v4.0: the v3 models emit a fixed 1024-wide vector that
+is not Matryoshka, so no prefix of it is a valid embedding.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from better_code_review_graph.embeddings import (
+    _COHERE_OUTPUT_DIMENSIONS,
+    _DEFAULT_EMBEDDING_CHAIN,
+    CloudEmbeddingBackend,
+    _cohere_output_dimension,
+)
+from better_code_review_graph.relay_schema import _EMBEDDING_SUGGESTED
+
+STORAGE_DIMS = 768
+
+
+def _resp(dim: int, count: int = 1) -> MagicMock:
+    resp = MagicMock()
+    resp.data = [{"index": i, "embedding": [0.1] * dim} for i in range(count)]
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Width selection
+# ---------------------------------------------------------------------------
+
+
+class TestOutputDimensionSelection:
+    @pytest.mark.parametrize(
+        ("requested", "expected"),
+        [
+            (768, 1024),  # the storage width: the case that was broken
+            (1, 256),
+            (256, 256),
+            (257, 512),
+            (512, 512),
+            (1024, 1024),
+            (1025, 1536),
+            (1536, 1536),
+        ],
+    )
+    def test_widens_to_the_narrowest_supported_value(self, requested, expected):
+        assert _cohere_output_dimension(requested) == expected
+
+    def test_returns_none_when_nothing_is_wide_enough(self):
+        """Caller then omits the parameter and takes Cohere's default width."""
+        assert _cohere_output_dimension(max(_COHERE_OUTPUT_DIMENSIONS) + 1) is None
+
+    def test_every_selectable_value_is_accepted_by_cohere(self):
+        """Whatever the storage width becomes, the negotiated value stays legal."""
+        for requested in range(1, max(_COHERE_OUTPUT_DIMENSIONS) + 1):
+            assert _cohere_output_dimension(requested) in _COHERE_OUTPUT_DIMENSIONS
+
+    def test_storage_width_is_not_directly_requestable(self):
+        """Guards the premise: if 768 ever became legal, this dance is pointless."""
+        assert STORAGE_DIMS not in _COHERE_OUTPUT_DIMENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCohereDispatch:
+    def test_requests_a_supported_width_and_trims_the_result(self):
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0", api_key="k")
+        with patch("mcp_core.llm.embedding", return_value=_resp(1024)) as m:
+            vectors = backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
+
+        assert m.call_args.kwargs["dimensions"] == 1024
+        assert len(vectors[0]) == STORAGE_DIMS
+
+    def test_never_sends_an_unsupported_width(self):
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0", api_key="k")
+        with patch("mcp_core.llm.embedding", return_value=_resp(1024)) as m:
+            backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
+        assert m.call_args.kwargs["dimensions"] in _COHERE_OUTPUT_DIMENSIONS
+
+    def test_other_providers_keep_the_exact_width(self):
+        """The negotiation is cohere-specific; nobody else pays for it."""
+        backend = CloudEmbeddingBackend(
+            model="openai/text-embedding-3-large", api_key="k"
+        )
+        with patch("mcp_core.llm.embedding", return_value=_resp(STORAGE_DIMS)) as m:
+            backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
+        assert m.call_args.kwargs["dimensions"] == STORAGE_DIMS
+
+    def test_no_dimensions_requested_stays_omitted(self):
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0", api_key="k")
+        with patch("mcp_core.llm.embedding", return_value=_resp(1536)) as m:
+            backend.embed_texts(["hello"], dimensions=None)
+        assert "dimensions" not in m.call_args.kwargs
+        assert m.call_args.kwargs["input_type"] == "search_document"
+
+
+# ---------------------------------------------------------------------------
+# Chain
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultChain:
+    def test_cohere_leg_pins_a_matryoshka_model(self):
+        cohere = [m for m in _DEFAULT_EMBEDDING_CHAIN if m.startswith("cohere/")]
+        assert cohere == ["cohere/embed-v4.0"]
+
+    def test_no_v3_cohere_model_in_the_chain(self):
+        """v3 is fixed-width and not Matryoshka -- it cannot reach 768."""
+        assert not [
+            m
+            for m in _DEFAULT_EMBEDDING_CHAIN
+            if m.startswith("cohere/embed-multilingual-v3")
+        ]
+
+    def test_relay_suggestions_match_the_chain(self):
+        """The setup form must not advertise a model the chain no longer uses."""
+        assert _EMBEDDING_SUGGESTED == list(_DEFAULT_EMBEDDING_CHAIN)
+
+
+# ---------------------------------------------------------------------------
+# Live round-trip (opt-in: needs a real key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY")),
+    reason="needs a real Cohere key",
+)
+def test_live_round_trip_returns_storage_width():
+    """The negotiated width is accepted by the real API, not just by our mock."""
+    backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
+    vectors = backend.embed_texts(["def parse(path): ..."], dimensions=STORAGE_DIMS)
+    assert len(vectors) == 1
+    assert len(vectors[0]) == STORAGE_DIMS

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -291,7 +291,7 @@ class TestResolveEmbeddingChain:
         ):
             monkeypatch.delenv(k, raising=False)
         monkeypatch.setenv("CO_API_KEY", "co-test")
-        assert resolve_embedding_chain() == ["cohere/embed-multilingual-v3.0"]
+        assert resolve_embedding_chain() == ["cohere/embed-v4.0"]
 
     def test_legacy_embedding_model_honored(self, monkeypatch):
         for k in (
@@ -427,7 +427,7 @@ class TestCloudEmbeddingBackend:
         """Cloud backend dispatches through mcp_core.llm.embedding."""
         with patch.dict(os.environ, {}, clear=True):
             backend = CloudEmbeddingBackend(
-                model="cohere/embed-english-v3.0", api_key="test-key"
+                model="cohere/embed-v4.0", api_key="test-key"
             )
             with patch("mcp_core.llm.embedding") as mock_embed:
                 mock_embed.return_value = _embedding_response(["hello"], dim=768)
@@ -436,9 +436,11 @@ class TestCloudEmbeddingBackend:
                 assert len(vectors[0]) == 768
                 mock_embed.assert_called_once()
                 call_kwargs = mock_embed.call_args.kwargs
-                assert call_kwargs["model"] == "cohere/embed-english-v3.0"
+                assert call_kwargs["model"] == "cohere/embed-v4.0"
                 assert call_kwargs["input"] == ["hello"]
-                assert call_kwargs["dimensions"] == 768
+                # Cohere only accepts a fixed set of widths, and 768 is not one
+                # of them, so the request is widened to 1024 and trimmed back.
+                assert call_kwargs["dimensions"] == 1024
                 # Cohere passes input_type through kwargs.
                 assert call_kwargs["input_type"] == "search_document"
                 # Explicit api_key forwarded; empty api_base normalised to None.


### PR DESCRIPTION
The cohere leg of the embedding fallback chain could never return a vector.

## What was wrong

Storage is fixed at 768 dimensions and that width was forwarded to the provider as-is (`embeddings.py`, `_DEFAULT_DIMS` → `embed_texts(dimensions=...)` → `_call_provider`). litellm maps `dimensions` to Cohere's `output_dimension`, which is validated against a fixed set. The live API answers:

```
768 is not a valid output_dimension value for this model, [256 512 1024 1536] is supported
```

The local truncation that exists for providers which over-return could not rescue this: it runs on the response, and a rejected request has no response. The `output_dimension` string already sitting in `_PERMANENT_PATTERNS` is a fossil of this failure being hit before and classified, but not fixed.

## What this changes

Ask for the narrowest supported width that still covers the storage width -- 1024 for 768 -- and let the existing truncation trim the remainder. The selection is derived from the storage constant rather than hardcoded, so changing `_DEFAULT_DIMS` keeps the behaviour correct; if no supported width is wide enough the parameter is dropped rather than sent invalid.

The chain also moves from `embed-multilingual-v3.0` to `embed-v4.0`. This is not cosmetic. Trimming a prefix only preserves meaning on a Matryoshka model: the v3 models emit a fixed 1024-wide vector and are not Matryoshka, so requesting a legal width from v3 would have replaced a loud failure with silently degraded vectors. v4 is Matryoshka and accepts the width set above. `relay_schema.py` carried a second copy of the chain and would otherwise keep advertising the retired model in the setup form.

## Verification

Against the live Cohere API, both directions:

| Requested | Result |
|---|---|
| 768 (old behaviour) | rejected -- `768 is not a valid output_dimension value for this model, [256 512 1024 1536] is supported` |
| 1024 (new behaviour) | accepted, returns a 1024-wide vector |

End to end through the backend, the caller asking for 768 gets 768 back after truncation.

`tests/test_cohere_dimensions.py` (18 cases) covers the width selection across the whole supported range, the dispatch path (cohere widens and trims; other providers keep the exact width and pay nothing), and chain/relay-form parity. A live round-trip is included but marked `integration` and skipped without a key, so the suite stays green in CI.

Full suite green; ruff lint and format clean.
