### PR TITLE
fix: derive TESTED_BY edges from calls made inside test functions

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -812,15 +812,31 @@ class CodeParser:
                 import_map or {},
                 defined_names or set(),
             )
+            line = node.start_point[0] + 1
             edges.append(
                 EdgeInfo(
                     kind="CALLS",
                     source=caller,
                     target=target,
                     file_path=file_path,
-                    line=node.start_point[0] + 1,
+                    line=line,
                 )
             )
+            # A call made from inside a test function is also evidence that the
+            # callee is covered by that test. Emitting TESTED_BY here rides on
+            # the call target already resolved above, so coverage is derived
+            # from what the test actually exercises rather than from whether
+            # the test happens to be named after its subject.
+            if _is_test_function(enclosing_func, file_path):
+                edges.append(
+                    EdgeInfo(
+                        kind="TESTED_BY",
+                        source=caller,
+                        target=target,
+                        file_path=file_path,
+                        line=line,
+                    )
+                )
         return False
 
     def _handle_solidity_emit_statement(

--- a/tests/test_tested_by_edges.py
+++ b/tests/test_tested_by_edges.py
@@ -1,0 +1,112 @@
+"""TESTED_BY edges are derived from calls made inside test functions.
+
+These run in the default suite on purpose. The pre-existing coverage for
+``tests_for`` either seeded ``TESTED_BY`` rows by hand before querying them
+(so it only exercised the read path) or lived behind the ``full`` marker,
+which ``addopts`` deselects -- neither could notice that the parser emitted
+no ``TESTED_BY`` edge at all.
+"""
+
+from pathlib import Path
+
+from better_code_review_graph.graph import GraphStore
+from better_code_review_graph.incremental import full_build, get_db_path
+from better_code_review_graph.parser import CodeParser
+from better_code_review_graph.tools import (
+    _compute_untested_functions,
+    query_graph,
+)
+
+SUBJECT = """\
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def calculate(op: str, a: int, b: int) -> int:
+    if op == "add":
+        return add(a, b)
+    return a * b
+"""
+
+# test_dispatch_path is deliberately NOT named after the function it covers --
+# that is the case the naming-convention fallback in _handle_tests_for misses.
+TESTS = """\
+from calculator import add, calculate
+
+
+def test_add():
+    assert add(1, 2) == 3
+
+
+def test_dispatch_path():
+    assert calculate("add", 1, 2) == 3
+"""
+
+
+def _write_repo(root: Path) -> None:
+    (root / "calculator.py").write_text(SUBJECT)
+    (root / "test_calculator.py").write_text(TESTS)
+    (root / ".git").mkdir(exist_ok=True)
+
+
+class TestParserEmitsTestedBy:
+    def test_call_from_test_function_emits_tested_by(self, tmp_path):
+        _write_repo(tmp_path)
+        parser = CodeParser()
+
+        _nodes, edges = parser.parse_file(tmp_path / "test_calculator.py")
+
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert tested_by, (
+            f"no TESTED_BY edge emitted, kinds={ {e.kind for e in edges} }"
+        )
+        # Source is the test, target is the function under test -- the direction
+        # _handle_tests_for and _compute_untested_functions both read.
+        assert all("test_" in Path(e.source).name for e in tested_by)
+        assert any(e.target.endswith("::calculate") for e in tested_by)
+
+    def test_call_outside_a_test_function_emits_no_tested_by(self, tmp_path):
+        _write_repo(tmp_path)
+        parser = CodeParser()
+
+        _nodes, edges = parser.parse_file(tmp_path / "calculator.py")
+
+        # calculate() calls add(), but neither is a test.
+        assert any(e.kind == "CALLS" for e in edges)
+        assert not [e for e in edges if e.kind == "TESTED_BY"]
+
+
+class TestTestsForFindsUnconventionallyNamedTests:
+    def test_tests_for_resolves_test_named_after_behaviour(self, tmp_path):
+        _write_repo(tmp_path)
+        # query_graph reopens the store via get_db_path, so build into the
+        # location it will read from rather than an arbitrary path.
+        store = GraphStore(get_db_path(tmp_path))
+        full_build(tmp_path, store)
+        store.close()
+
+        result = query_graph(
+            "tests_for",
+            str(tmp_path / "calculator.py") + "::calculate",
+            repo_root=str(tmp_path),
+        )
+
+        names = [r.get("name") for r in result.get("results", [])]
+        # Asserting on test_add instead would pass even without TESTED_BY,
+        # because "test_" + "add" matches the naming fallback.
+        assert "test_dispatch_path" in names, (
+            f"expected the behaviour-named test for calculate(), got {names}"
+        )
+
+    def test_covered_function_is_not_reported_untested(self, tmp_path):
+        _write_repo(tmp_path)
+        store = GraphStore(tmp_path / "graph.db")
+        full_build(tmp_path, store)
+
+        impact = store.get_impact_radius([str(tmp_path / "calculator.py")])
+        untested = _compute_untested_functions(impact)
+        store.close()
+
+        names = {u.get("name") for u in untested}
+        assert "add" not in names, "add() is covered by test_add"
+        assert "calculate" not in names, "calculate() is covered by test_dispatch_path"


### PR DESCRIPTION
The parser emits `CALLS`, `IMPORTS_FROM`, `INHERITS`, `CONTAINS` and `DEPENDS_ON`, but never `TESTED_BY` — despite the kind being declared in `graph.py:4`, `parser.py:60` and `docs/graph.md:214`, and read back by two call sites.

## What was actually broken

Not "`tests_for` returns nothing" — `_handle_tests_for` has a second path (`tools.py:1166-1173`) that matches `test_<name>` / `Test<name>` by name, so conventionally-named tests were found. Verified on a built graph:

```
tests_for("<abs>/calculator.py::add")  -> ["test_add"]   # naming fallback
tests_for("<abs>/calculator.py::calculate") -> []        # test_dispatch_path calls it, missed
```

Two real consequences:

1. **`tests_for` misses any test not named after its subject.** A test called `test_dispatch_path` that calls `calculate()` was invisible — and behaviour-named tests are the common case in a real suite.
2. **`_compute_untested_functions` (`tools.py:2110-2113`) reads `TESTED_BY` alone, with no fallback.** On a graph where `test_add` and `test_multiply` sat in the very same impact set, it reported:
   ```
   UNTESTED reported: ["add", "calculate", "multiply"]
   ```
   Every changed function flagged as lacking coverage.

## Fix

A call already resolves its target, and test functions are already classified `kind="Test"` by `_is_test_function` (`parser.py:684`). So `_handle_call_node` now emits `TESTED_BY` alongside `CALLS` when the enclosing function is a test — coverage derived from what a test calls, not from what it is named. No new AST pass, no tree-sitter query, no name heuristic.

Direction matches `CALLS` (`source`=test, `target`=subject), which is what both readers expect: `_handle_tests_for` filters `e.target_qualified == qn` then returns `e.source_qualified`; `_compute_untested_functions` loads both ends.

After the fix, same graph:
```
tests_for("<abs>/calculator.py::calculate") -> ["test_dispatch_path"]
UNTESTED reported: []
```

## Why the existing tests could not have caught this

- Unit tests `upsert_edge(kind="TESTED_BY")` by hand before querying, so they only exercise the read path.
- The one end-to-end assertion (`test_full_live.py:466`) carries `@pytest.mark.full`, which `pyproject.toml:104` deselects from every default run — and it asserts on `test_add`, which the naming fallback satisfies regardless.

The four new tests run in the **default** suite and go source → parse → store → query. The `tests_for` case asserts on the behaviour-named test specifically, since asserting on `test_add` would pass with the fix reverted. Confirmed: with the parser change stashed, 3 of 4 fail.

Full default suite: 1335 passed, 1 skipped. `test_full_live.py -m full -k tests_for` still passes.

## Out of scope

`IMPLEMENTS` is dead the same way — declared, never emitted, yet read at `incremental.py:349`, `tools.py:1186` and `tools.py:2284`. Left alone deliberately so this diff has one reason to merge.