### PR TITLE
fix: widen the Cohere embedding width only for models that support it

### DIFF
--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -272,6 +272,26 @@ _DEFAULT_EMBEDDING_CHAIN = (
 _COHERE_OUTPUT_DIMENSIONS = (256, 512, 1024, 1536)
 
 
+# Cohere models that accept an explicit output_dimension. Widening the request
+# is only correct for these, and for two reasons that happen to coincide: they
+# are the models that accept a width at all, and they are the Matryoshka ones,
+# which is what makes slicing the response back down meaning-preserving.
+#
+# Every other cohere model keeps receiving the exact width asked for. That is
+# deliberate: such a model rejects it outright ("output_dimension is not
+# supported for this model") and the caller finds out. Widening the request
+# instead would be accepted -- the native width is always a legal value -- and
+# we would then slice a non-Matryoshka vector into nonsense without a word.
+# A model added here later must be checked for Matryoshka training, not just
+# for accepting the parameter.
+_COHERE_WIDTH_SELECTABLE_MODELS = ("embed-v4.0",)
+
+
+def _cohere_supports_width_selection(model: str) -> bool:
+    """Whether ``model`` can be asked for a width other than its native one."""
+    return _strip_provider(model).lower() in _COHERE_WIDTH_SELECTABLE_MODELS
+
+
 def _cohere_output_dimension(dimensions: int) -> int | None:
     """Narrowest Cohere width that ``dimensions`` fits inside.
 
@@ -412,8 +432,9 @@ class CloudEmbeddingBackend:
             # which only accepts _COHERE_OUTPUT_DIMENSIONS. Requesting the
             # storage width directly is rejected before any vector is returned,
             # so ask for the next supported width up and let the truncation at
-            # the end of this method trim it back down.
-            if dimensions:
+            # the end of this method trim it back down. Models that cannot
+            # select a width are left alone -- see the note there.
+            if dimensions and _cohere_supports_width_selection(self.model):
                 negotiated = _cohere_output_dimension(dimensions)
                 if negotiated is None:
                     del kwargs["dimensions"]

--- a/tests/test_cohere_dimensions.py
+++ b/tests/test_cohere_dimensions.py
@@ -20,9 +20,11 @@ import pytest
 
 from better_code_review_graph.embeddings import (
     _COHERE_OUTPUT_DIMENSIONS,
+    _COHERE_WIDTH_SELECTABLE_MODELS,
     _DEFAULT_EMBEDDING_CHAIN,
     CloudEmbeddingBackend,
     _cohere_output_dimension,
+    _cohere_supports_width_selection,
 )
 from better_code_review_graph.relay_schema import _EMBEDDING_SUGGESTED
 
@@ -100,6 +102,34 @@ class TestCohereDispatch:
             backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
         assert m.call_args.kwargs["dimensions"] == STORAGE_DIMS
 
+    def test_a_model_that_cannot_select_a_width_is_left_alone(self):
+        """A pinned v3 model must keep failing loudly, not get silently sliced.
+
+        Cohere accepts output_dimension when it equals the model's native width,
+        so widening 768 to 1024 would succeed against v3 and hand back a vector
+        we would then slice -- and v3 is not Matryoshka, so that slice is
+        meaningless. Sending 768 unchanged makes the provider reject it instead.
+        """
+        backend = CloudEmbeddingBackend(
+            model="cohere/embed-multilingual-v3.0", api_key="k"
+        )
+        with patch("mcp_core.llm.embedding", return_value=_resp(1024)) as m:
+            backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
+        assert m.call_args.kwargs["dimensions"] == STORAGE_DIMS
+
+    def test_an_unknown_cohere_model_is_left_alone(self):
+        """Unrecognised models fail loudly rather than being assumed Matryoshka."""
+        backend = CloudEmbeddingBackend(model="cohere/embed-v9-imaginary", api_key="k")
+        with patch("mcp_core.llm.embedding", return_value=_resp(1024)) as m:
+            backend.embed_texts(["hello"], dimensions=STORAGE_DIMS)
+        assert m.call_args.kwargs["dimensions"] == STORAGE_DIMS
+
+    def test_bare_model_name_is_recognised(self):
+        """The chain uses a cohere/ prefix, but a bare name resolves too."""
+        assert _cohere_supports_width_selection("embed-v4.0")
+        assert _cohere_supports_width_selection("cohere/embed-v4.0")
+        assert not _cohere_supports_width_selection("cohere/embed-multilingual-v3.0")
+
     def test_no_dimensions_requested_stays_omitted(self):
         backend = CloudEmbeddingBackend(model="cohere/embed-v4.0", api_key="k")
         with patch("mcp_core.llm.embedding", return_value=_resp(1536)) as m:
@@ -125,6 +155,12 @@ class TestDefaultChain:
             for m in _DEFAULT_EMBEDDING_CHAIN
             if m.startswith("cohere/embed-multilingual-v3")
         ]
+
+    def test_the_pinned_model_is_one_the_negotiation_is_valid_for(self):
+        """Ties the two constants together: the chain cannot drift off the list."""
+        cohere = [m for m in _DEFAULT_EMBEDDING_CHAIN if m.startswith("cohere/")][0]
+        assert _cohere_supports_width_selection(cohere)
+        assert cohere.split("/", 1)[1] in _COHERE_WIDTH_SELECTABLE_MODELS
 
     def test_relay_suggestions_match_the_chain(self):
         """The setup form must not advertise a model the chain no longer uses."""


### PR DESCRIPTION
Follow-up to #905, which widened the requested embedding width for the whole cohere provider. That was too broad and introduced a worse failure than the one it fixed, for one configuration.

## The hole

Cohere accepts `output_dimension` when the value happens to equal the model's native width, and rejects it otherwise. Probing the live API:

| Model | `dimensions=768` | `dimensions=1024` |
|---|---|---|
| `embed-v4.0` | rejected | accepted, 1024-wide |
| `embed-multilingual-v3.0` | rejected -- `output_dimension is not supported for this model` | **accepted, 1024-wide** |

So for someone pinning a v3 model through `EMBEDDING_MODELS`, #905 turned a request that used to fail loudly into one that succeeds and returns a 1024-wide vector, which was then sliced down to the 768 storage width. v3 is not Matryoshka, so that slice is not an embedding of anything: the failure moved from an exception to silently meaningless vectors, which is the outcome that is hardest to notice and hardest to undo once a graph has been embedded with it.

## The fix

Widen only for models known to support width selection -- currently `embed-v4.0`, the one the default chain pins. Any other cohere model keeps receiving the exact width requested and is rejected by the provider, which is the honest answer: a non-Matryoshka model genuinely cannot produce a valid 768-wide embedding.

The allowlist is explicit rather than a substring heuristic on the version, and the comment states that a model added to it has to be checked for Matryoshka training, not merely for accepting the parameter.

## Verification

End to end through the backend against the live API:

- `cohere/embed-v4.0` -- returns width 768
- `cohere/embed-multilingual-v3.0` -- raises `output_dimension is not supported for this model`

Four new cases cover the pinned-v3 path, an unrecognised cohere model, bare vs prefixed model names, and a tie between the default chain and the allowlist so the two constants cannot drift apart. Full suite green; ruff clean.
