### PR TITLE
fix: support Dart parser files

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -104,6 +104,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".swift": "swift",
     ".php": "php",
     ".sol": "solidity",
+    ".dart": "dart",
 }
 
 #: The languages this parser claims to handle. Membership is what separates
@@ -142,6 +143,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
         "error_declaration",
         "user_defined_type_definition",
     ],
+    "dart": ["class_definition"],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -170,6 +172,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
         "event_definition",
         "fallback_receive_definition",
     ],
+    "dart": ["method_signature", "function_signature"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -877,7 +880,11 @@ class CodeParser:
                     python_abstract_contracts,
                     declared_interfaces,
                 )
-            elif node_type in func_types:
+            elif node_type in func_types and not (
+                language == "dart"
+                and node_type == "function_signature"
+                and root.type == "method_signature"
+            ):
                 processed = self._handle_function_node(
                     child,
                     source,
@@ -1745,6 +1752,20 @@ class CodeParser:
             if name:
                 return name
 
+        if language == "dart":
+            name_node = node.child_by_field_name("name")
+            if name_node is None and node.type == "method_signature":
+                name_node = next(
+                    (
+                        child.child_by_field_name("name")
+                        for child in node.children
+                        if child.type == "function_signature"
+                    ),
+                    None,
+                )
+            if name_node is not None:
+                return name_node.text.decode("utf-8", errors="replace")
+
         if language in ("c", "cpp") and kind == "function":
             name = self._get_name_cpp(node, language, kind)
             if name:
@@ -1798,6 +1819,21 @@ class CodeParser:
         if language == "solidity":
             return self._get_params_solidity(node)
 
+        if language == "dart" and node.type == "method_signature":
+            node = next(
+                (
+                    child
+                    for child in node.children
+                    if child.type == "function_signature"
+                ),
+                node,
+            )
+
+        if language == "dart":
+            for child in node.children:
+                if child.type == "formal_parameter_list":
+                    return child.text.decode("utf-8", errors="replace")
+
         for child in node.children:
             if child.type in ("parameters", "formal_parameters", "parameter_list"):
                 return child.text.decode("utf-8", errors="replace")
@@ -1818,6 +1854,20 @@ class CodeParser:
         """Extract return type annotation if present."""
         if language == "python":
             return self._get_return_type_python(node)
+
+        if language == "dart":
+            if node.type == "method_signature":
+                node = next(
+                    (
+                        child
+                        for child in node.children
+                        if child.type == "function_signature"
+                    ),
+                    node,
+                )
+            for child in node.children:
+                if child.type in ("type_identifier", "built_in_type"):
+                    return child.text.decode("utf-8", errors="replace")
 
         for child in node.children:
             if child.type in (
@@ -2092,6 +2142,14 @@ class CodeParser:
             return [("INHERITS", base) for base in self._get_bases_solidity(node)]
         if language == "go":
             return [("INHERITS", base) for base in self._get_bases_go(node)]
+        if language == "dart":
+            return [
+                ("INHERITS", sub.text.decode("utf-8", errors="replace"))
+                for child in node.children
+                if child.type in ("superclass", "interfaces")
+                for sub in child.children
+                if sub.type == "type_identifier"
+            ]
         return []
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:

--- a/tests/test_parser_extra.py
+++ b/tests/test_parser_extra.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from better_code_review_graph.parser import (
     CodeParser,
     _is_test_function,
@@ -17,6 +19,60 @@ def _relationship_edges(edges, source):
         for edge in edges
         if edge.source == source and edge.kind in {"INHERITS", "IMPLEMENTS"}
     }
+
+
+def _has_dart_parser():
+    try:
+        import tree_sitter_language_pack as tslp
+
+        tslp.get_parser("dart")
+        return True
+    except (LookupError, ImportError):
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_dart_parser(), reason="dart tree-sitter grammar not installed"
+)
+def test_parse_dart_classes_methods_and_top_level_function(tmp_path):
+    parser = CodeParser()
+    dart_file = tmp_path / "main.dart"
+    dart_file.write_text(
+        """abstract class Shape {
+  double area();
+}
+
+class Circle implements Shape {
+  @override
+  double area() {
+    return 1.0;
+  }
+}
+
+int add(int a, int b) => a + b;
+"""
+    )
+
+    assert parser.detect_language(Path("main.dart")) == "dart"
+
+    nodes, edges = parser.parse_file(dart_file)
+
+    assert {node.kind for node in nodes} >= {"File", "Class", "Function"}
+    assert {node.name for node in nodes if node.kind == "Class"} == {
+        "Shape",
+        "Circle",
+    }
+    functions = [
+        (node.name, node.parent_name) for node in nodes if node.kind == "Function"
+    ]
+    assert functions.count(("area", "Shape")) == 1
+    assert functions.count(("area", "Circle")) == 1
+    assert functions.count(("add", None)) == 1
+
+    inherits = [edge for edge in edges if edge.kind == "INHERITS"]
+    assert any(
+        edge.source.endswith("::Circle") and edge.target == "Shape" for edge in inherits
+    )
 
 
 class TestParserUtils:


### PR DESCRIPTION
## Summary\n- Register .dart as a supported language so Dart files reach the Tree-sitter parser instead of being silently skipped.\n- Extract Dart classes, top-level functions, class methods, parameters, return types, and superclass/interface relationships.\n- Avoid duplicate function nodes when Dart method signatures wrap function signatures.\n\nCloses #947\n\n## Verification\n- Dart grammar AST probe passed on the current host.\n- 1440 passed, 1 skipped, 48 deselected\n- Coverage: 95.01% with --cov-fail-under=95\n- Ruff check/format, ty, git diff check, and pre-commit hooks pass.\n- Branch rebased onto merged #908 commit cf410af.