### PR TITLE
feat: record module-level state sharing between Python functions

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -399,6 +399,69 @@ def _scan_state_access(
     return reads - writes, writes
 
 
+def _module_functions(root) -> list:
+    """Function definitions at module scope, decorated ones included.
+
+    A decorator wraps the definition in ``decorated_definition``, so looking
+    only for ``function_definition`` among the module's children silently
+    drops every decorated function.
+    """
+    found = []
+    for child in root.children:
+        if child.type == "function_definition":
+            found.append(child)
+        elif child.type == "decorated_definition":
+            found.extend(c for c in child.children if c.type == "function_definition")
+    return found
+
+
+def _module_state_edges(
+    root, source: bytes, file_path: str, state_names: set[str]
+) -> list[EdgeInfo]:
+    """Link each writer of a module-level name to each of its readers.
+
+    A SHARES_STATE edge from A to B means A assigns a module-level name that
+    B reads. It does not assert that the two are functionally related, and it
+    says nothing about ordering at runtime. Direction is writer to reader,
+    matching the direction of influence get_impact_radius reasons about.
+
+    Readers alone produce nothing: two functions reading the same constant
+    are not coupled, and linking them would swamp the impact radius.
+    """
+    writers: dict[str, list[str]] = {}
+    readers: dict[str, list[str]] = {}
+
+    for func in _module_functions(root):
+        name_node = func.child_by_field_name("name")
+        if name_node is None:
+            continue
+        func_name = source[name_node.start_byte : name_node.end_byte].decode()
+        qualified = f"{file_path}::{func_name}"
+        reads, writes = _scan_state_access(func, source, state_names)
+        for n in sorted(writes):
+            writers.setdefault(n, []).append(qualified)
+        for n in sorted(reads):
+            readers.setdefault(n, []).append(qualified)
+
+    edges: list[EdgeInfo] = []
+    for state_name in sorted(writers):
+        for writer_qn in writers[state_name]:
+            for reader_qn in readers.get(state_name, []):
+                if reader_qn == writer_qn:
+                    continue
+                edges.append(
+                    EdgeInfo(
+                        kind="SHARES_STATE",
+                        source=writer_qn,
+                        target=reader_qn,
+                        file_path=file_path,
+                        line=0,
+                        extra={"name": state_name},
+                    )
+                )
+    return edges
+
+
 def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
@@ -563,6 +626,17 @@ class CodeParser:
                 import_map=import_map,
                 defined_names=defined_names,
             )
+
+            # Module-level shared state. Runs after the walk because it pairs
+            # functions with each other rather than emitting per-node, and it
+            # needs the whole file's set of module-level names first.
+            state_names = _collect_module_state(tree.root_node, source, language)
+            if state_names:
+                edges.extend(
+                    _module_state_edges(
+                        tree.root_node, source, file_path_str, state_names
+                    )
+                )
         finally:
             self._current_source_lines = None
 

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -272,6 +272,133 @@ def _collect_module_state(root, source: bytes, language: str) -> set[str]:
     return names
 
 
