### PR TITLE
fix: report an unreadable credential store instead of "not configured"

### DIFF
--- a/src/better_code_review_graph/credential_state.py
+++ b/src/better_code_review_graph/credential_state.py
@@ -139,7 +139,19 @@ def resolve_credential_state() -> CredentialState:
                 _state = CredentialState.CONFIGURED
                 return _state
         except Exception as e:
-            logger.debug("Exception in %s: %s", __name__, e)
+            # load() returns None when nothing was ever saved, so reaching
+            # here means the store exists but could not be read: a corrupt
+            # config.json, a rotated machine key, or a permission problem.
+            # Startup still continues -- crg runs without cloud credentials --
+            # but falling through silently would report "not configured yet"
+            # and send the user to re-enter keys that are already saved.
+            logger.warning(
+                "Per-plugin credential store exists but could not be read "
+                "({}: {}). Continuing in awaiting_setup mode; any saved cloud "
+                "API keys are being ignored until this is resolved.",
+                type(e).__name__,
+                e,
+            )
 
         try:
             from mcp_core import get_mode
@@ -150,7 +162,16 @@ def resolve_credential_state() -> CredentialState:
                 _state = CredentialState.LOCAL
                 return _state
         except Exception as e:
-            logger.debug("Exception in %s: %s", __name__, e)
+            # Same reasoning: get_mode returns None when no marker was ever
+            # written, so an exception means an earlier "skip relay" choice is
+            # unreadable and the user will be prompted to set up again.
+            logger.warning(
+                "Local-mode marker could not be read ({}: {}). Continuing in "
+                "awaiting_setup mode; a previous 'skip relay' choice is being "
+                "ignored.",
+                type(e).__name__,
+                e,
+            )
 
     logger.info("No credentials found -- server starting in awaiting_setup mode")
     _state = CredentialState.AWAITING_SETUP

