### PR TITLE
fix: drop bot persona labels from source comments

### DIFF
--- a/src/better_code_review_graph/exporter.py
+++ b/src/better_code_review_graph/exporter.py
@@ -63,11 +63,9 @@ _CYPHER_VAR_PATTERN = re.compile(r"\W")
 def _cypher_var(node_id: str) -> str:
     """Return a Cypher-safe variable name derived from node id.
 
-    ⚡ Bolt Optimization:
-    Replaced generator expression `"".join(...)` with a pre-compiled
-    regular expression `\\W` (matches non-alphanumeric and non-underscore).
-    This pushes the string traversal into optimized C code and significantly
-    reduces overhead for large graph serializations (~2x faster).
+    Uses a pre-compiled `\\W` regular expression (non-alphanumeric,
+    non-underscore) rather than a generator expression with `"".join(...)`,
+    which keeps the string traversal in C for large graph serializations.
     """
     safe = _CYPHER_VAR_PATTERN.sub("_", node_id)
     return f"n_{safe}"

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1084,7 +1084,7 @@ class GraphStore:
     ) -> list[GraphEdge]:
         """Batch search for edges where source_qualified matches any of the given names.
 
-        Bolt: Optimized to prevent N+1 queries when resolving multiple sources
+        Batched to prevent N+1 queries when resolving multiple sources
         to their targets.
         """
         if not names:
@@ -1109,7 +1109,7 @@ class GraphStore:
     ) -> list[GraphEdge]:
         """Batch search for edges where target_qualified matches any of the given names.
 
-        Bolt: Optimized to prevent N+1 queries when resolving multiple targets
+        Batched to prevent N+1 queries when resolving multiple targets
         to their callers (issue #342).
         """
         if not names:
@@ -1162,8 +1162,8 @@ class GraphStore:
         # The temporal fragment is a static prefix/clause produced by
         # ``_temporal_filter`` from a hard-coded set of strings, so the
         # f-string interpolation is safe (Bandit B608 already lints).