+def _identifiers_in(target, source: bytes) -> list[str]:
+    """Names bound by an assignment target, flat or destructured."""
+    if target is None:
+        return []
+    if target.type == "identifier":
+        return [source[target.start_byte : target.end_byte].decode()]
+    return [
+        source[c.start_byte : c.end_byte].decode()
+        for c in target.children
+        if c.type == "identifier"
+    ]
+
+
+def _parameter_names(func_node, source: bytes) -> set[str]:
+    """Every name the function's signature binds locally.
+
+    Covers the plain, annotated, defaulted and splat spellings, each of which
+    the grammar gives a different node type.
+    """
+    names: set[str] = set()
+    params = func_node.child_by_field_name("parameters")
+    if params is None:
+        return names
+    for p in params.children:
+        if p.type == "identifier":
+            names.add(source[p.start_byte : p.end_byte].decode())
+            continue
+        named = p.child_by_field_name("name")
+        if named is not None:
+            names.add(source[named.start_byte : named.end_byte].decode())
+            continue
+        names.update(
+            source[c.start_byte : c.end_byte].decode()
+            for c in p.children
+            if c.type == "identifier"
+        )
+    return names
+
+
+def _bindings_and_globals(func_node, source: bytes) -> tuple[set[str], set[str]]:
+    """Names the body binds, and names it declares ``global``.
+
+    The two together decide whether a binding reaches module state: Python
+    only rebinds the module name when the function declared it ``global``.
+    Without that declaration the same statement creates a local.
+    """
+    bound: set[str] = set()
+    declared_global: set[str] = set()
+
+    def walk(node) -> None:
+        if node.type == "global_statement":
+            for c in node.children:
+                if c.type == "identifier":
+                    declared_global.add(source[c.start_byte : c.end_byte].decode())
+            return
+        if node.type in ("assignment", "augmented_assignment", "for_statement"):
+            bound.update(_identifiers_in(node.child_by_field_name("left"), source))
+        for c in node.children:
+            walk(c)
+
+    body = func_node.child_by_field_name("body")
+    if body is not None:
+        walk(body)
+    return bound, declared_global
+
+
+def _collect_reads(node, source: bytes, candidates: set[str], reads: set[str]) -> None:
+    """Record uses of ``candidates`` reachable from ``node``.
+
+    Two positions hold an identifier that is not a use of the name: the
+    member half of ``obj.NAME`` and the keyword half of ``f(NAME=1)``. Both
+    descend only into the part that can genuinely reference module state.
+
+    A missing field yields ``None``; tree-sitter returns a partial tree for
+    unparseable source, and the parser has to keep going on it.
+    """
+    if node is None:
+        return
+    if node.type == "attribute":
+        _collect_reads(node.child_by_field_name("object"), source, candidates, reads)
+        return
+    if node.type == "keyword_argument":
+        _collect_reads(node.child_by_field_name("value"), source, candidates, reads)
+        return
+    if node.type == "global_statement":
+        return
+    if node.type == "identifier":
+        name = source[node.start_byte : node.end_byte].decode()
+        if name in candidates:
+            reads.add(name)
+        return
+    for child in node.children:
+        _collect_reads(child, source, candidates, reads)
+
+
+def _scan_state_access(
+    func_node, source: bytes, state_names: set[str]
+) -> tuple[set[str], set[str]]:
+    """Which of ``state_names`` this function reads and which it rebinds.
+
+    A name is a write only where the function declared it ``global`` and then
+    bound it. A name bound without that declaration is a local that shadows
+    the module name for the whole body, so it is dropped from both sets, as
+    is any name the signature already binds.
+
+    Known to be missed: ``with`` and ``except`` aliases, comprehension
+    targets, and in-place mutation such as ``CONFIG["k"] = v``, which rebinds
+    nothing and is out of scope for this phase.
+    """
+    if not state_names:
+        return set(), set()
+
+    bound, declared_global = _bindings_and_globals(func_node, source)
+    writes = state_names & bound & declared_global
+    shadowed = _parameter_names(func_node, source) | (bound - declared_global)
+
+    candidates = state_names - shadowed
+    if not candidates:
+        return set(), writes
+
+    reads: set[str] = set()
+    body = func_node.child_by_field_name("body")
+    if body is not None:
+        _collect_reads(body, source, candidates, reads)
+    return reads - writes, writes
+
+
 def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -226,6 +226,52 @@ def _is_test_file(qualified_or_path: str) -> bool:
     return any(p.search(Path(path).stem) for p in _TEST_PATTERNS)
 
 
