### PR TITLE
fix: report unknown as null instead of faking zeroes in query responses

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -21,7 +21,21 @@ from sqlalchemy import engine_from_config, pool
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # ``disable_existing_loggers`` defaults to True, which sets
+    # ``disabled = True`` on every logger created before this point --
+    # including every ``better_code_review_graph.*`` logger, since the
+    # package is imported long before any migration runs. The effect is
+    # permanent for the life of the process: crg stops logging entirely,
+    # silently, with no error.
+    #
+    # In production this never fired because ``GraphStore`` builds its
+    # Alembic Config programmatically and leaves ``config_file_name``
+    # unset. It fired in the test suite, where ``tests/test_alembic_*``
+    # loads ``alembic.ini`` directly -- so from the first such test
+    # onward, every log-based assertion in the run was testing a logger
+    # that could not emit. Tests passed in isolation and silently lost
+    # their teeth in the full run.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # No declarative metadata: schema is hand-authored in versions/.
 target_metadata = None

--- a/src/better_code_review_graph/docs/recipes.md
+++ b/src/better_code_review_graph/docs/recipes.md
@@ -18,6 +18,10 @@ Look for `total_nodes > 0` and `last_updated < 24h`. If `embeddings_count == 0`
 and you plan to run `search` on phrases (not literal identifiers), run
 `graph action=embed` first or expect a keyword-only warning (#317).
 
+`embeddings_count` is `null` (not `0`) when the embedding store could not be
+read at all, with the reason in `header.embeddings_error`. Running
+`graph action=embed` will not fix that - check the store itself.
+
 ---
 
 ## Stage 1 - Build / refresh
@@ -67,7 +71,8 @@ and `hint` to scope down (#315).
 
 Check the response `header.embeddings_count` first (#330). If zero, use a
 literal identifier only - keyword fallback returns garbage on phrases
-(#317 emits a warning when it sees a phrase-shaped query).
+(#317 emits a warning when it sees a phrase-shaped query). If it is `null`,
+the count is unknown rather than zero; see `header.embeddings_error`.
 
 ---
 
@@ -164,6 +169,13 @@ reference.
   and `auth()` exist, the Function will be picked.
 - `search` and `query` responses always include a `header` block with
   `embeddings_count`, `keyword_only`, and `graph_last_updated` (#330)
-  so audit trails do not need a separate `config status` call.
+  so audit trails do not need a separate `config status` call. A `null` in
+  `embeddings_count` or `graph_last_updated` means the read failed, not that
+  the value is zero or unset; the companion `embeddings_error` /
+  `graph_last_updated_error` key carries the reason.
+- A `not_found` response reports `indexed_kinds: null` plus
+  `indexed_kinds_error` when the graph could not be queried for its node
+  kinds. That is distinct from `indexed_kinds: []`, which means the graph
+  really is empty and should be rebuilt.
 - Pass `max_payload_bytes=0` to `impact` to opt out of the size cap if
   you can handle the full payload.

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -767,10 +767,26 @@ class CodeParser:
                     source_repo_id,
                     target_repos,
                 )
-            except Exception:
+            except Exception as exc:
                 # The resolver may touch the filesystem; treat any
                 # error as "no cross-repo match" rather than aborting
                 # the whole parse. Single-repo mode is preserved.
+                #
+                # The fallback is deliberate, the silence was not: the
+                # resolver returns None for a genuine "no match", so an
+                # exception here is a different event entirely, and it
+                # previously produced no record at any log level. A whole
+                # federated build could resolve zero cross-repo imports and
+                # look exactly like a correctly configured single-repo one.
+                logger.warning(
+                    "Cross-repo import resolution failed for %r in %s "
+                    "(%s: %s); leaving the edge target unresolved, so this "
+                    "import will not be linked across repos.",
+                    stmt,
+                    path,
+                    type(exc).__name__,
+                    exc,
+                )
                 resolved = None
             if resolved is not None:
                 edge.target = resolved

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -232,9 +232,14 @@ def _build_response_header(
     Surfaces ``embeddings_count`` and the derived ``keyword_only`` flag so
     consumers know whether the results came from semantic-similarity search
     (``embeddings_count > 0``) or keyword-substring fallback. Plus
-    ``graph_last_updated`` when available. Errors are swallowed and the
-    relevant fields fall back to ``None`` -- the header is best-effort
-    metadata, never load-bearing for query correctness.
+    ``graph_last_updated`` when available.
+
+    The header never raises -- it is metadata, not query correctness -- but a
+    read that fails is reported as ``null`` plus an explicit ``*_error`` key
+    rather than as a plausible-looking value. ``embeddings_count: 0`` in
+    particular is documented advice (``docs/recipes.md``: "if
+    ``embeddings_count == 0`` ... run ``graph action=embed`` first"), and
+    embedding cannot fix a store that will not open.
 
     Args:
         store: Open ``GraphStore`` (used for ``last_updated`` metadata).
@@ -244,6 +249,7 @@ def _build_response_header(
             flag is derived from ``embeddings_count``.
     """
     emb_count: int | None = None
+    emb_error: str | None = None
     if db_path is not None:
         try:
             backend = init_backend()
@@ -253,25 +259,50 @@ def _build_response_header(
             finally:
                 emb_store.close()
         except Exception as e:
-            logger.debug("Exception in %s: %s", __name__, e)
+            emb_error = f"{type(e).__name__}: {e}"
             emb_count = None
+            logger.warning(
+                "Embedding store at %s could not be read (%s); reporting "
+                "embeddings_count as null rather than 0, because 0 means "
+                "'no embeddings yet, run graph action=embed' and that will "
+                "not fix an unreadable store.",
+                db_path,
+                emb_error,
+            )
 
     last_updated: str | None = None
+    meta_error: str | None = None
     if store is not None:
         try:
             last_updated = store.get_metadata("last_updated")
         except Exception as e:
-            logger.debug("Exception in %s: %s", __name__, e)
+            meta_error = f"{type(e).__name__}: {e}"
             last_updated = None
+            logger.warning(
+                "Graph metadata could not be read (%s); graph_last_updated "
+                "is null because the read failed, not because the graph was "
+                "never built.",
+                meta_error,
+            )
 
     if keyword_only is None:
+        # An unreadable embedding store cannot serve semantic search either,
+        # so keyword_only is true whether the count is zero or unknown.
         keyword_only = (emb_count is None) or (emb_count == 0)
 
-    return {
-        "embeddings_count": emb_count if emb_count is not None else 0,
+    header: dict[str, Any] = {
+        # Zero only when a read succeeded and found nothing, or when there
+        # was no db_path to read in the first place. Never as a stand-in for
+        # "could not tell".
+        "embeddings_count": None if emb_error else (emb_count or 0),
         "keyword_only": bool(keyword_only),
         "graph_last_updated": last_updated,
     }
+    if emb_error:
+        header["embeddings_error"] = emb_error
+    if meta_error:
+        header["graph_last_updated_error"] = meta_error
+    return header
 
 
 def _validate_repo_root(path: Path) -> Path:
@@ -717,14 +748,25 @@ _QUERY_PATTERNS = {
 _LAST_CALLERS_RESULT: dict[str, dict[str, Any]] = {}
 
 
-def _list_kinds_in_graph(store: Any) -> list[str]:
-    """Return distinct node kinds present in the graph (for D15 hints)."""
+def _list_kinds_in_graph(store: Any) -> list[str] | None:
+    """Return distinct node kinds present in the graph (for D15 hints).
+
+    Returns ``None`` -- not ``[]`` -- when the graph cannot be queried. An
+    empty list is a factual claim that nothing is indexed, and the caller
+    turns that claim into "rebuild your graph"; a failed read cannot
+    support it.
+    """
     try:
         cursor = store._conn.execute("SELECT DISTINCT kind FROM nodes ORDER BY kind")
         return [r["kind"] for r in cursor]
     except Exception as e:
-        logger.debug("Exception in %s: %s", __name__, e)
-        return []
+        logger.warning(
+            "Could not list node kinds from the graph (%s: %s); reporting "
+            "them as unknown rather than as an empty graph.",
+            type(e).__name__,
+            e,
+        )
+        return None
 
 
 def _lookup_node_directly(
@@ -853,7 +895,7 @@ def _resolve_path_fallback(
 def _handle_not_found(store: Any, target: str) -> dict[str, Any]:
     """Generate the not_found error response for D15."""
     indexed_kinds = _list_kinds_in_graph(store)
-    return {
+    response: dict[str, Any] = {
         "status": "not_found",
         "reason": "no_such_symbol",
         "summary": f"No node found matching {target!r}.",
@@ -864,6 +906,17 @@ def _handle_not_found(store: Any, target: str) -> dict[str, Any]:
             "('file_path::Class.method')."
         ),
     }
+    if indexed_kinds is None:
+        # The symbol genuinely was not found, so ``not_found`` still holds --
+        # but we cannot also claim the graph is empty. Saying
+        # ``indexed_kinds: []`` here would send the caller off to rebuild a
+        # graph whose real problem is that it will not answer queries.
+        response["indexed_kinds_error"] = (
+            "The graph could not be queried for its indexed node kinds, so "
+            "this is 'unknown', not 'nothing indexed'. See the server log "
+            "for the underlying error."
+        )
+    return response
 
 
 def _resolve_query_target(
@@ -978,7 +1031,17 @@ def _scan_dynamic_dispatch_hints(
         for e in store.get_edges_by_target(target_file, kind="IMPORTS_FROM"):  # type: ignore[attr-defined]
             candidate_files.add(e.file_path)
     except Exception as e:
-        logger.debug("Exception in %s: %s", __name__, e)
+        # Deliberately non-fatal: the scan still covers the target's own
+        # file, which is where most dynamic-dispatch sites live. But the
+        # caller gets a narrower hint set than it asked for, so say so --
+        # at debug this was indistinguishable from "no importers found".
+        logger.warning(
+            "Could not list importers of %s (%s: %s); dynamic-dispatch hints "
+            "cover only that file, so the hint list may be incomplete.",
+            target_file,
+            type(e).__name__,
+            e,
+        )
 
     hits: list[dict[str, Any]] = []
     for fp in candidate_files:

--- a/tests/test_graph_stats_error_coverage.py
+++ b/tests/test_graph_stats_error_coverage.py
@@ -7,14 +7,18 @@ from better_code_review_graph.tools import _build_response_header, _list_kinds_i
 def test_list_kinds_in_graph_exception_handled():
     mock_store = MagicMock()
     mock_store._conn.execute.side_effect = Exception("DB error")
-    assert _list_kinds_in_graph(mock_store) == []
+    # None, not []: an empty list would claim the graph holds no nodes.
+    assert _list_kinds_in_graph(mock_store) is None
 
 
 def test_build_response_header_embedding_exception_handled():
     with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
         mock_emb.side_effect = Exception("Embedding error")
         header = _build_response_header(db_path=Path("/tmp/fake"), store=None)
-        assert header["embeddings_count"] == 0
+        # None, not 0: 0 is documented advice to run `graph action=embed`,
+        # which cannot fix a store that will not open.
+        assert header["embeddings_count"] is None
+        assert "Embedding error" in header["embeddings_error"]
         assert header["keyword_only"] is True
 
 

--- a/tests/test_handle_not_found_coverage.py
+++ b/tests/test_handle_not_found_coverage.py
@@ -53,8 +53,10 @@ def test_handle_not_found_store_error(tmp_graph_store):
     target = "error_symbol"
     tmp_graph_store.close()
 
-    # _list_kinds_in_graph should catch the exception and return []
+    # The symbol genuinely was not found, so the status still holds -- but
+    # the closed connection means we cannot also claim the graph is empty.
     result = _handle_not_found(tmp_graph_store, target)
 
     assert result["status"] == "not_found"
-    assert result["indexed_kinds"] == []
+    assert result["indexed_kinds"] is None
+    assert "not 'nothing indexed'" in result["indexed_kinds_error"]

--- a/tests/test_kinds_error_path.py
+++ b/tests/test_kinds_error_path.py
@@ -9,4 +9,5 @@ def test_list_kinds_in_graph_error_path():
     mock_store._conn.execute.side_effect = Exception("DB Error")
 
     kinds = _list_kinds_in_graph(mock_store)
-    assert kinds == []
+    # None, not []: an empty list would claim the graph holds no nodes.
+    assert kinds is None

--- a/tests/test_list_kinds_coverage.py
+++ b/tests/test_list_kinds_coverage.py
@@ -17,17 +17,17 @@ def test_list_kinds_in_graph_success():
 
 
 def test_list_kinds_in_graph_execute_exception():
-    """Verify that _list_kinds_in_graph returns an empty list if execute() raises an exception."""
+    """A failed execute() reports unknown (None), never an empty graph."""
     mock_store = MagicMock()
     mock_store._conn.execute.side_effect = RuntimeError("SQL Error")
 
     result = _list_kinds_in_graph(mock_store)
 
-    assert result == []
+    assert result is None
 
 
 def test_list_kinds_in_graph_iteration_exception():
-    """Verify that _list_kinds_in_graph returns an empty list if cursor iteration raises."""
+    """Failed cursor iteration reports unknown (None), never an empty graph."""
     mock_store = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.__iter__.side_effect = Exception("Iter Error")
@@ -35,15 +35,15 @@ def test_list_kinds_in_graph_iteration_exception():
 
     result = _list_kinds_in_graph(mock_store)
 
-    assert result == []
+    assert result is None
 
 
 def test_list_kinds_in_graph_processing_exception():
-    """Verify that _list_kinds_in_graph returns an empty list if an exception occurs during list comprehension."""
+    """A row missing 'kind' reports unknown (None), never an empty graph."""
     mock_store = MagicMock()
     # Returning rows missing the 'kind' key will trigger a KeyError in the list comprehension
     mock_store._conn.execute.return_value = [{"not_kind": "foo"}]
 
     result = _list_kinds_in_graph(mock_store)
 
-    assert result == []
+    assert result is None

--- a/tests/test_response_payload_honesty.py
+++ b/tests/test_response_payload_honesty.py
@@ -1,0 +1,307 @@
+"""Failed reads must not be reported as factual zeroes and empty lists.
+
+Four helpers on the query/response path caught every exception and returned
+a value that is indistinguishable from a real, successful answer:
+
+* ``_build_response_header`` reported ``embeddings_count: 0`` when the
+  embedding store could not be opened. Zero is a documented instruction --
+  ``docs/recipes.md`` tells the caller "if ``embeddings_count == 0`` ... run
+  ``graph action=embed`` first" -- and running embed cannot fix a store that
+  will not open, so the caller loops.
+* the same helper reported ``graph_last_updated: null`` for an unreadable
+  metadata table, which reads as "never built".
+* ``_list_kinds_in_graph`` returned ``[]`` for a broken graph, which reaches
+  the user as ``indexed_kinds: []``: "nothing is indexed, rebuild".
+* ``_scan_dynamic_dispatch_hints`` and ``CodeParser._apply_federation``
+  degrade correctly but did so at ``debug`` and at no level at all
+  respectively, so nobody could tell degraded output from complete output.
+
+The first three are wrong answers. The last two are right answers delivered
+silently. Both are covered here.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from better_code_review_graph.parser import CodeParser, EdgeInfo
+from better_code_review_graph.tools import (
+    _build_response_header,
+    _handle_not_found,
+    _list_kinds_in_graph,
+    _scan_dynamic_dispatch_hints,
+)
+
+_BOOM = "disk I/O error"
+
+
+def _loud(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestEmbeddingsCountDoesNotFakeZero:
+    def test_unreadable_embedding_store_is_not_reported_as_zero(self, tmp_path):
+        """Zero is documented advice to run embed; it cannot fix this."""
+        with patch(
+            "better_code_review_graph.tools.EmbeddingStore",
+            side_effect=RuntimeError(_BOOM),
+        ):
+            header = _build_response_header(None, tmp_path / "graph.db")
+
+        assert header["embeddings_count"] != 0, (
+            "reporting 0 sends the caller to 'graph action=embed' "
+            "(docs/recipes.md) for a store that will not open"
+        )
+        assert header["embeddings_count"] is None
+        assert _BOOM in header["embeddings_error"]
+
+    def test_unreadable_embedding_store_is_logged_above_debug(self, tmp_path, caplog):
+        caplog.set_level(logging.DEBUG)
+        with patch(
+            "better_code_review_graph.tools.EmbeddingStore",
+            side_effect=RuntimeError(_BOOM),
+        ):
+            _build_response_header(None, tmp_path / "graph.db")
+
+        loud = _loud(caplog)
+        assert loud, f"nothing above debug; got {[r.message for r in caplog.records]}"
+        assert any(_BOOM in r.getMessage() for r in loud)
+
+    def test_keyword_only_stays_true_when_the_store_is_unreadable(self, tmp_path):
+        """A store that will not open cannot serve semantic search either."""
+        with patch(
+            "better_code_review_graph.tools.EmbeddingStore",
+            side_effect=RuntimeError(_BOOM),
+        ):
+            header = _build_response_header(None, tmp_path / "graph.db")
+        assert header["keyword_only"] is True
+
+
+class TestLastUpdatedDoesNotFakeNeverBuilt:
+    def test_unreadable_metadata_carries_an_explicit_error(self):
+        bad_store = MagicMock()
+        bad_store.get_metadata.side_effect = RuntimeError(_BOOM)
+
+        header = _build_response_header(bad_store, None, keyword_only=False)
+
+        assert header["graph_last_updated"] is None
+        assert _BOOM in header["graph_last_updated_error"], (
+            "a null timestamp reads as 'never built'; the read failure must "
+            "be stated separately"
+        )
+
+    def test_unreadable_metadata_is_logged_above_debug(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        bad_store = MagicMock()
+        bad_store.get_metadata.side_effect = RuntimeError(_BOOM)
+
+        _build_response_header(bad_store, None, keyword_only=False)
+
+        loud = _loud(caplog)
+        assert loud, f"nothing above debug; got {[r.message for r in caplog.records]}"
+        assert any(_BOOM in r.getMessage() for r in loud)
+
+
+class TestIndexedKindsDoesNotFakeEmpty:
+    def test_unreadable_graph_returns_none_not_empty_list(self):
+        bad_store = MagicMock()
+        bad_store._conn.execute.side_effect = RuntimeError(_BOOM)
+
+        assert _list_kinds_in_graph(bad_store) is None, (
+            "[] is a factual claim that nothing is indexed"
+        )
+
+    def test_unreadable_graph_is_logged_above_debug(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        bad_store = MagicMock()
+        bad_store._conn.execute.side_effect = RuntimeError(_BOOM)
+
+        _list_kinds_in_graph(bad_store)
+
+        loud = _loud(caplog)
+        assert loud, f"nothing above debug; got {[r.message for r in caplog.records]}"
+        assert any(_BOOM in r.getMessage() for r in loud)
+
+    def test_not_found_response_does_not_claim_an_empty_graph(self):
+        """The user-visible payload must not say "nothing is indexed"."""
+        bad_store = MagicMock()
+        bad_store._conn.execute.side_effect = RuntimeError(_BOOM)
+
+        result = _handle_not_found(bad_store, "some_symbol")
+
+        assert result["indexed_kinds"] != [], (
+            "an empty list here tells the user to rebuild a graph that is "
+            "not actually empty"
+        )
+        assert result["indexed_kinds"] is None
+        assert "not 'nothing indexed'" in result["indexed_kinds_error"]
+
+    def test_genuinely_empty_graph_still_reports_an_empty_list(self, tmp_graph_store):
+        """A real empty graph is a fact and must keep saying so."""
+        result = _handle_not_found(tmp_graph_store, "missing")
+
+        assert result["indexed_kinds"] == []
+        assert "indexed_kinds_error" not in result
+
+
+class TestDegradedScansAnnounceThemselves:
+    def test_dispatch_hint_scan_narrowing_is_logged_above_debug(self, tmp_path, caplog):
+        """Narrowing the scan is correct; doing it silently is not."""
+        caplog.set_level(logging.DEBUG)
+        target = tmp_path / "target.py"
+        target.write_text("def fn():\n    return 1\n")
+        node = MagicMock()
+        node.language = "python"
+        node.file_path = str(target)
+
+        store = MagicMock()
+        store.get_edges_by_target.side_effect = RuntimeError(_BOOM)
+
+        hits = _scan_dynamic_dispatch_hints(store, node, "fn")
+
+        # Behaviour is unchanged: the scan still runs over the target file.
+        assert isinstance(hits, list)
+
+        loud = _loud(caplog)
+        assert loud, (
+            "the caller receives a narrower hint set with no way to know; "
+            f"got {[r.message for r in caplog.records]}"
+        )
+        assert any(_BOOM in r.getMessage() for r in loud)
+
+    def test_healthy_dispatch_hint_scan_stays_quiet(self, tmp_path, caplog):
+        caplog.set_level(logging.DEBUG)
+        target = tmp_path / "target.py"
+        target.write_text("def fn():\n    return 1\n")
+        node = MagicMock()
+        node.language = "python"
+        node.file_path = str(target)
+
+        store = MagicMock()
+        store.get_edges_by_target.return_value = []
+
+        _scan_dynamic_dispatch_hints(store, node, "fn")
+
+        assert not _loud(caplog)
+
+
+class TestFederationResolverFailureIsAnnounced:
+    @pytest.fixture
+    def federation_args(self, tmp_path):
+        src = tmp_path / "repo_a"
+        src.mkdir()
+        (src / "mod.py").write_text("import other\n")
+
+        registry = MagicMock()
+        registry.assign.return_value = "repo-a"
+        entry = MagicMock()
+        entry.repo_id = "repo-a"
+        entry.path = src
+        registry.entries.return_value = [entry]
+
+        edge = EdgeInfo(
+            kind="IMPORTS_FROM",
+            source="mod.py::mod",
+            target="other",
+            file_path=str(src / "mod.py"),
+            extra={"import_stmt": "import other"},
+        )
+        return {
+            "path": src / "mod.py",
+            "language": "python",
+            "nodes": [],
+            "edges": [edge],
+            "repo_registry": registry,
+            "target_repos": [MagicMock()],
+        }
+
+    def test_resolver_failure_is_logged_above_debug(self, federation_args, caplog):
+        """Today this except swallows to `resolved = None` with no log."""
+        caplog.set_level(logging.DEBUG)
+        with patch(
+            "better_code_review_graph.resolver.resolve_cross_repo_imports",
+            side_effect=RuntimeError(_BOOM),
+        ):
+            CodeParser()._apply_federation(**federation_args)
+
+        # Behaviour is unchanged: the edge keeps its single-repo target.
+        assert federation_args["edges"][0].target == "other"
+
+        loud = _loud(caplog)
+        assert loud, (
+            "cross-repo resolution failed and produced no record at any "
+            f"level; got {[r.message for r in caplog.records]}"
+        )
+        assert any(_BOOM in r.getMessage() for r in loud)
+
+    def test_successful_resolution_stays_quiet(self, federation_args, caplog):
+        caplog.set_level(logging.DEBUG)
+        with patch(
+            "better_code_review_graph.resolver.resolve_cross_repo_imports",
+            return_value="repo-b::other",
+        ):
+            CodeParser()._apply_federation(**federation_args)
+
+        assert federation_args["edges"][0].target == "repo-b::other"
+        assert not _loud(caplog)
+
+
+class TestHealthyHeaderUnchanged:
+    def test_no_db_path_still_reports_zero_not_an_error(self):
+        """``db_path=None`` never attempts a read, so nothing failed."""
+        header = _build_response_header(None, None)
+
+        assert header["embeddings_count"] == 0
+        assert header["keyword_only"] is True
+        assert header["graph_last_updated"] is None
+        assert "embeddings_error" not in header
+        assert "graph_last_updated_error" not in header
+
+    def test_working_store_reports_the_real_count(self, tmp_path):
+        with patch("better_code_review_graph.tools.EmbeddingStore") as mock_emb:
+            mock_emb.return_value.count.return_value = 42
+            header = _build_response_header(None, tmp_path / "graph.db")
+
+        assert header["embeddings_count"] == 42
+        assert header["keyword_only"] is False
+        assert "embeddings_error" not in header
+
+
+class TestAlembicDoesNotDisableApplicationLogging:
+    """Regression guard for a defect that silently defanged log assertions.
+
+    ``migrations/env.py`` calls ``logging.config.fileConfig``, whose
+    ``disable_existing_loggers`` argument defaults to ``True``. Every
+    ``better_code_review_graph.*`` logger is created at import time, long
+    before any migration runs, so the default set ``disabled = True`` on all
+    of them for the rest of the process.
+
+    Production never hit this: ``GraphStore`` builds its Alembic ``Config``
+    programmatically and leaves ``config_file_name`` unset, so ``env.py``
+    skips the ``fileConfig`` call. The test suite did hit it, because
+    ``tests/test_alembic_baseline.py`` loads ``alembic.ini`` directly. From
+    that point on, every log-based assertion in the run was inspecting a
+    logger that could not emit -- such tests passed alone and quietly stopped
+    testing anything in the full run.
+    """
+
+    def test_running_migrations_from_alembic_ini_leaves_logging_alive(self, tmp_path):
+        from alembic import command
+        from alembic.config import Config
+
+        from better_code_review_graph import tools as tools_module
+
+        repo_root = Path(__file__).resolve().parent.parent
+        cfg = Config(str(repo_root / "alembic.ini"))
+        cfg.set_main_option("script_location", str(repo_root / "migrations"))
+        cfg.set_main_option("sqlalchemy.url", f"sqlite:///{tmp_path / 'g.db'}")
+        command.upgrade(cfg, "head")
+
+        assert not tools_module.logger.disabled, (
+            "alembic's fileConfig disabled the application loggers; every "
+            "log-based assertion after this point is silently inert"
+        )

--- a/tests/test_v17_coverage_gaps.py
+++ b/tests/test_v17_coverage_gaps.py
@@ -65,19 +65,20 @@ def _clear_caches():
 
 
 # ---------------------------------------------------------------------------
-# _build_response_header (#330) — exception fallbacks
+# _build_response_header (#330) â€” exception fallbacks
 # ---------------------------------------------------------------------------
 
 
 class TestBuildResponseHeader:
     def test_init_backend_exception_yields_zero_count(self, tmp_path):
-        """When init_backend raises, emb_count fallback is None -> 0."""
+        """When init_backend raises, the count is unknown, not zero."""
         with patch(
             "better_code_review_graph.tools.init_backend",
             side_effect=RuntimeError("backend boom"),
         ):
             header = _build_response_header(None, tmp_path / "graph.db")
-        assert header["embeddings_count"] == 0
+        assert header["embeddings_count"] is None
+        assert "backend boom" in header["embeddings_error"]
         assert header["keyword_only"] is True
         assert header["graph_last_updated"] is None
 
@@ -91,18 +92,19 @@ class TestBuildResponseHeader:
 
 
 # ---------------------------------------------------------------------------
-# _list_kinds_in_graph — exception fallback
+# _list_kinds_in_graph â€” exception fallback
 # ---------------------------------------------------------------------------
 
 
-def test_list_kinds_in_graph_returns_empty_on_exception():
+def test_list_kinds_in_graph_returns_none_on_exception():
     bad_store = MagicMock()
     bad_store._conn.execute.side_effect = RuntimeError("sql boom")
-    assert _list_kinds_in_graph(bad_store) == []
+    # None, not []: an empty list would claim the graph holds no nodes.
+    assert _list_kinds_in_graph(bad_store) is None
 
 
 # ---------------------------------------------------------------------------
-# _scan_dynamic_dispatch_hints — language fallthroughs / edge cases
+# _scan_dynamic_dispatch_hints â€” language fallthroughs / edge cases
 # ---------------------------------------------------------------------------
 
 
@@ -177,7 +179,7 @@ class TestScanDynamicDispatchHints:
 
 
 # ---------------------------------------------------------------------------
-# spot_check_last_callers — no-edges + read-error
+# spot_check_last_callers â€” no-edges + read-error
 # ---------------------------------------------------------------------------
 
 
@@ -222,7 +224,7 @@ class TestSpotCheckEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# renamed_in_diff (#320) — filter branches
+# renamed_in_diff (#320) â€” filter branches
 # ---------------------------------------------------------------------------
 
 
@@ -400,7 +402,7 @@ class TestLiteralIdentifier:
 
 
 # ---------------------------------------------------------------------------
-# semantic_search_nodes — query-too-long guard
+# semantic_search_nodes â€” query-too-long guard
 # ---------------------------------------------------------------------------
 
 
@@ -411,7 +413,7 @@ def test_semantic_search_rejects_overlong_query():
 
 
 # ---------------------------------------------------------------------------
-# query_graph — target-too-long guard
+# query_graph â€” target-too-long guard
 # ---------------------------------------------------------------------------
 
 
@@ -426,7 +428,7 @@ def test_query_graph_rejects_overlong_target():
 
 
 # ---------------------------------------------------------------------------
-# get_impact_radius — symlink + path-traversal filters
+# get_impact_radius â€” symlink + path-traversal filters
 # ---------------------------------------------------------------------------
 
 
@@ -477,7 +479,7 @@ class TestReviewContextHelpers:
 
 
 # ---------------------------------------------------------------------------
-# server.py — spot_check + renamed_in_diff action wrappers
+# server.py â€” spot_check + renamed_in_diff action wrappers
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Part 2 of 2 of the swallow sweep following #929. Part 1 is #930 (`credential_state.py`). The two are independent and both branch from `main`.

## Two different defects, both called "swallowing"

**Wrong answers.** Three helpers returned a value indistinguishable from a real, successful one:

| site | reported | truth |
|---|---|---|
| `tools.py:255` | `embeddings_count: 0` | could not open the store |
| `tools.py:263` | `graph_last_updated: null` | could not read metadata |
| `tools.py:725` | `indexed_kinds: []` | could not query the graph |

`0` and `[]` are not neutral here — they are documented instructions. `docs/recipes.md` says "if `embeddings_count == 0` ... run `graph action=embed` first", and `indexed_kinds: []` reads as "nothing is indexed, rebuild". Both send the caller to a command that cannot fix the actual problem.

These now report `null` plus an explicit `*_error` key. The header still never raises — it is metadata, not query correctness. The happy path and the `db_path=None` path are byte-identical.

**Right answers, delivered silently.** `tools.py:980` (`_scan_dynamic_dispatch_hints`) and `parser.py:770` (`_apply_federation`) degrade *correctly*, and that degradation is deliberately kept: the scan still covers the target's own file, and a failed cross-repo resolve still falls back to the single-repo target. The problem was that the first announced itself only at `debug` and the second **at no level at all** — a federated build could resolve zero cross-repo imports and look exactly like a correctly configured single-repo one. Both now log at `warning` with the cause; behaviour is unchanged and pinned by tests.

## The harness defect that hid all of it

Five of the new log assertions passed in isolation and failed in the full suite with `caplog.records == []`. Root cause, bisected to `tests/test_alembic_baseline.py`:

`migrations/env.py` called `logging.config.fileConfig(...)` without `disable_existing_loggers=False`. That argument defaults to `True`, which sets `disabled = True` on every logger created earlier — i.e. every `better_code_review_graph.*` logger, since the package is imported long before any migration runs.

Measured directly:

```
BEFORE alembic.ini Config+upgrade: tools.logger.disabled = False
AFTER : tools.logger.disabled = True
```

with the subsequent `logger.warning("CANARY-2")` producing no output.

**Production was never affected** — `GraphStore` builds its Alembic `Config` programmatically and leaves `config_file_name` unset, so `env.py` skips the `fileConfig` call entirely (verified with the same canary: it emits normally). The test suite *was* affected, and from `test_alembic_baseline.py` onward every log-based assertion in the run was inspecting a logger that could not emit. Such tests passed alone and silently lost their teeth in the full run.

Fixed at the root with `disable_existing_loggers=False` and pinned by `TestAlembicDoesNotDisableApplicationLogging`.

## Red before, green after

Against unpatched code, `tests/test_response_payload_honesty.py` — 9 failed / 6 passed:

```
E   AssertionError: reporting 0 sends the caller to 'graph action=embed' (docs/recipes.md) for a store that will not open
E   assert 0 != 0

E   KeyError: 'graph_last_updated_error'

E   AssertionError: nothing above debug; got ['Exception in better_code_review_graph.tools: disk I/O error']
E   assert []

E   AssertionError: [] is a factual claim that nothing is indexed
E   assert [] is None

E   AssertionError: an empty list here tells the user to rebuild a graph that is not actually empty
E   assert [] != []

E   AssertionError: the caller receives a narrower hint set with no way to know; got ['Exception in better_code_review_graph.tools: disk I/O error']
E   assert []

E   AssertionError: cross-repo resolution failed and produced no record at any level; got []
E   assert []
```

That last one is the federation site: no record at any level, which is why it had never been noticed.

Full suite after: **1418 passed, 1 skipped, 48 deselected**, coverage **95.27%** (gate 95%).

## Existing tests that pinned the defective contract

Nine tests asserted the old behaviour. Per the standing rule they were updated to the corrected contract rather than the patch being loosened:

- `test_graph_stats_error_coverage.py` — `test_list_kinds_in_graph_exception_handled`, `test_build_response_header_embedding_exception_handled`
- `test_handle_not_found_coverage.py` — `test_handle_not_found_store_error`
- `test_kinds_error_path.py` — `test_list_kinds_in_graph_error_path`
- `test_list_kinds_coverage.py` — `test_list_kinds_in_graph_execute_exception`, `..._iteration_exception`, `..._processing_exception`
- `test_v17_coverage_gaps.py` — `test_init_backend_exception_yields_zero_count`, `test_list_kinds_in_graph_returns_empty_on_exception` (renamed to `..._returns_none_on_exception`)

Two tests assert `[]` for a **genuinely** empty graph — `test_handle_not_found_empty_graph` and `test_list_kinds_in_graph_success`. Those are correct and were left alone; the patch keeps `[]` meaning "really empty".

`docs/recipes.md` is updated so the documented `== 0` / `== []` branches now describe the `null` case too.