-        # Bolt: Removed unnecessary LOWER() calls since SQLite's LIKE is case-insensitive
-        # for ASCII by default. This reduces query execution time by ~50% (issue #342).
+        # No LOWER() call: SQLite's LIKE is already case-insensitive for
+        # ASCII by default (issue #342).
         cursor = self._conn.execute(
             f"""
             SELECT * FROM nodes
@@ -1472,8 +1472,8 @@ class GraphStore:
             if self._nxg_cache is not None:
                 return self._nxg_cache
             g: nx.DiGraph = nx.DiGraph()
-            # Bolt: Optimized to fetch only necessary columns and use generator expression
-            # with add_edges_from instead of multiple add_edge calls in a Python loop.
+            # Fetch only the needed columns and feed add_edges_from a generator
+            # rather than calling add_edge per row in a Python loop.
             cursor = self._conn.execute(
                 "SELECT source_qualified, target_qualified, kind FROM edges"
             )

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -453,9 +453,9 @@ def _snapshot_pre_functions(
 ) -> dict[str, dict[str, str]]:
     """Create per-file snapshot of pre-update Function qualified_names.
 
-    Bolt: Optimized to use a single batched query to fetch only the needed columns,
-    avoiding the overhead of N+1 database calls and materializing full GraphNode
-    objects (including large source_text fields) just to read hashes.
+    Uses a single batched query over just the needed columns, so reading
+    hashes does not cost N+1 database calls or materialize full GraphNode
+    objects (including large source_text fields).
     """
     pre_functions: dict[str, dict[str, str]] = {}
     repo_resolved = repo_root.resolve()
@@ -518,7 +518,7 @@ def _update_files_in_store(
             source_preview = abs_path.read_bytes()
             fhash = hashlib.sha256(source_preview).hexdigest()
 
-            # Bolt: Check file_hash directly via SQL to avoid materializing all
+            # Check file_hash directly via SQL to avoid materializing all
             # GraphNode objects for unchanged files.
             existing_hash = store.get_file_hash(str(abs_path))
             if existing_hash == fhash:

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -1016,7 +1016,7 @@ def _handle_callers_of(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving callers (issue #342).
+    # Batched search to avoid N+1 queries when resolving callers (issue #342).
     # We look for CALLS edges targeting either the qualified name or the bare name.
     search_targets = [qn]
     if node and node.name and node.name != qn:
@@ -1047,7 +1047,7 @@ def _handle_callees_of(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving callees
+    # Batched search to avoid N+1 queries when resolving callees
     edges = store.search_edges_by_source_names([qn], kind="CALLS", as_of=as_of)
     qns = []
     for e in edges:
@@ -1069,7 +1069,7 @@ def _handle_imports_of(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving imports
+    # Batched search to avoid N+1 queries when resolving imports
     edges = store.search_edges_by_source_names([qn], kind="IMPORTS_FROM", as_of=as_of)
     qns = []
     for e in edges:
@@ -1097,7 +1097,7 @@ def _handle_importers_of(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving importers
+    # Batched search to avoid N+1 queries when resolving importers
     edges = store.search_edges_by_target_names(
         [abs_target], kind="IMPORTS_FROM", as_of=as_of
     )
@@ -1126,7 +1126,7 @@ def _handle_importers_of(
 def _handle_children_of(
     store: Any, qn: str, results: list[dict], edges_out: list[dict], *, as_of: str = ""
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving children
+    # Batched search to avoid N+1 queries when resolving children
     edges = store.search_edges_by_source_names([qn], kind="CONTAINS", as_of=as_of)
     qns = []
     for e in edges:
@@ -1149,7 +1149,7 @@ def _handle_tests_for(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving tests
+    # Batched search to avoid N+1 queries when resolving tests
     edges = store.search_edges_by_target_names([qn], kind="TESTED_BY", as_of=as_of)
     # Filter out fallback bare name matches since the original call used fallback=False
     edges = [e for e in edges if e.target_qualified == qn]
@@ -1181,7 +1181,7 @@ def _handle_inheritors_of(
     *,
     as_of: str = "",
 ) -> None:
-    # Bolt: Use batched search to avoid N+1 queries when resolving inheritors
+    # Batched search to avoid N+1 queries when resolving inheritors
     edges = store.search_edges_by_target_names(
         [qn], kind=("INHERITS", "IMPLEMENTS"), as_of=as_of
     )


### PR DESCRIPTION
Fourteen source comments carried a bot byline. This removes the labels and keeps the explanations.

## Scope

| file | count |
|---|---|
| `tools.py` | 7 |
| `graph.py` | 4 |
| `incremental.py` | 2 |
| `exporter.py` | 1 |

`exporter.py:66` was not on the original list of thirteen — it reads `⚡ Bolt Optimization:` and also carried a decorative emoji, which the repository standard excludes from source.

## What was kept and what was dropped

**Kept:** the technical reason. Why a query is batched, why a pre-compiled regex replaces a `"".join(...)` generator, why the file hash is read via SQL instead of materializing `GraphNode` objects. That content is accurate and answers a question a reader will have.

**Dropped:** the speed claims that travelled with the bylines — `~50%` on the node search and `~2x faster` on the Cypher variable helper. Neither is measured anywhere in this repository and no benchmark asserts them, so they read as authority the code cannot back.

## graph.py:1165 checked, not assumed

That comment describes a past edit ("Removed unnecessary LOWER() calls"), so it was verified against current code rather than reworded on faith. The SQL genuinely contains no `LOWER()` call, and SQLite `LIKE` is case-insensitive for ASCII by default, so the surviving sentence is still true. It now reads as a statement about the code rather than a note about an edit:

```
# No LOWER() call: SQLite's LIKE is already case-insensitive for
# ASCII by default (issue #342).
```

Issue references (`#342`) are kept — they are useful provenance, not persona.

## No code touched

Every line in the diff is a comment or a docstring. 20 insertions, 22 deletions across four files; `git diff -U0` contains no statement, no expression, no signature.

Also checked: the remaining hits for `sentinel` in `graph.py:543-545` are the 40-zero SHA sentinel, an unrelated technical term, and are left alone.