+# Languages whose module-level state is understood well enough to emit
+# SHARES_STATE edges. Every other language returns no state and is untouched.
+_MODULE_STATE_LANGUAGES = {"python"}
+
+
+def _assignment_nodes(root) -> list:
+    """Assignment nodes bound at module scope in ``root``.
+
+    Only direct children of the module node count. A name bound inside a
+    function or class body belongs to that scope, not to module state, and
+    treating it as shared would link every function that reuses a common
+    local name.
+
+    Both spellings the grammar has used are accepted: tree-sitter 0.26 puts
+    the ``assignment`` directly under ``module``, while earlier versions wrap
+    it in an ``expression_statement``. Reading only one of them yields an
+    empty set and no error, so the feature would go quiet rather than fail.
+    """
+    found = []
+    for child in root.children:
+        if child.type == "assignment":
+            found.append(child)
+        elif child.type == "expression_statement":
+            found.extend(c for c in child.children if c.type == "assignment")
+    return found
+
+
+def _collect_module_state(root, source: bytes, language: str) -> set[str]:
+    """Names bound at module import time in ``root``."""
+    if language not in _MODULE_STATE_LANGUAGES:
+        return set()
+
+    names: set[str] = set()
+    for assignment in _assignment_nodes(root):
+        left = assignment.child_by_field_name("left")
+        if left is None:
+            continue
+        if left.type == "identifier":
+            names.add(source[left.start_byte : left.end_byte].decode())
+        elif left.type in ("pattern_list", "tuple_pattern"):
+            for target in left.children:
+                if target.type == "identifier":
+                    names.add(source[target.start_byte : target.end_byte].decode())
+    return names
+
+
 def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/tests/test_shares_state_edges.py
+++ b/tests/test_shares_state_edges.py
@@ -2,7 +2,11 @@
 
 import tree_sitter_language_pack as tslp
 
-from better_code_review_graph.parser import _collect_module_state, _scan_state_access
+from better_code_review_graph.parser import (
+    CodeParser,
+    _collect_module_state,
+    _scan_state_access,
+)
 
 
 def _root(source: bytes):
@@ -243,3 +247,100 @@ def test_reading_through_an_attribute_call_still_counts():
     reads, writes = _scan_state_access(_functions(source)[0], source, {"REGISTRY"})
     assert reads == {"REGISTRY"}
     assert writes == set()
+
+
+SUBJECT = """\
+REGISTRY: dict[str, int] = {}
+
+
+def register(key: str, value: int) -> None:
+    global REGISTRY
+    REGISTRY = {**REGISTRY, key: value}
+
+
+def lookup(key: str) -> int | None:
+    return REGISTRY.get(key)
+"""
+
+
+def _shares_state(path):
+    _nodes, edges = CodeParser().parse_file(path)
+    return [e for e in edges if e.kind == "SHARES_STATE"]
+
+
+def test_writer_links_to_reader_through_module_state(tmp_path):
+    (tmp_path / "registry.py").write_text(SUBJECT)
+
+    _nodes, edges = CodeParser().parse_file(tmp_path / "registry.py")
+
+    shares = [e for e in edges if e.kind == "SHARES_STATE"]
+    assert shares, (
+        f"expected a SHARES_STATE edge, got kinds {sorted({e.kind for e in edges})}"
+    )
+    assert len(shares) == 1
+    edge = shares[0]
+    assert edge.source.endswith("::register")
+    assert edge.target.endswith("::lookup")
+    assert edge.extra.get("name") == "REGISTRY"
+
+
+def test_no_edge_when_nobody_writes(tmp_path):
+    (tmp_path / "constants.py").write_text(
+        "LIMIT = 10\n\n\ndef a():\n    return LIMIT\n\n\ndef b():\n    return LIMIT * 2\n"
+    )
+
+    assert _shares_state(tmp_path / "constants.py") == []
+
+
+def test_decorated_writer_is_not_skipped(tmp_path):
+    """A decorated writer sits under ``decorated_definition``.
+
+    Scanning module children for ``function_definition`` alone would drop it
+    and the reader would look uncoupled.
+    """
+    (tmp_path / "decorated.py").write_text(
+        "REGISTRY = {}\n"
+        "\n"
+        "\n"
+        "@staticmethod\n"
+        "def register(key):\n"
+        "    global REGISTRY\n"
+        "    REGISTRY = {}\n"
+        "\n"
+        "\n"
+        "def lookup(key):\n"
+        "    return REGISTRY.get(key)\n"
+    )
+
+    shares = _shares_state(tmp_path / "decorated.py")
+    assert len(shares) == 1
+    assert shares[0].source.endswith("::register")
+    assert shares[0].target.endswith("::lookup")
+
+
+def test_local_shadow_does_not_create_an_edge(tmp_path):
+    """A same-named local is not a writer of the module name."""
+    (tmp_path / "shadow.py").write_text(
+        "REGISTRY = {}\n"
+        "\n"
+        "\n"
+        "def builds_its_own():\n"
+        "    REGISTRY = {}\n"
+        "    return REGISTRY\n"
+        "\n"
+        "\n"
+        "def lookup(key):\n"
+        "    return REGISTRY.get(key)\n"
+    )
+
+    assert _shares_state(tmp_path / "shadow.py") == []
+
+
+def test_non_python_file_gets_no_shared_state_edges(tmp_path):
+    (tmp_path / "mod.js").write_text(
+        "let registry = {};\n"
+        "function register() { registry = {}; }\n"
+        "function lookup() { return registry; }\n"
+    )
+
+    assert _shares_state(tmp_path / "mod.js") == []