--- a/tests/test_credential_state_store_errors.py
+++ b/tests/test_credential_state_store_errors.py
@@ -1,0 +1,164 @@
+"""A broken credential store must not be reported as "not configured yet".
+
+``resolve_credential_state`` reads the encrypted per-plugin store and the
+local-mode marker in HTTP mode. Both reads used to swallow every exception
+into ``logger.debug``, so a store that exists but cannot be decrypted was
+indistinguishable from a fresh install: the server logged "No credentials
+found -- server starting in awaiting_setup mode" and the user went off to
+re-enter API keys that were already saved and already correct.
+
+Two things made that invisible rather than merely quiet:
+
+* the level was ``debug``, below the default threshold, and
+* ``credential_state`` is the only module using loguru, where
+  ``logger.debug("Exception in %s: %s", name, exc)`` renders literally as
+  ``Exception in %s: %s`` -- loguru formats with ``str.format``, so the
+  ``%s`` placeholders never interpolate and the cause is dropped even when
+  debug logging is switched on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loguru import logger
+
+from better_code_review_graph import credential_state as cs
+
+_DECRYPT_ERROR = "machine key mismatch -- cannot decrypt config.json"
+
+
+@pytest.fixture
+def loguru_messages():
+    """Capture every loguru record emitted during the test."""
+    captured: list[object] = []
+    sink_id = logger.add(captured.append, level="DEBUG", format="{message}")
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
+
+@pytest.fixture
+def http_mode_without_env_keys(monkeypatch):
+    """HTTP mode with no cloud keys set, so the store path is reached."""
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    for key in cs.CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _levels_and_texts(captured) -> list[tuple[str, str]]:
+    return [(m.record["level"].name, str(m)) for m in captured]
+
+
+class TestUnreadableStoreIsReported:
+    def test_store_read_failure_is_logged_above_debug_with_the_cause(
+        self, loguru_messages, http_mode_without_env_keys, monkeypatch
+    ):
+        """The operator must be able to tell "broken" from "not set up"."""
+        monkeypatch.setattr(
+            cs.PerPluginStore,
+            "load",
+            lambda self: (_ for _ in ()).throw(RuntimeError(_DECRYPT_ERROR)),
+        )
+
+        state = cs.resolve_credential_state()
+
+        # The server still starts -- crg works without cloud credentials.
+        assert state is cs.CredentialState.AWAITING_SETUP
+
+        emitted = _levels_and_texts(loguru_messages)
+        loud = [
+            (level, text)
+            for level, text in emitted
+            if level in ("WARNING", "ERROR", "CRITICAL")
+        ]
+        assert loud, f"a broken store must not be debug-only; got {emitted}"
+        assert any(_DECRYPT_ERROR in text for _level, text in loud), (
+            f"the underlying cause must survive into the message; got {loud}"
+        )
+
+    def test_mode_marker_read_failure_is_logged_above_debug_with_the_cause(
+        self, loguru_messages, http_mode_without_env_keys, monkeypatch
+    ):
+        """A previous "skip relay" choice going unreadable is also a fault."""
+        monkeypatch.setattr(cs.PerPluginStore, "load", lambda self: None)
+
+        import mcp_core
+
+        monkeypatch.setattr(
+            mcp_core,
+            "get_mode",
+            lambda name: (_ for _ in ()).throw(RuntimeError(_DECRYPT_ERROR)),
+        )
+
+        state = cs.resolve_credential_state()
+        assert state is cs.CredentialState.AWAITING_SETUP
+
+        emitted = _levels_and_texts(loguru_messages)
+        loud = [
+            (level, text)
+            for level, text in emitted
+            if level in ("WARNING", "ERROR", "CRITICAL")
+        ]
+        assert loud, f"an unreadable mode marker must not be debug-only; got {emitted}"
+        assert any(_DECRYPT_ERROR in text for _level, text in loud), (
+            f"the underlying cause must survive into the message; got {loud}"
+        )
+
+    def test_no_placeholder_leaks_into_any_message(
+        self, loguru_messages, http_mode_without_env_keys, monkeypatch
+    ):
+        """Guard the loguru-vs-printf trap that dropped the cause entirely."""
+        monkeypatch.setattr(
+            cs.PerPluginStore,
+            "load",
+            lambda self: (_ for _ in ()).throw(RuntimeError(_DECRYPT_ERROR)),
+        )
+
+        cs.resolve_credential_state()
+
+        for _level, text in _levels_and_texts(loguru_messages):
+            assert "%s" not in text, (
+                f"printf placeholder reached the log verbatim: {text!r} -- "
+                "loguru formats with str.format, not %-style"
+            )
+
+
+class TestHealthyPathsUnchanged:
+    def test_absent_store_still_reports_awaiting_setup_quietly(
+        self, loguru_messages, http_mode_without_env_keys, monkeypatch
+    ):
+        """A fresh install is not a fault and must stay quiet.
+
+        ``PerPluginStore.load()`` returns ``None`` when nothing was ever
+        saved, so this path raises nothing and must not warn.
+        """
+        monkeypatch.setattr(cs.PerPluginStore, "load", lambda self: None)
+
+        import mcp_core
+
+        monkeypatch.setattr(mcp_core, "get_mode", lambda name: None)
+
+        state = cs.resolve_credential_state()
+
+        assert state is cs.CredentialState.AWAITING_SETUP
+        loud = [
+            (level, text)
+            for level, text in _levels_and_texts(loguru_messages)
+            if level in ("WARNING", "ERROR", "CRITICAL")
+        ]
+        assert not loud, f"a fresh install must not warn; got {loud}"
+
+    def test_env_keys_short_circuit_before_touching_the_store(
+        self, loguru_messages, monkeypatch
+    ):
+        """Env-var credentials win and never read the store at all."""
+        monkeypatch.setenv("MCP_TRANSPORT", "http")
+        monkeypatch.setenv("GEMINI_API_KEY", "set-by-user")
+
+        def _explode(self):
+            raise AssertionError("store must not be read when env keys are present")
+
+        monkeypatch.setattr(cs.PerPluginStore, "load", _explode)
+
+        assert cs.resolve_credential_state() is cs.CredentialState.CONFIGURED


### PR DESCRIPTION
Part 1 of 2 of the swallow sweep following #929. This PR covers the two sites in `credential_state.py`; the `tools.py` / `parser.py` sites follow in a separate PR so each stays reviewable.

## The defect

`resolve_credential_state` swallowed every exception from `PerPluginStore.load()` and `mcp_core.get_mode()` into `logger.debug`. A store that exists but cannot be decrypted was therefore indistinguishable from a fresh install: startup logged `No credentials found -- server starting in awaiting_setup mode` and the user went off to re-enter API keys that were already saved and already correct.

Two things made that invisible rather than merely quiet:

1. the level was `debug`, below the default threshold; and
2. `credential_state` is the only module in `src/` that uses **loguru**, where `logger.debug("Exception in %s: %s", __name__, e)` renders literally as `Exception in %s: %s` — loguru formats with `str.format`, not printf, so the placeholders never interpolate and the cause was dropped even with debug logging switched on.

The second point is visible in the pre-patch test output below.

## The fix

Both handlers log at `warning` with the exception type and message, using loguru's brace style so the cause actually renders.

Startup behaviour is deliberately unchanged — crg works without cloud credentials, so the resolved state is still `AWAITING_SETUP`. What changes is that an operator can tell "broken" from "not set up yet".

The absent-store path stays silent by construction: `load()` and `get_mode()` return `None` when nothing was ever saved, so a fresh install never enters either handler. `tests/test_credential_state_store_errors.py::TestHealthyPathsUnchanged` pins that.

## Red before, green after

Against unpatched `credential_state.py` (3 failed / 2 passed):

```
_ TestUnreadableStoreIsReported.test_store_read_failure_is_logged_above_debug_with_the_cause _
E   AssertionError: a broken store must not be debug-only; got [('DEBUG', 'Exception in %s: %s\n'), ('INFO', 'No credentials found -- server starting in awaiting_setup mode\n')]
E   assert []

_ TestUnreadableStoreIsReported.test_mode_marker_read_failure_is_logged_above_debug_with_the_cause _
E   AssertionError: an unreadable mode marker must not be debug-only; got [('DEBUG', 'Exception in %s: %s\n'), ('INFO', 'No credentials found -- server starting in awaiting_setup mode\n')]
E   assert []

__ TestUnreadableStoreIsReported.test_no_placeholder_leaks_into_any_message ___
E   AssertionError: printf placeholder reached the log verbatim: 'Exception in %s: %s\n' -- loguru formats with str.format, not %-style
E   assert '%s' not in 'Exception in %s: %s\n'
```

After the patch: `38 passed` for `test_credential_state_store_errors.py` + `test_credential_state.py`.

Full suite: `1407 passed, 1 skipped, 48 deselected` — coverage **95.26%** (gate 95%).

## Not in this PR

`reset_state()` at `credential_state.py:326` has the same broken `logger.debug("Exception in %s: %s", ...)` pattern but was not in the assigned list; reported separately rather than fixed here.