### PR TITLE
fix: keep a test's own helpers out of TESTED_BY and state what the edge means

### DIFF
--- a/src/better_code_review_graph/docs/graph.md
+++ b/src/better_code_review_graph/docs/graph.md
@@ -213,4 +213,14 @@ Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/
 **Node types:** File, Class, Function, Type, Test
 **Edge types:** CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON
 
+`TESTED_BY` means **called directly by a test function**, not "adequately
+tested". It is emitted for each call site inside a test, so a function the
+test merely uses along the way -- a fixture builder, a comparison utility --
+also receives one. Functions defined in a test file are excluded, since test
+scaffolding is never the subject under test; support code living in an
+ordinary module cannot be told apart from a subject by syntax alone and is
+not excluded. A call written inside a helper belongs to that helper, so
+indirect reach is not credited to the test. Read `tests_for` results and the
+untested-function warning in `get_review_context` with that meaning in mind.
+
 Qualified names use `file_path::name` format (e.g. `src/auth.py::authenticate`). Cross-repo edges produced by federation prefix the target with the owning `repo_id`: `<repo_id>:<file_path>::<symbol>` (see "Federation: cross-repo graphs" above).

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -211,6 +211,21 @@ def _is_test_function(name: str, file_path: str) -> bool:
     return any(p.search(name) for p in _TEST_PATTERNS)
 
 
+def _is_test_file(qualified_or_path: str) -> bool:
+    """Whether a qualified name (``<path>::<name>``) or path sits in a test file.
+
+    Used to keep a test's own helpers out of TESTED_BY: a function defined in
+    a test file is test scaffolding, never the subject under test. Helpers
+    living in a non-test module (``support.py``, a fixtures package) are not
+    detectable this way and do produce an edge -- see the TESTED_BY note in
+    ``docs/graph.md``.
+    """
+    path = qualified_or_path.split("::", 1)[0]
+    if not path:
+        return False
+    return any(p.search(Path(path).stem) for p in _TEST_PATTERNS)
+
+
 def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
@@ -822,12 +837,14 @@ class CodeParser:
                     line=line,
                 )
             )