--- a/tests/test_shares_state_edges.py
+++ b/tests/test_shares_state_edges.py
@@ -2,7 +2,7 @@
 
 import tree_sitter_language_pack as tslp
 
-from better_code_review_graph.parser import _collect_module_state
+from better_code_review_graph.parser import _collect_module_state, _scan_state_access
 
 
 def _root(source: bytes):
@@ -148,3 +148,98 @@ def test_non_python_returns_empty():
     source = b"const x = 1;\n"
     root = tslp.get_parser("javascript").parse(source).root_node
     assert _collect_module_state(root, source, "javascript") == set()
+
+
+def _functions(source: bytes) -> list:
+    return [c for c in _root(source).children if c.type == "function_definition"]
+
+
+def test_reads_and_writes_are_separated():
+    source = (
+        b"REGISTRY = {}\n"
+        b"\n"
+        b"def writer():\n"
+        b"    global REGISTRY\n"
+        b"    REGISTRY = {}\n"
+        b"\n"
+        b"def reader():\n"
+        b"    return REGISTRY\n"
+    )
+    funcs = _functions(source)
+
+    reads_w, writes_w = _scan_state_access(funcs[0], source, {"REGISTRY"})
+    assert writes_w == {"REGISTRY"}
+    assert reads_w == set()
+
+    reads_r, writes_r = _scan_state_access(funcs[1], source, {"REGISTRY"})
+    assert reads_r == {"REGISTRY"}
+    assert writes_r == set()
+
+
+def test_shadowed_parameter_is_not_shared_state():
+    source = b"REGISTRY = {}\n\n\ndef takes_it(REGISTRY):\n    return REGISTRY\n"
+    reads, writes = _scan_state_access(_functions(source)[0], source, {"REGISTRY"})
+    assert reads == set()
+    assert writes == set()
+
+
+def test_annotated_and_splat_parameters_also_shadow():
+    source = (
+        b"REGISTRY = {}\n"
+        b"CACHE = {}\n"
+        b"\n"
+        b"def takes_them(REGISTRY: dict, *CACHE):\n"
+        b"    return REGISTRY, CACHE\n"
+    )
+    reads, writes = _scan_state_access(
+        _functions(source)[0], source, {"REGISTRY", "CACHE"}
+    )
+    assert reads == set()
+    assert writes == set()
+
+
+def test_augmented_assignment_is_a_write_not_a_read():
+    """``COUNT += 1`` under ``global`` rebinds the module name.
+
+    Matching only ``assignment`` records this as a read, which reverses the
+    edge: the function that changes the value would be listed as depending on
+    it instead of the other way round.
+    """
+    source = b"COUNT = 0\n\n\ndef bump():\n    global COUNT\n    COUNT += 1\n"
+    reads, writes = _scan_state_access(_functions(source)[0], source, {"COUNT"})
+    assert writes == {"COUNT"}
+    assert reads == set()
+
+
+def test_rebinding_without_global_is_a_local_not_a_write():
+    """Assigning a name without ``global`` creates a local that shadows it.
+
+    Python binds the name to the function for its whole body, so the module
+    value is neither read nor replaced. Counting it as a write would make
+    every function holding a same-named local a writer of shared state.
+    """
+    source = b"REGISTRY = {}\n\n\ndef local_only():\n    REGISTRY = {}\n    return REGISTRY\n"
+    reads, writes = _scan_state_access(_functions(source)[0], source, {"REGISTRY"})
+    assert writes == set()
+    assert reads == set()
+
+
+def test_attribute_and_keyword_names_are_not_reads():
+    """``obj.REGISTRY`` and ``f(REGISTRY=1)`` do not read the module name."""
+    source = (
+        b"REGISTRY = {}\n"
+        b"\n"
+        b"def unrelated(obj):\n"
+        b"    f(REGISTRY=1)\n"
+        b"    return obj.REGISTRY\n"
+    )
+    reads, writes = _scan_state_access(_functions(source)[0], source, {"REGISTRY"})
+    assert reads == set()
+    assert writes == set()
+
+
+def test_reading_through_an_attribute_call_still_counts():
+    source = b"REGISTRY = {}\n\n\ndef lookup(key):\n    return REGISTRY.get(key)\n"
+    reads, writes = _scan_state_access(_functions(source)[0], source, {"REGISTRY"})
+    assert reads == {"REGISTRY"}
+    assert writes == set()

