### PR TITLE
fix: detach git fallback stdin

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -236,6 +236,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
                 text=True,
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
+                stdin=subprocess.DEVNULL,
             )
         files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
         return files


### PR DESCRIPTION
The incremental update fallback runs git diff --cached after an invalid base such as HEAD~1 on a one-commit repository. That subprocess inherited the MCP stdio pipe on Windows and blocked until the 30-second git timeout. Pass stdin=subprocess.DEVNULL consistently with the other git calls. Verification: test_graph_update passes, all live integration tests except the independent stale tools/list contract pass, commit hooks pass.