### PR TITLE
fix: skip empty graph extra JSON parsing

### DIFF
--- a/scripts/benchmark_row_deserialization.py
+++ b/scripts/benchmark_row_deserialization.py
@@ -1,0 +1,39 @@
+"""Đo chi phí bỏ qua json.loads cho extra='{}'."""
+
+from __future__ import annotations
+
+import json
+from statistics import median, stdev
+from timeit import repeat
+
+ROWS = ["{}"] * 9_500 + ['{"kind":"Function"}'] * 500
+
+
+def baseline() -> None:
+    for raw in ROWS:
+        json.loads(raw) if raw else {}
+
+
+def optimized() -> None:
+    for raw in ROWS:
+        json.loads(raw) if raw and raw != "{}" else {}
+
+
+def measure(function) -> list[float]:
+    return repeat(function, number=100, repeat=25)
+
+
+def report(name: str, samples: list[float]) -> None:
+    print(
+        f"{name}: min={min(samples):.6f}s "
+        f"median={median(samples):.6f}s "
+        f"stdev={stdev(samples):.6f}s"
+    )
+
+
+if __name__ == "__main__":
+    baseline_samples = measure(baseline)
+    optimized_samples = measure(optimized)
+    report("baseline", baseline_samples)
+    report("optimized", optimized_samples)
+    print(f"rows={len(ROWS)} empty_rows={ROWS.count('{}')} reps=25 number=100")

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1506,7 +1506,9 @@ class GraphStore:
             return_type=row["return_type"],
             is_test=bool(row["is_test"]),
             file_hash=row["file_hash"],
-            extra=json.loads(row["extra"]) if row["extra"] else {},
+            extra=json.loads(row["extra"])
+            if row["extra"] and row["extra"] != "{}"
+            else {},
         )
 
     def _row_to_edge(self, row: sqlite3.Row) -> GraphEdge:
@@ -1517,7 +1519,9 @@ class GraphStore:
             target_qualified=row["target_qualified"],
             file_path=row["file_path"],
             line=row["line"],
-            extra=json.loads(row["extra"]) if row["extra"] else {},
+            extra=json.loads(row["extra"])
+            if row["extra"] and row["extra"] != "{}"
+            else {},
         )
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.parser import EdgeInfo, NodeInfo
@@ -96,6 +97,48 @@ class TestGraphStore:
         assert len(edges) == 1
         assert edges[0].kind == "CALLS"
         assert edges[0].target_qualified == "/test/file.py::func_b"
+
+    def test_empty_json_extra_skips_deserialization(self):
+        node = self._make_file_node()
+        edge = EdgeInfo(
+            kind="CONTAINS",
+            source="/test/file.py",
+            target="/test/file.py::my_func",
+            file_path="/test/file.py",
+        )
+        self.store.upsert_node(node)
+        self.store.upsert_edge(edge)
+        self.store.commit()
+
+        with patch("better_code_review_graph.graph.json.loads") as loads:
+            result = self.store.get_node("/test/file.py")
+            edges = self.store.get_edges_by_source("/test/file.py")
+
+        assert result is not None
+        assert result.extra == {}
+        assert edges[0].extra == {}
+        loads.assert_not_called()
+
+    def test_non_empty_json_extra_is_deserialized(self):
+        node = self._make_file_node()
+        node.extra = {"origin": "parser"}
+        edge = EdgeInfo(
+            kind="CONTAINS",
+            source="/test/file.py",
+            target="/test/file.py::my_func",
+            file_path="/test/file.py",
+            extra={"confidence": 1},
+        )
+        self.store.upsert_node(node)
+        self.store.upsert_edge(edge)
+        self.store.commit()
+
+        result = self.store.get_node("/test/file.py")
+        edges = self.store.get_edges_by_source("/test/file.py")
+
+        assert result is not None
+        assert result.extra == {"origin": "parser"}
+        assert edges[0].extra == {"confidence": 1}
 
     def test_remove_file_data(self):
         node = self._make_file_node()


### PR DESCRIPTION
## Tóm tắt\n\n- Bỏ qua json.loads khi row xtra là {} cho node và edge.\n- Thêm regression test chứng minh empty JSON không deserialize và non-empty JSON vẫn deserialize.\n- Thêm benchmark reproducible, không đưa .jules/bolt.md vào PR.\n\n## Verification\n\n- Focused graph tests: 17 passed.\n- Full pytest suite: PASS.\n- Ruff, format, ty, gitleaks và pre-commit hooks: PASS.\n- Benchmark: 25 reps x 100 iterations trên 10,000 rows, 9,500 empty; median baseline 1.085078s, optimized 0.103743s.\n\nSupersedes the implementation-only approach in #961; giữ #961 mở cho đến khi PR này được review.