--- a/tests/test_shares_state_edges.py
+++ b/tests/test_shares_state_edges.py
@@ -2,6 +2,8 @@
 
 import tree_sitter_language_pack as tslp
 
+from better_code_review_graph.parser import _collect_module_state
+
 
 def _root(source: bytes):
     return tslp.get_parser("python").parse(source).root_node
@@ -119,3 +121,30 @@ def test_attribute_and_keyword_argument_hold_a_bare_identifier():
     kwarg = call.child_by_field_name("arguments").children[1]
     assert kwarg.type == "keyword_argument"
     assert kwarg.child_by_field_name("name").type == "identifier"
+
+
+def test_collects_only_module_level_names():
+    source = (
+        b"REGISTRY = {}\n"
+        b"_CACHE, _MISSES = {}, 0\n"
+        b"\n"
+        b"def f():\n"
+        b"    local_only = 1\n"
+        b"    return local_only\n"
+        b"\n"
+        b"class C:\n"
+        b"    attr = 2\n"
+    )
+    names = _collect_module_state(_root(source), source, "python")
+    assert names == {"REGISTRY", "_CACHE", "_MISSES"}
+
+
+def test_collects_annotated_module_binding():
+    source = b"REGISTRY: dict[str, int] = {}\n"
+    assert _collect_module_state(_root(source), source, "python") == {"REGISTRY"}
+
+
+def test_non_python_returns_empty():
+    source = b"const x = 1;\n"
+    root = tslp.get_parser("javascript").parse(source).root_node
+    assert _collect_module_state(root, source, "javascript") == set()

