### PR TITLE
fix: isolate test HOME so the suite cannot write to the developer's real home

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
+
+#: The developer's / CI runner's genuine home directory, captured at conftest
+#: import time -- i.e. before any fixture has had a chance to redirect it.
+#: ``tests/test_home_isolation.py`` compares against this to prove the
+#: ``_isolate_per_plugin_home`` fixture below is still in force.
+REAL_HOME = Path.home()
 
 
 def pytest_addoption(parser):
@@ -72,6 +79,36 @@ def _allow_temporal_migration_without_git() -> None:
     explicitly clear this env var via ``monkeypatch.delenv``.
     """
     os.environ["CRG_TEST_ALLOW_NO_GIT"] = "1"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
+    """Redirect ``~`` to a per-test tmp dir so credential-store writes stay
+    out of the developer's real home directory.
+
+    ``mcp_core.storage.per_plugin_store.PerPluginStore`` resolves every path
+    from ``Path.home()``: the encrypted config lands in
+    ``~/.better-code-review-graph-mcp/config.json`` and the AES-GCM machine
+    key in ``~/.better-code-review-graph-mcp/.secret``. Tests that exercise
+    the ``config`` tool end-to-end (e.g.
+    ``test_server.py::TestConfigTool::test_setup_status_action``) reach the
+    real store unmocked, so on a machine where the developer actually uses
+    CRG a plain ``uv run pytest`` reads their live credentials and
+    ``_load_or_generate_machine_key`` mints a fresh ``.secret`` into their
+    home. ``credential_state._sub_data_dir`` has the same problem via its
+    ``~/.crg`` default. In CI with parallel workers those writes race on one
+    shared home.
+
+    ``Path.home()`` reads ``HOME`` on POSIX and ``USERPROFILE`` on Windows,
+    so both are set. This is function-scoped on purpose: neither
+    session-scoped autouse fixture above resolves a home path (they only set
+    ``GIT_CONFIG_GLOBAL`` and ``CRG_TEST_ALLOW_NO_GIT``), so there is nothing
+    that needs the redirect earlier than per-test setup, and function scope
+    keeps the plain ``monkeypatch`` fixture usable.
+    """
+    fake_home = tmp_path_factory.mktemp("crg_test_home")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,39 @@ def _allow_temporal_migration_without_git() -> None:
     os.environ["CRG_TEST_ALLOW_NO_GIT"] = "1"
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _pin_tree_sitter_grammar_cache() -> None:
+    """Pin the tree-sitter grammar cache to its real location.
+
+    MUST run before ``_isolate_per_plugin_home`` redirects HOME -- session
+    scope guarantees that, since pytest sets higher-scoped fixtures up first.
+
+    ``tree_sitter_language_pack`` keeps its downloaded grammar shared
+    libraries in an OS cache dir derived from the environment (``$HOME`` /
+    ``$XDG_CACHE_HOME`` on Linux, ``LOCALAPPDATA`` on Windows). Redirecting
+    HOME per-test moves that cache to an empty tmp dir, so every
+    ``get_parser`` call has to re-download the grammar; on a network-
+    restricted CI runner that raises
+    ``RuntimeError: Download error: Could not determine system cache
+    directory``. ``CodeParser._get_parser`` catches that and returns
+    ``None``, which ``parse_bytes`` turns into an empty result -- so the
+    whole suite silently parses zero nodes instead of erroring. That is
+    exactly what happened on ubuntu-latest, while Windows stayed green
+    because its cache follows LOCALAPPDATA rather than the redirected home.
+
+    Resolving the path here and handing it straight back via ``configure``
+    is idempotent (verified: ``cache_dir()`` is unchanged afterwards) and
+    keeps grammar loading working identically to a run with no fixtures at
+    all. The grammar cache is a downloaded build artifact, not developer
+    state, so sharing it is the same deliberate carve-out as
+    ``GIT_CONFIG_GLOBAL`` above -- credential isolation is unaffected because
+    ``PerPluginStore`` resolves from ``Path.home()``, not this cache.
+    """
+    import tree_sitter_language_pack as tslp
+
+    tslp.configure(tslp.PackConfig(cache_dir=tslp.cache_dir()))
+
+
 @pytest.fixture(autouse=True)
 def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
     """Redirect ``~`` to a per-test tmp dir so credential-store writes stay

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -1,0 +1,74 @@
+"""Guard: the test session must never touch the real home directory.
+
+``conftest._isolate_per_plugin_home`` redirects ``HOME`` / ``USERPROFILE`` so
+``PerPluginStore`` (and anything else resolving ``Path.home()``) writes into a
+tmp dir. These tests fail loudly if that fixture is ever removed, renamed, or
+stops being ``autouse``, instead of the failure showing up as mysterious
+credential files appearing in a developer's home directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from mcp_core.storage.per_plugin_store import PerPluginStore
+
+from better_code_review_graph.credential_state import PLUGIN_NAME
+
+from .conftest import REAL_HOME
+
+_FIXTURE_HINT = (
+    "conftest._isolate_per_plugin_home is not in force -- tests are running "
+    "against the real home directory and will read/write the developer's "
+    "live credential store."
+)
+
+
+def test_path_home_is_redirected_away_from_the_real_home() -> None:
+    """``Path.home()`` inside a test must not be the real home."""
+    assert Path.home() != REAL_HOME, _FIXTURE_HINT
+
+
+def test_home_env_vars_point_at_the_isolated_home() -> None:
+    """Both POSIX ``HOME`` and Windows ``USERPROFILE`` must be redirected.
+
+    Setting only one of them silently leaves the other platform unprotected,
+    so assert on both regardless of which one this platform's
+    ``Path.home()`` actually consults.
+    """
+    assert Path(os.environ["HOME"]) != REAL_HOME, _FIXTURE_HINT
+    assert Path(os.environ["USERPROFILE"]) != REAL_HOME, _FIXTURE_HINT
+    assert os.environ["HOME"] == str(Path.home()), _FIXTURE_HINT
+    assert os.environ["USERPROFILE"] == str(Path.home()), _FIXTURE_HINT
+
+
+def test_per_plugin_store_writes_land_outside_the_real_home() -> None:
+    """A real ``PerPluginStore.save()`` must not write into the real home.
+
+    The guard assertions run *before* ``save()`` so that a broken fixture can
+    never cause this test itself to pollute the real home.
+    """
+    real_leak_target = REAL_HOME / f".{PLUGIN_NAME}-mcp"
+    assert Path.home() != REAL_HOME, _FIXTURE_HINT
+
+    store = PerPluginStore(PLUGIN_NAME)
+    assert store.cred_path.parent != real_leak_target, _FIXTURE_HINT
+
+    store.save({"GEMINI_API_KEY": "home-isolation-guard-value"})
+
+    assert store.cred_path.exists()
+    assert store.cred_path.parent.parent == Path.home()
+    assert store.load() == {"GEMINI_API_KEY": "home-isolation-guard-value"}
+
+
+def test_isolated_home_is_empty_per_test() -> None:
+    """Each test gets a fresh home, so no state leaks between tests.
+
+    ``test_per_plugin_store_writes_land_outside_the_real_home`` saves a
+    credential store; if the fixture were session-scoped that store would
+    still be visible here.
+    """
+    assert Path.home() != REAL_HOME, _FIXTURE_HINT
+    assert not (Path.home() / f".{PLUGIN_NAME}-mcp").exists()
+    assert PerPluginStore(PLUGIN_NAME).load() is None

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import tree_sitter_language_pack as tslp
 from mcp_core.storage.per_plugin_store import PerPluginStore
 
 from better_code_review_graph.credential_state import PLUGIN_NAME
+from better_code_review_graph.parser import CodeParser
 
 from .conftest import REAL_HOME
 
@@ -72,3 +74,36 @@ def test_isolated_home_is_empty_per_test() -> None:
     assert Path.home() != REAL_HOME, _FIXTURE_HINT
     assert not (Path.home() / f".{PLUGIN_NAME}-mcp").exists()
     assert PerPluginStore(PLUGIN_NAME).load() is None
+
+
+def test_tree_sitter_grammar_cache_survives_the_isolated_home() -> None:
+    """Redirecting HOME must not drag the tree-sitter grammar cache with it.
+
+    ``tree_sitter_language_pack`` resolves its grammar cache from the
+    environment (``$HOME`` / ``$XDG_CACHE_HOME`` on Linux, ``LOCALAPPDATA``
+    on Windows) and memoises the result on first use. If the first resolution
+    happens inside a test, it lands in that test's empty tmp home, grammar
+    loading fails, ``CodeParser._get_parser`` swallows the error and returns
+    ``None``, and ``parse_bytes`` yields an empty result -- so the suite
+    parses zero nodes everywhere instead of erroring.
+
+    ``conftest._pin_tree_sitter_grammar_cache`` forces that first resolution
+    to happen at session start, with the real environment still in place.
+    ``cache_dir()`` raises outright when unresolvable, so this asserts both
+    that it resolves and that it did not follow the redirect.
+    """
+    assert Path.home() != REAL_HOME, _FIXTURE_HINT
+
+    cache = Path(tslp.cache_dir())
+    assert not cache.is_relative_to(Path.home()), (
+        f"tree-sitter grammar cache followed the isolated home ({cache}) -- "
+        "see conftest._pin_tree_sitter_grammar_cache"
+    )
+
+    nodes, _edges = CodeParser().parse_bytes(
+        Path("sample.py"), b"def outer():\n    return 1\n"
+    )
+    assert [n for n in nodes if n.kind == "Function"], (
+        "tree-sitter returned no Function nodes -- grammar loading is broken "
+        "under the isolated HOME (see conftest._pin_tree_sitter_grammar_cache)"
+    )


### PR DESCRIPTION
## Problem

`mcp_core.storage.per_plugin_store.PerPluginStore` resolves every path from `Path.home()`:

- config -> `~/.better-code-review-graph-mcp/config.json`
- AES-GCM machine key -> `~/.better-code-review-graph-mcp/.secret`

`tests/conftest.py` has autouse fixtures for git config, embeddings and credential state, but **none redirects HOME**. `tests/test_server.py::TestConfigTool::test_setup_status_action` calls `config(action="setup_status")` with no `PerPluginStore` patch, so it reaches the real store. `credential_state._sub_data_dir` has the same exposure via its `~/.crg` default.

## Evidence

Instrumented `_cred_path` / `_load_or_generate_machine_key` and ran the suite. Six test invocations resolved the real home path; the one that is not `load`-patched is `test_setup_status_action`.

On a machine where `~/.better-code-review-graph-mcp/` exists — the normal state for anyone who actually uses this plugin — a plain `uv run pytest` reads the developer's live credential file and mints a fresh 32-byte `.secret` into their home.

Before the patch:

```
=== BEFORE full unpatched suite ===
-rw-r--r-- 44 2026-08-02 22:21:51 config.json
1383 passed, 1 skipped, 48 deselected in 273.70s
=== AFTER full unpatched suite ===
-rw-r--r-- 32 2026-08-02 22:25:58 .secret      <-- written by the test run
-rw-r--r-- 44 2026-08-02 22:21:51 config.json
```

After the patch:

```
=== BEFORE full PATCHED suite ===
-rw-r--r-- 44 2026-08-02 22:21:51 config.json
1388 passed, 1 skipped, 48 deselected in 141.83s
=== AFTER full PATCHED suite ===
-rw-r--r-- 44 2026-08-02 22:21:51 config.json  <-- unchanged, no .secret
```

Re-running the instrumented suite after the patch: **0** resolutions of `~/.better-code-review-graph-mcp`; all now land in `pytest-of-*/crg_test_home*/`.

In CI, parallel workers race on one shared home for the same paths.

## Fix

Redirect `HOME` (POSIX) and `USERPROFILE` (Windows) to a per-test tmp dir.

Function scope is deliberate: neither session-scoped autouse fixture resolves a home path (they only set `GIT_CONFIG_GLOBAL` and `CRG_TEST_ALLOW_NO_GIT`), so nothing needs the redirect earlier than per-test setup, and function scope keeps the plain `monkeypatch` fixture usable.

## Second commit: tree-sitter grammar cache

The first commit turned ubuntu-latest red while Windows stayed green. `tree_sitter_language_pack` resolves its grammar cache from the environment (`$HOME` / `$XDG_CACHE_HOME` on Linux, `LOCALAPPDATA` on Windows) and **memoises the result on the first resolution in the process**. With the redirect, that first resolution happened inside a test, landed in an empty tmp home, and `get_parser` raised `DownloadError: Could not determine system cache directory`.

`CodeParser._get_parser` catches every exception and returns `None`, which `parse_bytes` turns into an empty result — so the failure was **silent**: the suite parsed zero nodes everywhere and reported ~120 assertion failures plus coverage dropping to 83%, instead of one clear error.

Memoisation confirmed locally:

```
=== A: resolve FIRST, then move ===
  first call : .../tree-sitter-language-pack/v1.13.3/libs
  after move : .../tree-sitter-language-pack/v1.13.3/libs
=== B: move FIRST, then resolve ===
  RAISED     : RuntimeError Download error: Could not determine system cache directory
```

Fix: a session-scoped fixture forces that first resolution at session start, with the real environment still in place, and hands the resolved path back via `configure()` (verified idempotent). Session scope guarantees it runs before the function-scoped redirect. The grammar cache is a downloaded build artifact rather than developer state, so sharing it is the same deliberate carve-out as `GIT_CONFIG_GLOBAL`; credential isolation is untouched because `PerPluginStore` resolves from `Path.home()`.

## Guard

`tests/test_home_isolation.py` fails with an actionable message if the fixture is removed, renamed, or stops being autouse. Verified by deleting the fixture:

```
5 failed in 2.80s
AssertionError: conftest._isolate_per_plugin_home is not in force -- tests are
running against the real home directory and will read/write the developer's
live credential store.
```

Restored -> `5 passed`.

## Scope

`tests/` only; `src/` untouched. CI green on ubuntu / macos / windows, coverage 95.25%.