-            # A call made from inside a test function is also evidence that the
-            # callee is covered by that test. Emitting TESTED_BY here rides on
-            # the call target already resolved above, so coverage is derived
-            # from what the test actually exercises rather than from whether
-            # the test happens to be named after its subject.
-            if _is_test_function(enclosing_func, file_path):
+            # TESTED_BY means "called directly by a test", NOT "properly
+            # tested". A test calls its subject, but it also calls helpers,
+            # builders and assertion utilities, and no static rule separates
+            # intent from incidental use. Consumers must read the edge with
+            # that meaning -- see _is_test_file for the one exclusion applied.
+            if _is_test_function(enclosing_func, file_path) and not _is_test_file(
+                target
+            ):
                 edges.append(
                     EdgeInfo(
                         kind="TESTED_BY",

--- a/tests/test_tested_by_edges.py
+++ b/tests/test_tested_by_edges.py
@@ -43,9 +43,38 @@ def test_dispatch_path():
 """
 
 
+# A test calls more than its subject. These two fixtures pin down which of
+# those calls become TESTED_BY -- see TestTestedByScope.
+SUPPORT = """\
+def build_fixture():
+    return {"a": 1, "b": 2}
+"""
+
+MIXED_TEST = """\
+from calculator import add
+from support import build_fixture
+
+
+def _local_helper(v):
+    return v
+
+
+def test_add_with_helpers():
+    data = build_fixture()
+    assert add(_local_helper(data["a"]), data["b"]) == 3
+"""
+
+
 def _write_repo(root: Path) -> None:
     (root / "calculator.py").write_text(SUBJECT)
     (root / "test_calculator.py").write_text(TESTS)
+    (root / ".git").mkdir(exist_ok=True)
+
+
+def _write_mixed_repo(root: Path) -> None:
+    (root / "calculator.py").write_text(SUBJECT)
+    (root / "support.py").write_text(SUPPORT)
+    (root / "test_mixed.py").write_text(MIXED_TEST)
     (root / ".git").mkdir(exist_ok=True)
 
 
@@ -74,6 +103,70 @@ class TestParserEmitsTestedBy:
         # calculate() calls add(), but neither is a test.
         assert any(e.kind == "CALLS" for e in edges)
         assert not [e for e in edges if e.kind == "TESTED_BY"]
+
+
+class TestTestedByScope:
+    """Pins the declared meaning of the edge: called directly by a test.
+
+    Not "properly tested" -- a test also calls helpers, and no static rule
+    separates intent from incidental use. One exclusion is applied (helpers
+    defined in a test file); the rest is accepted and documented. A later
+    change that widens or narrows this should have to edit these assertions.
+    """
+
+    def test_subject_called_by_test_gets_an_edge(self, tmp_path):
+        _write_mixed_repo(tmp_path)
+
+        _nodes, edges = CodeParser().parse_file(tmp_path / "test_mixed.py")
+
+        targets = {e.target for e in edges if e.kind == "TESTED_BY"}
+        assert any(t.endswith("::add") for t in targets)
+
+    def test_helper_defined_in_the_test_file_is_excluded(self, tmp_path):
+        _write_mixed_repo(tmp_path)
+
+        _nodes, edges = CodeParser().parse_file(tmp_path / "test_mixed.py")
+
+        targets = {e.target for e in edges if e.kind == "TESTED_BY"}
+        assert not any(t.endswith("::_local_helper") for t in targets), (
+            "a function defined in a test file is scaffolding, not a subject"
+        )
+
+    def test_helper_in_a_non_test_module_still_gets_an_edge(self, tmp_path):
+        """Accepted false positive, asserted so it stays a decision.
+
+        build_fixture() is test support, but it lives in support.py and
+        nothing in the syntax says so. Consumers are told the edge means
+        "called by a test" precisely because of cases like this.
+        """
+        _write_mixed_repo(tmp_path)
+
+        _nodes, edges = CodeParser().parse_file(tmp_path / "test_mixed.py")
+
+        targets = {e.target for e in edges if e.kind == "TESTED_BY"}
+        assert any(t.endswith("::build_fixture") for t in targets)
+
+    def test_call_nested_inside_a_helper_is_not_attributed_to_the_test(self, tmp_path):
+        """Only the test's own call sites count.
+
+        A call written inside a helper has that helper as its enclosing
+        function, so it never reaches the TESTED_BY branch -- indirect reach
+        is not silently credited to the test.
+        """
+        (tmp_path / "calculator.py").write_text(SUBJECT)
+        (tmp_path / "test_indirect.py").write_text(
+            "from calculator import add\n\n\n"
+            "def _run(a, b):\n"
+            "    return add(a, b)\n\n\n"
+            "def test_indirect():\n"
+            "    assert _run(1, 2) == 3\n"
+        )
+        (tmp_path / ".git").mkdir(exist_ok=True)
+
+        _nodes, edges = CodeParser().parse_file(tmp_path / "test_indirect.py")
+
+        targets = {e.target for e in edges if e.kind == "TESTED_BY"}
+        assert not any(t.endswith("::add") for t in targets)
 
 
 class TestTestsForFindsUnconventionallyNamedTests:


### PR DESCRIPTION
**This changes edge semantics, not just test coverage.** #906 made the parser emit `TESTED_BY` for every call inside a test, which marks anything a test touches along the way as covered. This narrows that by one rule and states plainly what the edge does and does not mean.

## Measured before deciding

Parsed a test that calls its subject plus two kinds of helper. On `946cbc2`:

```
TESTED_BY -> support.py::build_fixture           # fixture builder, ordinary module
TESTED_BY -> calculator.py::add                  # the subject, correct
TESTED_BY -> test_calculator.py::_local_helper   # helper inside the test file
```

Two of three are false positives. Left alone, `_compute_untested_functions` stops warning about a function that no test ever exercises just because some test called through it — under-reporting, which is worse than the over-reporting #906 fixed, because nobody investigates a warning that never appears.

## The position taken

**Excluded:** targets defined in a test file. New `_is_test_file()` reuses `_TEST_PATTERNS` against `Path(path).stem`, so `foo_test.go` and `bar.spec.ts` are covered too. A function defined in a test file is scaffolding and the file it lives in says so unambiguously — consistent with the existing `_is_test_function` docstring ("test files contain helpers too").

**Kept:** support code in an ordinary module (`support.py`, a fixtures package). Syntax cannot separate it from a subject, so this is not guessed at.

**Already correct, now asserted:** a call written inside a helper has that helper as its enclosing function, so it never reached the `TESTED_BY` branch. Indirect reach was never credited to the test; a test now locks that in.

After the change, same repository:
```
TESTED_BY -> support.py::build_fixture   # kept, deliberately
TESTED_BY -> calculator.py::add          # correct
                                         # _local_helper is gone
```

## Semantics, written where readers will meet them

`TESTED_BY` means **called directly by a test**, not **adequately tested**.

Recorded in the comment at the emission site in `parser.py`, and in `docs/graph.md` under the edge-type list — the latter because that file is what the `help` tool serves to users, whereas the `graph.py` module docstring only lists kind names. Both point at the two consumers that need the distinction: `tests_for` and the untested-function warning in `get_review_context`.

## Tests lock the semantics

`TestTestedByScope` asserts one clause each:

| case | expected |
|---|---|
| subject called by the test | edge |
| helper defined in the test file | **no** edge |
| helper in an ordinary module | edge (accepted false positive, asserted so it stays a decision) |
| call nested inside a helper | not attributed to the test |

The class docstring says it outright: a later change that widens or narrows this boundary has to edit these assertions rather than move it silently.

`tests/test_tested_by_edges.py` is now 8 tests, all in the default suite, all going source → parse → store → query. Full default suite: 1357 passed, 1 skipped.