--- a/tests/test_shares_state_edges.py
+++ b/tests/test_shares_state_edges.py
@@ -1,0 +1,121 @@
+"""SHARES_STATE edges link a writer of module-level state to its readers."""
+
+import tree_sitter_language_pack as tslp
+
+
+def _root(source: bytes):
+    return tslp.get_parser("python").parse(source).root_node
+
+
+def test_module_level_assignment_is_a_direct_child_of_module():
+    """A top-level binding is an ``assignment`` directly under ``module``.
+
+    Every later step dispatches on this type name, and a wrong name matches
+    nothing rather than raising, so the whole feature would emit no edges and
+    report no error. Pinning the shape here turns a silent miss into one
+    failing test naming the type it actually saw.
+    """
+    source = b"REGISTRY = {}\n\n\ndef read_it():\n    return REGISTRY\n"
+    root = _root(source)
+
+    top_level = [c.type for c in root.children]
+    assert "assignment" in top_level, top_level
+
+    assignment = next(c for c in root.children if c.type == "assignment")
+    left = assignment.child_by_field_name("left")
+    assert left is not None
+    assert left.type == "identifier"
+    assert source[left.start_byte : left.end_byte] == b"REGISTRY"
+
+
+def test_annotated_assignment_keeps_the_plain_assignment_shape():
+    source = b"REGISTRY: dict[str, int] = {}\n"
+    root = _root(source)
+
+    assert [c.type for c in root.children] == ["assignment"]
+    left = root.children[0].child_by_field_name("left")
+    assert left is not None
+    assert left.type == "identifier"
+
+
+def test_tuple_binding_puts_targets_in_a_pattern_list():
+    source = b"_CACHE, _MISSES = {}, 0\n"
+    root = _root(source)
+
+    left = root.children[0].child_by_field_name("left")
+    assert left is not None
+    assert left.type == "pattern_list"
+    assert [c.type for c in left.children if c.type == "identifier"] == [
+        "identifier",
+        "identifier",
+    ]
+
+
+def test_augmented_assignment_is_a_separate_node_type():
+    """``X += 1`` is ``augmented_assignment``, not ``assignment``.
+
+    Anything that recognises rebinding by matching ``assignment`` alone reads
+    this as a plain use of ``X`` and records a read where a write belongs,
+    which points the resulting edge backwards.
+    """
+    source = b"def bump():\n    global COUNT\n    COUNT += 1\n"
+    body = _root(source).children[0].child_by_field_name("body")
+    assert body is not None
+
+    types = [c.type for c in body.children]
+    assert "augmented_assignment" in types, types
+    assert "assignment" not in types, types
+
+    aug = next(c for c in body.children if c.type == "augmented_assignment")
+    left = aug.child_by_field_name("left")
+    assert left is not None
+    assert left.type == "identifier"
+
+
+def test_global_declaration_is_its_own_statement():
+    source = b"def w():\n    global R\n    R = {}\n"
+    body = _root(source).children[0].child_by_field_name("body")
+    assert body is not None
+
+    stmt = next(c for c in body.children if c.type == "global_statement")
+    names = [
+        source[c.start_byte : c.end_byte]
+        for c in stmt.children
+        if c.type == "identifier"
+    ]
+    assert names == [b"R"]
+
+
+def test_decorated_function_is_wrapped_before_the_definition():
+    """A decorated function sits under ``decorated_definition``.
+
+    Scanning ``module`` children for ``function_definition`` alone would skip
+    every decorated function in the file.
+    """
+    source = b"@deco\ndef f():\n    return R\n"
+    root = _root(source)
+
+    assert [c.type for c in root.children] == ["decorated_definition"]
+    inner = [c.type for c in root.children[0].children]
+    assert "function_definition" in inner, inner
+
+
+def test_attribute_and_keyword_argument_hold_a_bare_identifier():
+    """``obj.REGISTRY`` and ``f(REGISTRY=1)`` both contain an ``identifier``.
+
+    Neither is a use of the module-level name, so a scan that counts every
+    ``identifier`` it walks past would invent readers.
+    """
+    attr_src = b"def m():\n    return obj.REGISTRY\n"
+    attr = (
+        _root(attr_src).children[0].child_by_field_name("body").children[0].children[1]
+    )
+    assert attr.type == "attribute"
+    assert attr.child_by_field_name("object").type == "identifier"
+    assert attr.child_by_field_name("attribute").type == "identifier"
+
+    kw_src = b"def k():\n    return f(REGISTRY=1)\n"
+    call = _root(kw_src).children[0].child_by_field_name("body").children[0].children[1]
+    kwarg = call.child_by_field_name("arguments").children[1]
+    assert kwarg.type == "keyword_argument"
+    assert kwarg.child_by_field_name("name").type == "identifier"


### PR DESCRIPTION
Phase 1 Tasks 1-4 of SHARES_STATE: the parser records which module-level names each Python function reads and which it rebinds, and links writer to reader within a file.

A `SHARES_STATE` edge from A to B means **A assigns a module-level name that B reads**. It does not mean the two are functionally related, and it says nothing about ordering at runtime. Direction is writer to reader, matching the direction of influence `get_impact_radius` reasons about. That paragraph is on `_module_state_edges` itself rather than only here, because an edge kind whose meaning lives in a pull request body is how the `TESTED_BY` and `IMPLEMENTS` gaps survived.

Tasks 5 and 6 are not in this branch: `find_dependents` still filters `SHARES_STATE` out, and there is no cross-file join yet. Edges are emitted per file only.

## Four things the plan assumed that the grammar does not do

Each was found by running against tree-sitter 0.26.0, not by reading.

**Module bindings have no `expression_statement` wrapper.** `REGISTRY = {}` at module scope is an `assignment` node directly beneath `module`:

```
plain     -> ['assignment']
annotated -> ['assignment']
```

Collecting only children of type `expression_statement` returns an empty set, and an empty set emits no edges and raises nothing. Every later test would have failed with no diagnostic pointing here. Both spellings are now accepted, and the shape is pinned by a test so a grammar bump reports rather than goes quiet.

**`X += 1` is `augmented_assignment`, a different node type.** Code matching `assignment` alone walks into it, meets the bare `identifier`, and records a **read**. A function that only increments a counter would be classified as a reader of it, pointing the edge backwards.

**A binding without `global` is a local, not a write.** This one changes results rather than just node names. Python binds `REGISTRY = {}` inside a function to that function for its whole body; the module value is neither read nor replaced. Treating it as a write makes every function holding a same-named local a writer of shared state, linked to every genuine reader. Writes now require a `global` declaration, and a name bound without one is dropped from both sets exactly like a shadowing parameter.

**Decorated functions sit under `decorated_definition`.** Scanning module children for `function_definition` skips them, so a decorated writer disappears and its reader looks uncoupled.

Two smaller corrections: `obj.REGISTRY` and `f(REGISTRY=1)` each contain a bare `identifier` that is not a use of the module name, and both were being counted as reads; and the emission hook belongs in `parse_bytes`, not `parse_file`, because `parse_file` only reads bytes and delegates while the tree, decoded source and detected language exist one level down.

## Readers-only emits nothing, and that holds

Two functions reading the same constant are not coupled — changing one cannot affect the other — so no edge is correct, and `test_no_edge_when_nobody_writes` locks it. The case that might look like a counterexample, a module-level name whose value comes from a call at import time, is already covered: `CONTAINS` connects the file to both readers.

## Tests

Twenty-two tests in the default suite, no marker. The behavioural ones go source to parse to store, through `CodeParser().parse_file` on a real file written to `tmp_path`; none seeds an edge and reads it back.

Default suite: **1383 passed, 1 skipped, 48 deselected**, against 1361 passed / 1 skipped on `main` at `23a7091`. The plan quoted 1335 and the previous task quoted 1357; both predate tests added by #906 and #909.

## Out of scope for this phase

- Instance attributes (`self.x`), where the same name on two unrelated classes would be conflated.
- In-place mutation (`CONFIG["k"] = v`, `ITEMS.append(x)`), which rebinds nothing and needs alias analysis.
- Languages other than Python; the handler is gated on `language == "python"` and the other fifteen are untouched.
- Re-exported names through an intermediate module.
- `with` and `except` aliases and comprehension targets are not yet treated as local bindings, so a module name reused in one of those positions is still read as shared. Recorded in the `_scan_state_access` docstring.
- Whether module state declared inside a test file should produce edges is still open. `_is_test_file` exists for it, but nothing in Tasks 1-4 forced the decision, so none was made.
